### PR TITLE
Update drivers gte 6.10

### DIFF
--- a/software/kernel/main.c
+++ b/software/kernel/main.c
@@ -990,7 +990,12 @@ static int litepcie_phc_get_syncdevicetime(ktime_t *device,
 
 #if IS_ENABLED(CONFIG_X86_TSC) && !defined(CONFIG_UML)
 	/* Convert ART (Absolute Reference Time) to TSC (Time Stamp Counter) */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	*system = convert_art_ns_to_tsc(ptm_master_time);
+#else
+	system->cycles = ptm_master_time;
+	system->cs_id = CSID_X86_ART;
+#endif
 #else
     *system = (struct system_counterval_t) { };
 #endif


### PR DESCRIPTION
This PR updates `main.c` and `liteuart.c`:
- align `liteuart` driver to `litepcie` (fixes for recent kernel)
- adapts `main.c` since `convert_art_ns_to_tsc` have been removed starting with 6.12 serie