### PR TITLE
add aux clock and locksweep signals

### DIFF
--- a/litex_wr_nic/gateware/soc.py
+++ b/litex_wr_nic/gateware/soc.py
@@ -190,9 +190,10 @@ class LiteXWRNICSoC(SoCMini):
             if hasattr(flash_pads, "hold"):
                 self.comb += flash_pads.hold.eq(1)
 
-        # White Rabbit Core Instance.
+        # White Rabbit Core Parameters.
         # ---------------------------
-        self.specials += Instance("xwrc_board_litex_wr_nic_wrapper",
+        self.wr_params = {}
+        self.wr_params.update(
             # Parameters.
             p_g_dpram_initf               = os.path.abspath(cpu_firmware),
             p_g_dpram_size                = 131072//4,
@@ -640,3 +641,45 @@ class LiteXWRNICSoC(SoCMini):
             register     = True,
             csr_csv      = "test/analyzer.csv"
         )
+
+    def add_aux_clock(self,
+                      clk_fb,
+                      dac_aux_load,
+                      dac_aux_data,
+                      lock_en=True,
+                      locked=None,
+                      lock_sweep = None, # only one auxpll can use locksweep for now
+                      lock_sweep_phase = None
+                      ):
+        i = 0 # aux clk index
+        if 'p_g_aux_clk' in self.wr_params.keys():
+            i = self.wr_params['p_g_aux_clks']
+            self.wr_params['p_g_aux_clks'] = i + 1
+        else :
+            self.wr_params['p_g_aux_clks'] = 1
+
+        if i != 0:
+            self.comb += dac_aux_data.eq(self.wr_params['o_tm_dac_value_o'])
+
+            clk_fb        = Cat(self.wr_params['i_clk_aux_i'], clk_fb)
+            dac_aux_load  = Cat(self.wr_params['o_tm_dac_wr_o'], dac_aux_load)
+            lock_en       = Cat(self.wr_params['i_tm_clk_lock_en_i'], lock_en)
+            locked        = Cat(self.wr_params['o_tm_dac_value_o'], locked)
+        else :
+            self.wr_params['o_tm_dac_value_o'] = dac_aux_data
+
+        self.wr_params.update(
+                i_clk_aux_i            = clk_fb,
+                o_tm_dac_wr_o          = dac_aux_load,
+                i_tm_clk_aux_lock_en_i = lock_en,
+                o_tm_clk_aux_locked_o  = locked,
+                )
+        if lock_sweep_phase is not None:
+            self.wr_params.update(
+                    i_lock_sweep_i       = lock_sweep,
+                    i_lock_sweep_phase_i = lock_sweep_phase,
+                    )
+
+    def do_finalize(self):
+        self.specials += Instance("xwrc_board_litex_wr_nic_wrapper", **self.wr_params)
+ 

--- a/litex_wr_nic/gateware/soc.py
+++ b/litex_wr_nic/gateware/soc.py
@@ -663,8 +663,8 @@ class LiteXWRNICSoC(SoCMini):
 
             clk_fb        = Cat(self.wr_params['i_clk_aux_i'], clk_fb)
             dac_aux_load  = Cat(self.wr_params['o_tm_dac_wr_o'], dac_aux_load)
-            lock_en       = Cat(self.wr_params['i_tm_clk_lock_en_i'], lock_en)
-            locked        = Cat(self.wr_params['o_tm_dac_value_o'], locked)
+            lock_en       = Cat(self.wr_params['i_tm_clk_aux_lock_en_i'], lock_en)
+            locked        = Cat(self.wr_params['o_tm_clk_aux_locked_o'], locked)
         else :
             self.wr_params['o_tm_dac_value_o'] = dac_aux_data
 

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
@@ -197,6 +197,10 @@ entity xwrc_board_litex_wr_nic is
     tm_dac_wr_o          : out std_logic_vector(g_aux_clks-1 downto 0);
     tm_clk_aux_lock_en_i : in  std_logic_vector(g_aux_clks-1 downto 0) := (others => '0');
     tm_clk_aux_locked_o  : out std_logic_vector(g_aux_clks-1 downto 0);
+    clk_aux_i            : in  std_logic_vector(g_aux_clks-1 downto 0) := (others => '0'); -- aux clks feedback
+    -- LockSweep signals
+    lock_sweep_i         : in std_logic := '0';
+    lock_sweep_phase_i   : in std_logic_vector(15 downto 0) := (others => '0');
 
     ---------------------------------------------------------------------------
     -- External Tx Timestamping I/F
@@ -239,7 +243,6 @@ entity xwrc_board_litex_wr_nic is
     pps_led_o   : out std_logic;
     -- Link ok indication
     link_ok_o  : out std_logic;
-
     GT0_EXT_QPLL_RESET  : out std_logic;
     GT0_EXT_QPLL_CLK    : in  std_logic;
     GT0_EXT_QPLL_REFCLK : in  std_logic;
@@ -419,7 +422,7 @@ begin  -- architecture struct
       clk_sys_i            => clk_pll_62m5,
       clk_dmtd_i           => clk_dmtd,
       clk_ref_i            => clk_ref_62m5,
-      clk_aux_i            => (0 downto 0 => '0'),
+      clk_aux_i            => clk_aux_i,
       clk_10m_ext_i        => clk_10m_ext,
       clk_ext_mul_i        => ext_ref_mul,
       clk_ext_mul_locked_i => ext_ref_mul_locked,
@@ -497,6 +500,9 @@ begin  -- architecture struct
       pps_csync_o          => pps_csync_o,
       pps_p_o              => pps_p_o,
       pps_led_o            => pps_led_o,
+      lock_sweep_i         => lock_sweep_i,
+      lock_sweep_phase_i   => lock_sweep_phase_i,
+
       link_ok_o            => link_ok_o);
 
   onewire_oen_o <= onewire_en(0);

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
@@ -142,6 +142,10 @@ entity xwrc_board_litex_wr_nic_wrapper is
     tm_dac_wr_o          : out std_logic_vector(g_aux_clks-1 downto 0);
     tm_clk_aux_lock_en_i : in  std_logic_vector(g_aux_clks-1 downto 0);
     tm_clk_aux_locked_o  : out std_logic_vector(g_aux_clks-1 downto 0);
+    clk_aux_i            : in  std_logic_vector(g_aux_clks-1 downto 0); -- aux clks feedback
+    -- LockSweep signals
+    lock_sweep_i         : in std_logic := '0';
+    lock_sweep_phase_i   : in std_logic_vector(15 downto 0) := (others => '0');
 
     -- External Tx Timestamping I/F
     timestamps_o         : out t_txtsu_timestamp;
@@ -297,6 +301,9 @@ begin
       tm_dac_wr_o          => tm_dac_wr_o,
       tm_clk_aux_lock_en_i => tm_clk_aux_lock_en_i,
       tm_clk_aux_locked_o  => tm_clk_aux_locked_o,
+      clk_aux_i            => clk_aux_i,
+      lock_sweep_i         => lock_sweep_i,
+      lock_sweep_phase_i   => lock_sweep_phase_i,
       timestamps_o         => timestamps_o,
       timestamps_ack_i     => timestamps_ack_i,
       fc_tx_pause_req_i    => fc_tx_pause_req_i,


### PR DESCRIPTION
Hello,

This adds the ability to connect auxiliary white rabbit clocks and locksweep signals.

The locksweep signals are for the standard locksweep (which is for the external 10 MHz output, and NOT auxiliary softplls) but can be repurposed to sync auxiliaries plls with some firmware modifications (https://github.com/Mimil25/wrpc-sw).
So this use is not standard, and you might want to edit out the locksweep parts of my commit in `soc.py`

Good evening