### PR TITLE
wr: support LiteX-managed CPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ litex_wr_nic/firmware/sdb-wrpc.bin
 litex_wr_nic/firmware/spec_a7_wrc.bin
 litex_wr_nic/firmware/spec_a7_wrc.boot
 litex_wr_nic/firmware/spec_a7_wrc.bram
+litex_wr_nic/firmware/spec_a7_wrc_vexriscv.bin
+litex_wr_nic/firmware/spec_a7_wrc_vexriscv.boot
+litex_wr_nic/firmware/spec_a7_wrc_vexriscv.bram

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ requiring precise timing and basic networking functionality.
 - [> White Rabbit / PTM Demonstration](#-white-rabbit--ptm-demonstration)
 - [> Build and test designs](#-build-and-test-designs)
 - [> Build the WR RISC-V firmware](#-build-the-wr-risc-v-firmware)
+- [> Select the WR CPU](#-select-the-wr-cpu)
 - [> Select the WR CPU memory](#-select-the-wr-cpu-memory)
 - [> Compare WR CPU memory resources](#-compare-wr-cpu-memory-resources)
+- [> Compare WR CPU resources](#-compare-wr-cpu-resources)
 - [> Configure Flash Data Base (SDB)](#-configure-flash-data-base-sdb)
 - [> Use LiteX Server and LiteScope](#-use-litex-server-and-litescope)
 - [> JTAGBone Tests](#-jtagbone-tests)
@@ -267,6 +269,10 @@ cd litex_wr_nic/firmware
 ./build.py
 ```
 
+Pass `--wr-cpu-type vexriscv` to build the LiteX VexRiscv-compatible profile. It creates distinct
+`spec_a7_wrc_vexriscv.bin`, `.bram`, and `.boot` artifacts, so switching CPU types cannot silently
+reuse firmware built for the other core.
+
 The build.py script compiles the firmware using a specific RISC-V toolchain as recommended in the WRPC User Manual ([Section 2.2]
 (https://ohwr.org/project/wr-cores/wikis/uploads/7cf8d2161b6e5fa86348455bbd022196/wrpc-user-manual-v5.0.pdf)).
 If the toolchain is not already installed, build.py will automatically download and use it.
@@ -298,15 +304,39 @@ Loading firmware from ../firmware/wrpc-sw/wrc.bin...
 Loading firmware: 100%|██████████████████████████████████| 30270/30270 [00:00<00:00,
 ```
 
+[> Select the WR CPU
+--------------------
+
+The embedded WR-core uRV remains the default. A LiteX-managed VexRiscv `lite` core can instead run
+the same WRPC firmware from the SoC memory path:
+
+```sh
+./spec_a7_wr_nic.py --build --wr-cpu-type vexriscv --wr-cpu-memory integrated
+./spec_a7_wr_nic.py --build --wr-cpu-type vexriscv --wr-cpu-memory hyperram
+./acorn_wr_nic.py --build --wr-cpu-type vexriscv --wr-cpu-memory integrated
+./hyvision_pcie_opt01_revf.py --build --wr-cpu-type vexriscv --wr-cpu-memory integrated
+```
+
+The VexRiscv core runs in the existing 62.5 MHz WR clock domain. Its instruction and low-memory
+data buses share the selected LiteX memory, while accesses at and above `0x00100000` are routed
+directly to the WR-core peripheral bus. WR's interrupt and software-reset signals are connected to
+the LiteX CPU. The firmware profile initializes VexRiscv's trap vector and external-interrupt mask.
+
+Only the `lite` VexRiscv variant is qualified initially; select it explicitly with
+`--wr-cpu-variant lite`, or omit the variant to use that default. LiteX CPU mode requires
+`integrated` or `hyperram` memory because the CPU is outside the WR core. The WR CPU reset CSR and
+host memory-loading path remain available, but uRV instruction-upload/debug CSR fields read as zero
+and ignore writes in this mode.
+
 [> Select the WR CPU memory
 ---------------------------
 
-The WR uRV CPU keeps its 128 KiB logical memory window in all configurations. The implementation is
+The WR CPU keeps its 128 KiB logical memory window in all configurations. The implementation is
 selected at gateware build time:
 
 | Mode | Boards | Firmware source | FPGA memory cost |
 |---|---|---|---|
-| `private` | All | WR-core private dual-port RAM initialized from `spec_a7_wrc.bram` | 128 KiB private BRAM |
+| `private` | All, uRV only | WR-core private dual-port RAM initialized from `spec_a7_wrc.bram` | 128 KiB private BRAM |
 | `integrated` | All | LiteX `wr_cpu_mem` initialized from `spec_a7_wrc.bin` | 128 KiB SoC BRAM |
 | `hyperram` | SPEC-A7 | SPI-flash boot image copied automatically to HyperRAM | 8 KiB write-back cache plus HyperRAM controller |
 
@@ -323,15 +353,16 @@ different implementation with:
 In the external modes, instruction and low-memory data accesses cross from the 62.5 MHz WR clock
 domain to the LiteX system bus. Existing WR peripheral accesses at and above 1 MiB remain on the
 WR-core Wishbone bus. The LiteX region is named `wr_cpu_mem` and is mapped at `0x40000000` for host
-access; the uRV still sees it starting at address zero.
+access; the selected WR CPU still sees it starting at address zero.
 
 The integrated mode embeds the raw binary in SoC RAM. The HyperRAM mode holds the WR CPU in reset
-while an FPGA boot loader reads `spec_a7_wrc.boot` from SPI flash offset `0x002f0000`, validates its
-magic, version, aligned length, and CRC32, and copies it to HyperRAM. It then releases the CPU and
-returns the flash pins to WRPC. A write-back 8 KiB cache fronts the controller, which uses its 4:1
-mode to generate a conservative 31.25 MHz HyperRAM clock from the 125 MHz system clock. The existing
-64 KiB WR SDB slot remains at `0x002e0000`. The packaged image zero-fills the complete 128 KiB CPU
-window so its initial contents match the private and integrated modes.
+while an FPGA boot loader reads the selected profile (`spec_a7_wrc.boot` or
+`spec_a7_wrc_vexriscv.boot`) from SPI flash offset `0x002f0000`, validates its magic, version,
+aligned length, and CRC32, and copies it to HyperRAM. It then releases the CPU and returns the flash
+pins to WRPC. A write-back 8 KiB cache fronts the controller, which uses its 4:1 mode to generate a
+conservative 31.25 MHz HyperRAM clock from the 125 MHz system clock. The existing 64 KiB WR SDB slot
+remains at `0x002e0000`. The packaged image zero-fills the complete 128 KiB CPU window so its initial
+contents match the private and integrated modes.
 
 The firmware build creates both the raw binary and the packaged boot image:
 
@@ -366,6 +397,24 @@ already completed builds without rebuilding:
 ```sh
 python3 tools/compare_wr_cpu_resources.py build/wr_cpu_resources \
     --firmware litex_wr_nic/firmware/spec_a7_wrc.bin
+```
+
+[> Compare WR CPU resources
+---------------------------
+
+Build matched uRV and VexRiscv-lite SPEC-A7 designs with both integrated RAM and HyperRAM:
+
+```sh
+python3 tools/build_wr_cpu_type_matrix.py
+```
+
+The four placed designs use identical Vivado directives and CPU clock constraints. Results and
+VexRiscv-minus-uRV deltas are written to `doc/wr_cpu_type_resource_comparison.md`, `.json`, and
+`.csv`. Existing build reports can be parsed again without synthesis:
+
+```sh
+python3 tools/compare_wr_cpu_types.py build/wr_cpu_types \
+    --firmware-dir litex_wr_nic/firmware
 ```
 
 [> Configure Flash Data Base (SDB)

--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -51,7 +51,13 @@ from litex_wr_nic.gateware.pps               import PPSGenerator
 from litex_wr_nic.gateware.clk10m            import Clk10MGenerator
 from litex_wr_nic.gateware.nic.phy           import LiteEthPHYWRGMII
 from litex_wr_nic.gateware.ps_gen            import PSGen
-from litex_wr_nic.gateware.wr_cpu            import WR_CPU_MEMORY_ORIGIN, WR_CPU_MEMORY_SIZE
+from litex_wr_nic.gateware.wr_cpu            import (
+    WR_CPU_MEMORY_ORIGIN,
+    WR_CPU_MEMORY_SIZE,
+    WR_CPU_TYPES,
+    validate_wr_cpu_config,
+    wr_cpu_firmware_filename,
+)
 
 # CRG ----------------------------------------------------------------------------------------------
 
@@ -110,9 +116,11 @@ class BaseSoC(LiteXWRNICSoC):
         # ------------------------
         with_white_rabbit          = True,
         white_rabbit_sfp_connector = 0,
-        white_rabbit_cpu_firmware  = "litex_wr_nic/firmware/spec_a7_wrc.bram",
-        white_rabbit_cpu_binary    = "litex_wr_nic/firmware/spec_a7_wrc.bin",
-        wr_cpu_memory              = "private",
+        white_rabbit_cpu_firmware  = None,
+        white_rabbit_cpu_binary    = None,
+        wr_cpu_type               = "urv",
+        wr_cpu_variant            = None,
+        wr_cpu_memory             = "private",
 
     ):
         # Platform ---------------------------------------------------------------------------------
@@ -160,8 +168,16 @@ class BaseSoC(LiteXWRNICSoC):
 
         if wr_cpu_memory not in ("private", "integrated"):
             raise ValueError(f"Unsupported WR CPU memory mode: {wr_cpu_memory}")
+        wr_cpu_variant = validate_wr_cpu_config(
+            wr_cpu_type, wr_cpu_variant, wr_cpu_memory)
         if not with_white_rabbit and wr_cpu_memory != "private":
             raise ValueError("External WR CPU memory requires White Rabbit support.")
+        if white_rabbit_cpu_firmware is None:
+            white_rabbit_cpu_firmware = os.path.join("litex_wr_nic", "firmware",
+                wr_cpu_firmware_filename(wr_cpu_type, "bram"))
+        if white_rabbit_cpu_binary is None:
+            white_rabbit_cpu_binary = os.path.join("litex_wr_nic", "firmware",
+                wr_cpu_firmware_filename(wr_cpu_type, "bin"))
         wr_cpu_region = None
         if wr_cpu_memory == "integrated":
             if not os.path.isfile(white_rabbit_cpu_binary):
@@ -221,7 +237,9 @@ class BaseSoC(LiteXWRNICSoC):
             # --------------
             self.add_wr_core(
                 # CPU.
-                cpu_firmware    = white_rabbit_cpu_firmware,
+                cpu_firmware      = white_rabbit_cpu_firmware,
+                cpu_type          = wr_cpu_type,
+                cpu_variant       = wr_cpu_variant,
                 cpu_memory_region = wr_cpu_region,
 
                 # Board name.
@@ -375,6 +393,10 @@ def main():
     parser.add_argument("--flash", action="store_true", help="Flash bitstream.")
     parser.add_argument("--wr-cpu-memory", default="private", choices=["private", "integrated"],
         help="WR CPU memory implementation (default: private).")
+    parser.add_argument("--wr-cpu-type", default="urv", choices=WR_CPU_TYPES,
+        help="WR CPU implementation (default: embedded uRV).")
+    parser.add_argument("--wr-cpu-variant", default=None,
+        help="LiteX WR CPU variant (VexRiscv defaults to lite).")
     parser.add_argument("--output-dir", default=None, help="Build directory.")
 
     # Probes.
@@ -390,13 +412,18 @@ def main():
     # ---------------
     if args.build:
         print("Building firmware...")
-        r = os.system("cd litex_wr_nic/firmware && ./build.py --target acorn")
+        r = os.system("cd litex_wr_nic/firmware && ./build.py --target acorn --wr-cpu-type {}".format(
+            args.wr_cpu_type))
         if r != 0:
             raise RuntimeError("Firmware build failed.")
 
     # Build SoC/Gateware (with integrated Firmware).
     # ----------------------------------------------
-    soc = BaseSoC(wr_cpu_memory=args.wr_cpu_memory)
+    soc = BaseSoC(
+        wr_cpu_type    = args.wr_cpu_type,
+        wr_cpu_variant = args.wr_cpu_variant,
+        wr_cpu_memory  = args.wr_cpu_memory,
+    )
     if args.with_wishbone_fabric_interface_probe:
         soc.add_wishbone_fabric_interface_probe()
     if args.with_wishbone_slave_probe:

--- a/doc/wr_cpu_type_resource_comparison.csv
+++ b/doc/wr_cpu_type_resource_comparison.csv
@@ -1,0 +1,5 @@
+config,slice_luts,logic_luts,lut_memory,ffs,ramb36,ramb18,bram18_equivalent,dsps,wns_ns,tns_ns,whs_ns,ths_ns,wr_clk_wns_ns,bit_bytes,build_seconds
+urv-integrated,12361,11902,459,15141,65,16,146,8,0.004,0.0,0.028,0.0,4.54,1829716,316.442
+vexriscv-lite-integrated,12292,11837,455,15167,65,18,148,4,-0.011,-0.112,0.028,0.0,4.413,1810396,446.811
+urv-hyperram,12975,12496,479,15933,34,21,89,8,-0.144,-2.339,0.028,0.0,5.282,1611720,475.554
+vexriscv-lite-hyperram,12754,12277,477,15970,34,23,91,4,-0.527,-26.231,0.028,0.0,5.102,1594152,431.982

--- a/doc/wr_cpu_type_resource_comparison.json
+++ b/doc/wr_cpu_type_resource_comparison.json
@@ -1,0 +1,373 @@
+{
+  "metadata": {
+    "git_sha": "20b3641a6bdf46779ce5e05717d46bc0df071772",
+    "git_dirty": true,
+    "target": "spec_a7_wr_nic",
+    "device": "xc7a50tcsg325-2",
+    "tool_version": "Vivado v.2024.1 (lin64) Build 5076996 Wed May 22 18:36:09 MDT 2024",
+    "firmware_sha256": {
+      "urv": "26b47b5ace087438b7964f1ff74c2f10ac3739ce85e434ad925816ff2fe046a4",
+      "vexriscv-lite": "8ee256c1688dcaa803c3e76d65499e183db7c68f3cd02d683a4ebd49df4cb357"
+    },
+    "wr_cpu_clk_hz": 62500000,
+    "directives": {
+      "place": "Explore",
+      "route": "Explore",
+      "post_route_phys_opt": "Explore"
+    }
+  },
+  "configs": {
+    "urv-integrated": {
+      "slice_luts": 12361,
+      "logic_luts": 11902,
+      "lut_memory": 459,
+      "lutram": 446,
+      "srls": 13,
+      "ffs": 15141,
+      "ramb36": 65,
+      "ramb18": 16,
+      "dsps": 8,
+      "bram18_equivalent": 146,
+      "tool_version": "Vivado v.2024.1 (lin64) Build 5076996 Wed May 22 18:36:09 MDT 2024",
+      "device": "xc7a50tcsg325-2",
+      "wns_ns": 0.004,
+      "tns_ns": 0.0,
+      "setup_failing_endpoints": 0,
+      "whs_ns": 0.028,
+      "ths_ns": 0.0,
+      "hold_failing_endpoints": 0,
+      "hierarchy": [
+        {
+          "instance": "gen_external_cpu_memory.U_CPU_EXTERNAL",
+          "module": "wrc_urv_external_memory",
+          "total_luts": 1919,
+          "logic_luts": 1919,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 1256,
+          "ramb36": 0,
+          "ramb18": 2,
+          "dsps": 4
+        },
+        {
+          "instance": "(gen_external_cpu_memory.U_CPU_EXTERNAL)",
+          "module": "wrc_urv_external_memory",
+          "total_luts": 310,
+          "logic_luts": 310,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 259,
+          "ramb36": 0,
+          "ramb18": 0,
+          "dsps": 0
+        }
+      ],
+      "reports": {
+        "utilization": "gateware/spec_a7_wr_nic_utilization_place.rpt",
+        "timing": "gateware/spec_a7_wr_nic_timing.rpt",
+        "hierarchy": "gateware/spec_a7_wr_nic_utilization_hierarchical_place.rpt"
+      },
+      "bit_bytes": 1829716,
+      "bin_bytes": null,
+      "build_seconds": 316.442,
+      "wr_clk_wns_ns": 4.54
+    },
+    "vexriscv-lite-integrated": {
+      "slice_luts": 12292,
+      "logic_luts": 11837,
+      "lut_memory": 455,
+      "lutram": 442,
+      "srls": 13,
+      "ffs": 15167,
+      "ramb36": 65,
+      "ramb18": 18,
+      "dsps": 4,
+      "bram18_equivalent": 148,
+      "tool_version": "Vivado v.2024.1 (lin64) Build 5076996 Wed May 22 18:36:09 MDT 2024",
+      "device": "xc7a50tcsg325-2",
+      "wns_ns": -0.011,
+      "tns_ns": -0.112,
+      "setup_failing_endpoints": 17,
+      "whs_ns": 0.028,
+      "ths_ns": 0.0,
+      "hold_failing_endpoints": 0,
+      "hierarchy": [
+        {
+          "instance": "VexRiscv",
+          "module": "VexRiscv",
+          "total_luts": 1427,
+          "logic_luts": 1427,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 1041,
+          "ramb36": 0,
+          "ramb18": 4,
+          "dsps": 0
+        },
+        {
+          "instance": "(VexRiscv)",
+          "module": "VexRiscv",
+          "total_luts": 922,
+          "logic_luts": 922,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 946,
+          "ramb36": 0,
+          "ramb18": 2,
+          "dsps": 0
+        },
+        {
+          "instance": "IBusCachedPlugin_cache",
+          "module": "InstructionCache",
+          "total_luts": 521,
+          "logic_luts": 521,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 95,
+          "ramb36": 0,
+          "ramb18": 2,
+          "dsps": 0
+        },
+        {
+          "instance": "gen_external_cpu.U_CPU_CONTROL",
+          "module": "wrc_external_cpu_control",
+          "total_luts": 57,
+          "logic_luts": 57,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 154,
+          "ramb36": 0,
+          "ramb18": 0,
+          "dsps": 0
+        }
+      ],
+      "reports": {
+        "utilization": "gateware/spec_a7_wr_nic_utilization_place.rpt",
+        "timing": "gateware/spec_a7_wr_nic_timing.rpt",
+        "hierarchy": "gateware/spec_a7_wr_nic_utilization_hierarchical_place.rpt"
+      },
+      "bit_bytes": 1810396,
+      "bin_bytes": null,
+      "build_seconds": 446.811,
+      "wr_clk_wns_ns": 4.413
+    },
+    "urv-hyperram": {
+      "slice_luts": 12975,
+      "logic_luts": 12496,
+      "lut_memory": 479,
+      "lutram": 466,
+      "srls": 13,
+      "ffs": 15933,
+      "ramb36": 34,
+      "ramb18": 21,
+      "dsps": 8,
+      "bram18_equivalent": 89,
+      "tool_version": "Vivado v.2024.1 (lin64) Build 5076996 Wed May 22 18:36:09 MDT 2024",
+      "device": "xc7a50tcsg325-2",
+      "wns_ns": -0.144,
+      "tns_ns": -2.339,
+      "setup_failing_endpoints": 28,
+      "whs_ns": 0.028,
+      "ths_ns": 0.0,
+      "hold_failing_endpoints": 0,
+      "hierarchy": [
+        {
+          "instance": "gen_external_cpu_memory.U_CPU_EXTERNAL",
+          "module": "wrc_urv_external_memory",
+          "total_luts": 1917,
+          "logic_luts": 1917,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 1256,
+          "ramb36": 0,
+          "ramb18": 2,
+          "dsps": 4
+        },
+        {
+          "instance": "(gen_external_cpu_memory.U_CPU_EXTERNAL)",
+          "module": "wrc_urv_external_memory",
+          "total_luts": 311,
+          "logic_luts": 311,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 259,
+          "ramb36": 0,
+          "ramb18": 0,
+          "dsps": 0
+        }
+      ],
+      "reports": {
+        "utilization": "gateware/spec_a7_wr_nic_utilization_place.rpt",
+        "timing": "gateware/spec_a7_wr_nic_timing.rpt",
+        "hierarchy": "gateware/spec_a7_wr_nic_utilization_hierarchical_place.rpt"
+      },
+      "bit_bytes": 1611720,
+      "bin_bytes": null,
+      "build_seconds": 475.554,
+      "wr_clk_wns_ns": 5.282
+    },
+    "vexriscv-lite-hyperram": {
+      "slice_luts": 12754,
+      "logic_luts": 12277,
+      "lut_memory": 477,
+      "lutram": 464,
+      "srls": 13,
+      "ffs": 15970,
+      "ramb36": 34,
+      "ramb18": 23,
+      "dsps": 4,
+      "bram18_equivalent": 91,
+      "tool_version": "Vivado v.2024.1 (lin64) Build 5076996 Wed May 22 18:36:09 MDT 2024",
+      "device": "xc7a50tcsg325-2",
+      "wns_ns": -0.527,
+      "tns_ns": -26.231,
+      "setup_failing_endpoints": 79,
+      "whs_ns": 0.028,
+      "ths_ns": 0.0,
+      "hold_failing_endpoints": 0,
+      "hierarchy": [
+        {
+          "instance": "VexRiscv",
+          "module": "VexRiscv",
+          "total_luts": 1420,
+          "logic_luts": 1420,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 1041,
+          "ramb36": 0,
+          "ramb18": 4,
+          "dsps": 0
+        },
+        {
+          "instance": "(VexRiscv)",
+          "module": "VexRiscv",
+          "total_luts": 926,
+          "logic_luts": 926,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 946,
+          "ramb36": 0,
+          "ramb18": 2,
+          "dsps": 0
+        },
+        {
+          "instance": "IBusCachedPlugin_cache",
+          "module": "InstructionCache",
+          "total_luts": 515,
+          "logic_luts": 515,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 95,
+          "ramb36": 0,
+          "ramb18": 2,
+          "dsps": 0
+        },
+        {
+          "instance": "gen_external_cpu.U_CPU_CONTROL",
+          "module": "wrc_external_cpu_control",
+          "total_luts": 57,
+          "logic_luts": 57,
+          "lutram": 0,
+          "srls": 0,
+          "ffs": 154,
+          "ramb36": 0,
+          "ramb18": 0,
+          "dsps": 0
+        }
+      ],
+      "reports": {
+        "utilization": "gateware/spec_a7_wr_nic_utilization_place.rpt",
+        "timing": "gateware/spec_a7_wr_nic_timing.rpt",
+        "hierarchy": "gateware/spec_a7_wr_nic_utilization_hierarchical_place.rpt"
+      },
+      "bit_bytes": 1594152,
+      "bin_bytes": null,
+      "build_seconds": 431.982,
+      "wr_clk_wns_ns": 5.102
+    }
+  },
+  "vexriscv_delta_vs_urv": {
+    "integrated": {
+      "slice_luts": {
+        "absolute": -69,
+        "percent": -0.5582072647844025
+      },
+      "logic_luts": {
+        "absolute": -65,
+        "percent": -0.5461267013947235
+      },
+      "lut_memory": {
+        "absolute": -4,
+        "percent": -0.8714596949891068
+      },
+      "ffs": {
+        "absolute": 26,
+        "percent": 0.17171917310613566
+      },
+      "ramb36": {
+        "absolute": 0,
+        "percent": 0.0
+      },
+      "ramb18": {
+        "absolute": 2,
+        "percent": 12.5
+      },
+      "bram18_equivalent": {
+        "absolute": 2,
+        "percent": 1.36986301369863
+      },
+      "dsps": {
+        "absolute": -4,
+        "percent": -50.0
+      },
+      "bit_bytes": {
+        "absolute": -19320,
+        "percent": -1.0559015716100204
+      },
+      "wns_ns": -0.015,
+      "whs_ns": 0.0,
+      "wr_clk_wns_ns": -0.12699999999999978
+    },
+    "hyperram": {
+      "slice_luts": {
+        "absolute": -221,
+        "percent": -1.7032755298651252
+      },
+      "logic_luts": {
+        "absolute": -219,
+        "percent": -1.752560819462228
+      },
+      "lut_memory": {
+        "absolute": -2,
+        "percent": -0.4175365344467641
+      },
+      "ffs": {
+        "absolute": 37,
+        "percent": 0.2322224314316199
+      },
+      "ramb36": {
+        "absolute": 0,
+        "percent": 0.0
+      },
+      "ramb18": {
+        "absolute": 2,
+        "percent": 9.523809523809524
+      },
+      "bram18_equivalent": {
+        "absolute": 2,
+        "percent": 2.247191011235955
+      },
+      "dsps": {
+        "absolute": -4,
+        "percent": -50.0
+      },
+      "bit_bytes": {
+        "absolute": -17568,
+        "percent": -1.0900156354701809
+      },
+      "wns_ns": -0.383,
+      "whs_ns": 0.0,
+      "wr_clk_wns_ns": -0.17999999999999972
+    }
+  }
+}

--- a/doc/wr_cpu_type_resource_comparison.md
+++ b/doc/wr_cpu_type_resource_comparison.md
@@ -1,0 +1,56 @@
+# WR CPU Type Resource Comparison
+
+- Target: `spec_a7_wr_nic` / `xc7a50tcsg325-2`
+- Tool: `Vivado v.2024.1 (lin64) Build 5076996 Wed May 22 18:36:09 MDT 2024`
+- Git: `20b3641a6bdf46779ce5e05717d46bc0df071772` (dirty)
+- CPU clock: `62.5 MHz`
+
+## Integrated memory
+
+| Metric | uRV | VexRiscv lite | VexRiscv Δ |
+|---|---:|---:|---:|
+| Slice LUTs | 12361 | 12292 | -69 (-0.6%) |
+| Logic LUTs | 11902 | 11837 | -65 (-0.5%) |
+| LUT memory | 459 | 455 | -4 (-0.9%) |
+| Flip-flops | 15141 | 15167 | +26 (+0.2%) |
+| RAMB36 | 65 | 65 | +0 (+0.0%) |
+| RAMB18 | 16 | 18 | +2 (+12.5%) |
+| BRAM18 equivalents | 146 | 148 | +2 (+1.4%) |
+| DSPs | 8 | 4 | -4 (-50.0%) |
+| Bitstream bytes | 1829716 | 1810396 | -19320 (-1.1%) |
+| WR clock WNS (ns) | 4.54 | 4.413 | -0.127 |
+| WNS (ns) | 0.004 | -0.011 | -0.015 |
+| WHS (ns) | 0.028 | 0.028 | +0.000 |
+| Build time (s) | 316.442 | 446.811 | +130.369 |
+
+Resource result: VexRiscv changes Slice LUTs by -69 (-0.6%), DSPs by -4 (-50.0%), and BRAM18 equivalents by +2 (+1.4%).
+
+Timing: uRV MET (+0.004 ns WNS), VexRiscv VIOLATED (-0.011 ns WNS).
+
+WR-clock timing: uRV MET (+4.540 ns WNS), VexRiscv MET (+4.413 ns WNS).
+
+## HyperRAM memory
+
+| Metric | uRV | VexRiscv lite | VexRiscv Δ |
+|---|---:|---:|---:|
+| Slice LUTs | 12975 | 12754 | -221 (-1.7%) |
+| Logic LUTs | 12496 | 12277 | -219 (-1.8%) |
+| LUT memory | 479 | 477 | -2 (-0.4%) |
+| Flip-flops | 15933 | 15970 | +37 (+0.2%) |
+| RAMB36 | 34 | 34 | +0 (+0.0%) |
+| RAMB18 | 21 | 23 | +2 (+9.5%) |
+| BRAM18 equivalents | 89 | 91 | +2 (+2.2%) |
+| DSPs | 8 | 4 | -4 (-50.0%) |
+| Bitstream bytes | 1611720 | 1594152 | -17568 (-1.1%) |
+| WR clock WNS (ns) | 5.282 | 5.102 | -0.180 |
+| WNS (ns) | -0.144 | -0.527 | -0.383 |
+| WHS (ns) | 0.028 | 0.028 | +0.000 |
+| Build time (s) | 475.554 | 431.982 | -43.572 |
+
+Resource result: VexRiscv changes Slice LUTs by -221 (-1.7%), DSPs by -4 (-50.0%), and BRAM18 equivalents by +2 (+2.2%).
+
+Timing: uRV VIOLATED (-0.144 ns WNS), VexRiscv VIOLATED (-0.527 ns WNS).
+
+WR-clock timing: uRV MET (+5.282 ns WNS), VexRiscv MET (+5.102 ns WNS).
+
+All utilization figures are from placed designs; timing is from the final timing report.

--- a/hyvision_pcie_opt01_revf.py
+++ b/hyvision_pcie_opt01_revf.py
@@ -47,7 +47,13 @@ from litex_wr_nic.gateware.time              import TimeGenerator
 from litex_wr_nic.gateware.measurement       import MultiClkMeasurement
 from litex_wr_nic.gateware.pps               import PPSGenerator
 from litex_wr_nic.gateware.nic.phy           import LiteEthPHYWRGMII
-from litex_wr_nic.gateware.wr_cpu            import WR_CPU_MEMORY_ORIGIN, WR_CPU_MEMORY_SIZE
+from litex_wr_nic.gateware.wr_cpu            import (
+    WR_CPU_MEMORY_ORIGIN,
+    WR_CPU_MEMORY_SIZE,
+    WR_CPU_TYPES,
+    validate_wr_cpu_config,
+    wr_cpu_firmware_filename,
+)
 
 # CRG ----------------------------------------------------------------------------------------------
 
@@ -105,9 +111,11 @@ class BaseSoC(LiteXWRNICSoC):
         # ------------------------
         with_white_rabbit          = True,
         white_rabbit_sfp_connector = 0,
-        white_rabbit_cpu_firmware  = "litex_wr_nic/firmware/spec_a7_wrc.bram",
-        white_rabbit_cpu_binary    = "litex_wr_nic/firmware/spec_a7_wrc.bin",
-        wr_cpu_memory              = "private",
+        white_rabbit_cpu_firmware  = None,
+        white_rabbit_cpu_binary    = None,
+        wr_cpu_type               = "urv",
+        wr_cpu_variant            = None,
+        wr_cpu_memory             = "private",
     ):
         # Platform ---------------------------------------------------------------------------------
 
@@ -137,8 +145,16 @@ class BaseSoC(LiteXWRNICSoC):
 
         if wr_cpu_memory not in ("private", "integrated"):
             raise ValueError(f"Unsupported WR CPU memory mode: {wr_cpu_memory}")
+        wr_cpu_variant = validate_wr_cpu_config(
+            wr_cpu_type, wr_cpu_variant, wr_cpu_memory)
         if not with_white_rabbit and wr_cpu_memory != "private":
             raise ValueError("External WR CPU memory requires White Rabbit support.")
+        if white_rabbit_cpu_firmware is None:
+            white_rabbit_cpu_firmware = os.path.join("litex_wr_nic", "firmware",
+                wr_cpu_firmware_filename(wr_cpu_type, "bram"))
+        if white_rabbit_cpu_binary is None:
+            white_rabbit_cpu_binary = os.path.join("litex_wr_nic", "firmware",
+                wr_cpu_firmware_filename(wr_cpu_type, "bin"))
         wr_cpu_region = None
         if wr_cpu_memory == "integrated":
             if not os.path.isfile(white_rabbit_cpu_binary):
@@ -197,6 +213,8 @@ class BaseSoC(LiteXWRNICSoC):
             self.add_wr_core(
                 # CPU.
                 cpu_firmware        = white_rabbit_cpu_firmware,
+                cpu_type            = wr_cpu_type,
+                cpu_variant         = wr_cpu_variant,
                 cpu_memory_region   = wr_cpu_region,
 
                 # Configuration.
@@ -357,6 +375,10 @@ def main():
     parser.add_argument("--flash", action="store_true", help="Flash bitstream.")
     parser.add_argument("--wr-cpu-memory", default="private", choices=["private", "integrated"],
         help="WR CPU memory implementation (default: private).")
+    parser.add_argument("--wr-cpu-type", default="urv", choices=WR_CPU_TYPES,
+        help="WR CPU implementation (default: embedded uRV).")
+    parser.add_argument("--wr-cpu-variant", default=None,
+        help="LiteX WR CPU variant (VexRiscv defaults to lite).")
     parser.add_argument("--output-dir", default=None, help="Build directory.")
 
     # Probes.
@@ -372,13 +394,18 @@ def main():
     # ---------------
     if args.build:
         print("Building firmware...")
-        r = os.system("cd litex_wr_nic/firmware && ./build.py --target acorn")
+        r = os.system("cd litex_wr_nic/firmware && ./build.py --target acorn --wr-cpu-type {}".format(
+            args.wr_cpu_type))
         if r != 0:
             raise RuntimeError("Firmware build failed.")
 
     # Build SoC/Gateware (with integrated Firmware).
     # ----------------------------------------------
-    soc = BaseSoC(wr_cpu_memory=args.wr_cpu_memory)
+    soc = BaseSoC(
+        wr_cpu_type    = args.wr_cpu_type,
+        wr_cpu_variant = args.wr_cpu_variant,
+        wr_cpu_memory  = args.wr_cpu_memory,
+    )
     if args.with_wishbone_fabric_interface_probe:
         soc.add_wishbone_fabric_interface_probe()
     if args.with_wishbone_slave_probe:

--- a/litex_wr_nic/firmware/build.py
+++ b/litex_wr_nic/firmware/build.py
@@ -7,12 +7,12 @@
 # Copyright (c) 2024 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-import argparse
 import os
+import sys
 import shutil
 import tarfile
+import argparse
 import subprocess
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -20,6 +20,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from litex.build import tools
+
+from litex_wr_nic.gateware.wr_cpu import WR_CPU_TYPES, wr_cpu_firmware_filename
 from litex_wr_nic.wr_boot import write_boot_image
 
 # Toolchain and firmware variables -----------------------------------------------------------------
@@ -35,10 +37,7 @@ COMMIT_HASH       = "baf7749610b2880bf243b38a9a1608af8e0e688d"
 CONFIG_SRC        = "spec_a7_defconfig"
 
 FIRMWARE_SRC       = os.path.join(CLONE_DIR, "wrc.bram")
-FIRMWARE_DEST      = "spec_a7_wrc.bram"
 FIRMWARE_BIN_SRC   = os.path.join(CLONE_DIR, "wrc.bin")
-FIRMWARE_BIN_DEST  = "spec_a7_wrc.bin"
-FIRMWARE_BOOT_DEST = "spec_a7_wrc.boot"
 
 SDBFS_DEST        = "sdb-wrpc.bin"
 SDBFS_SRC         = "sdbfs"
@@ -82,6 +81,11 @@ def checkout_commit(target="spec_a7"):
     # Ensure no kp/ki modifications.
     run_command(f"git checkout softpll/spll_main.c", cwd=CLONE_DIR)
     run_command(f"git checkout {COMMIT_HASH}", cwd=CLONE_DIR)
+    # These files receive the project-local CPU-profile overlay below. Restore
+    # only those owned files so repeated uRV/VexRiscv builds cannot leak flags.
+    run_command(
+        f"git checkout {COMMIT_HASH} -- Makefile arch/risc-v/crt0.S arch/risc-v/irq_helper.c",
+        cwd=CLONE_DIR)
 
     # For Acorn: adapts kp/ki.
     if target != "spec_a7":
@@ -96,22 +100,66 @@ def copy_config_file():
         exit(1)
     shutil.copy(CONFIG_SRC, config_dest)
 
-def build_firmware():
-    """Build the firmware."""
-    run_command("make spec_a7_defconfig", cwd=CLONE_DIR)
-    run_command("make", cwd=CLONE_DIR)
+def configure_cpu_profile(cpu_type):
+    """Add the small WRPC CPU abstraction needed by LiteX VexRiscv."""
+    makefile   = os.path.join(CLONE_DIR, "Makefile")
+    crt0       = os.path.join(CLONE_DIR, "arch/risc-v/crt0.S")
+    irq_helper = os.path.join(CLONE_DIR, "arch/risc-v/irq_helper.c")
+    tools.replace_in_file(
+        makefile,
+        "asflags-y = $(archflags-y)\n",
+        "asflags-y = $(archflags-y)\nasflags-y += $(WR_CPU_ASFLAGS)\n",
+    )
+    tools.replace_in_file(
+        makefile,
+        "cflags-y += $(archflags-y)\n",
+        "cflags-y += $(archflags-y)\ncflags-y += $(WR_CPU_CFLAGS)\n",
+    )
+    tools.replace_in_file(
+        crt0,
+        "_entry:\n\n    la     gp, _gp",
+        "_entry:\n\n"
+        "#ifdef WR_CPU_VEXRISCV\n"
+        "    /* The LiteX VexRiscv mtvec register has no reset value. */\n"
+        "    la     t0, _exception_entry\n"
+        "    csrw   mtvec, t0\n"
+        "#endif\n\n"
+        "    la     gp, _gp",
+    )
+    tools.replace_in_file(
+        irq_helper,
+        "void enable_irq(void)\n{\n    unsigned long t;\n\n",
+        "void enable_irq(void)\n{\n    unsigned long t;\n\n"
+        "#ifdef WR_CPU_VEXRISCV\n"
+        "    /* LiteX VexRiscv masks its external interrupt array in CSR BC0. */\n"
+        "    asm volatile (\"csrw 0xbc0, %0\" : : \"r\"(1));\n"
+        "#endif\n\n",
+    )
 
-def copy_firmware():
+def build_firmware(cpu_type):
+    """Build the firmware."""
+    configure_cpu_profile(cpu_type)
+    run_command("make clean", cwd=CLONE_DIR)
+    run_command("make spec_a7_defconfig", cwd=CLONE_DIR)
+    cpu_flags = "-DWR_CPU_VEXRISCV" if cpu_type == "vexriscv" else ""
+    run_command(
+        f"make WR_CPU_CFLAGS={cpu_flags} WR_CPU_ASFLAGS={cpu_flags}",
+        cwd=CLONE_DIR)
+
+def copy_firmware(cpu_type):
     """Copy the resulting firmware to the destination."""
+    firmware_dest      = wr_cpu_firmware_filename(cpu_type, "bram")
+    firmware_bin_dest  = wr_cpu_firmware_filename(cpu_type, "bin")
+    firmware_boot_dest = wr_cpu_firmware_filename(cpu_type, "boot")
     if not os.path.exists(FIRMWARE_SRC):
         print(f"Error: Firmware file {FIRMWARE_SRC} does not exist.")
         exit(1)
-    shutil.copy(FIRMWARE_SRC, FIRMWARE_DEST)
+    shutil.copy(FIRMWARE_SRC, firmware_dest)
     if not os.path.exists(FIRMWARE_BIN_SRC):
         print(f"Error: Firmware file {FIRMWARE_BIN_SRC} does not exist.")
         exit(1)
-    shutil.copy(FIRMWARE_BIN_SRC, FIRMWARE_BIN_DEST)
-    write_boot_image(FIRMWARE_BIN_DEST, FIRMWARE_BOOT_DEST)
+    shutil.copy(FIRMWARE_BIN_SRC, firmware_bin_dest)
+    write_boot_image(firmware_bin_dest, firmware_boot_dest)
 
 def build_sdbfs():
     """Build the SDB filesystem."""
@@ -138,6 +186,8 @@ def main():
     os.chdir(Path(__file__).resolve().parent)
     parser = argparse.ArgumentParser(description="LiteX-WR-NIC on Acorn Baseboard Mini.")
     parser.add_argument("--target", default="spec_a7", help="Target Board.", choices=["spec_a7", "acorn"])
+    parser.add_argument("--wr-cpu-type", default="urv", choices=WR_CPU_TYPES,
+        help="WR CPU firmware profile (default: urv).")
     args = parser.parse_args()
 
     init_riscv_toolchain()
@@ -145,8 +195,8 @@ def main():
     clone_repository()
     checkout_commit(args.target)
     copy_config_file()
-    build_firmware()
-    copy_firmware()
+    build_firmware(args.wr_cpu_type)
+    copy_firmware(args.wr_cpu_type)
     build_sdbfs()
     print("Build process completed successfully.")
 

--- a/litex_wr_nic/gateware/soc.py
+++ b/litex_wr_nic/gateware/soc.py
@@ -39,7 +39,13 @@ from litex_wr_nic.gateware.wr_common         import (
     patch_wr_clock_monitor_presc_cdc,
     patch_wr_external_cpu_memory,
 )
-from litex_wr_nic.gateware.wr_cpu            import WRCPUMemoryBridge, wr_cpu_word_bus
+from litex_wr_nic.gateware.wr_cpu            import (
+    WRCPUMemoryBridge,
+    WRCPUMemoryMonitor,
+    WRLiteXCPU,
+    resolve_wr_cpu_variant,
+    wr_cpu_word_bus,
+)
 from litex_wr_nic.gateware.wrf_stream2wb     import Stream2Wishbone
 from litex_wr_nic.gateware.wrf_wb2stream     import Wishbone2Stream
 from litex_wr_nic.gateware.wb_clock_crossing import WishboneClockCrossing
@@ -92,6 +98,8 @@ class LiteXWRNICSoC(SoCMini):
     def add_wr_core(self,
         # CPU.
         cpu_firmware,
+        cpu_type          = "urv",
+        cpu_variant       = None,
         cpu_memory_region = None,
         cpu_memory_ready  = 1,
         cpu_boot_loader   = None,
@@ -156,13 +164,40 @@ class LiteXWRNICSoC(SoCMini):
 
         # Optional WR CPU Memory Master.
         # ------------------------------
+        cpu_variant         = resolve_wr_cpu_variant(cpu_type, cpu_variant)
+        external_cpu        = cpu_type != "urv"
         external_cpu_memory = cpu_memory_region is not None
-        memory_ready_wr     = Signal(reset=not external_cpu_memory)
+        if external_cpu and not external_cpu_memory:
+            raise ValueError(f"WR CPU type {cpu_type} requires external CPU memory.")
+
+        memory_ready_wr   = Signal(reset=not external_cpu_memory)
+        wr_cpu_bridge     = None
+        wr_cpu_peripheral = None
+        wr_cpu_irq        = Signal()
+        wr_cpu_reset      = Signal()
         if external_cpu_memory:
-            wr_cpu_bus_sys = wishbone.Interface(data_width=32, address_width=32, addressing="byte")
-            self.wr_cpu_bridge = wr_cpu_bridge = WRCPUMemoryBridge(monitor_bus=wr_cpu_bus_sys)
+            if external_cpu:
+                self.wr_cpu = WRLiteXCPU(self.platform,
+                    cpu_type       = cpu_type,
+                    variant        = cpu_variant,
+                    irq            = wr_cpu_irq,
+                    software_reset = wr_cpu_reset,
+                    memory_ready   = memory_ready_wr,
+                )
+                wr_cpu_bus_wr     = self.wr_cpu.memory_bus
+                wr_cpu_bus_sys    = wishbone.Interface.like(wr_cpu_bus_wr)
+                wr_cpu_peripheral = self.wr_cpu.peripheral_bridge
+                self.wr_cpu_bridge = wr_cpu_bridge = WRCPUMemoryMonitor(monitor_bus=wr_cpu_bus_sys)
+            else:
+                wr_cpu_bus_sys = wishbone.Interface(
+                    data_width    = 32,
+                    address_width = 32,
+                    addressing    = "byte",
+                )
+                self.wr_cpu_bridge = wr_cpu_bridge = WRCPUMemoryBridge(monitor_bus=wr_cpu_bus_sys)
+                wr_cpu_bus_wr = wr_cpu_bridge.bus
             self.submodules.wr_cpu_memory_cdc = WishboneClockCrossing(self.platform,
-                wb_from        = wr_cpu_bridge.bus,
+                wb_from        = wr_cpu_bus_wr,
                 cd_from        = "wr_sys",
                 wb_to          = wr_cpu_bus_sys,
                 cd_to          = "sys",
@@ -257,6 +292,7 @@ class LiteXWRNICSoC(SoCMini):
             # Vivado binds quoted "FALSE" to true across the Verilog/VHDL
             # boundary; use a numeric boolean for deterministic elaboration.
             p_g_external_cpu_memory       = int(external_cpu_memory),
+            p_g_external_cpu              = int(external_cpu),
             p_txpolarity                  = sfp_tx_polarity,
             p_rxpolarity                  = sfp_rx_polarity,
             p_g_with_external_clock_input = str(with_ext_clk).upper(),
@@ -309,18 +345,34 @@ class LiteXWRNICSoC(SoCMini):
             i_spi_miso_i          = 0      if flash_pads is None else flash_pads.miso,
 
             # Optional WR CPU Memory Master.
-            o_cpu_mem_cyc_o       = Open() if not external_cpu_memory else wr_cpu_bridge.cyc,
-            o_cpu_mem_stb_o       = Open() if not external_cpu_memory else wr_cpu_bridge.stb,
-            o_cpu_mem_we_o        = Open() if not external_cpu_memory else wr_cpu_bridge.we,
-            o_cpu_mem_adr_o       = Open() if not external_cpu_memory else wr_cpu_bridge.adr,
-            o_cpu_mem_sel_o       = Open() if not external_cpu_memory else wr_cpu_bridge.sel,
-            o_cpu_mem_dat_o       = Open() if not external_cpu_memory else wr_cpu_bridge.dat_w,
-            i_cpu_mem_dat_i       = 0      if not external_cpu_memory else wr_cpu_bridge.dat_r,
-            i_cpu_mem_ack_i       = 0      if not external_cpu_memory else wr_cpu_bridge.ack,
-            i_cpu_mem_err_i       = 0      if not external_cpu_memory else wr_cpu_bridge.err,
-            i_cpu_mem_rty_i       = 0      if not external_cpu_memory else wr_cpu_bridge.rty,
-            i_cpu_mem_stall_i     = 0      if not external_cpu_memory else wr_cpu_bridge.stall,
+            o_cpu_mem_cyc_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.cyc,
+            o_cpu_mem_stb_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.stb,
+            o_cpu_mem_we_o        = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.we,
+            o_cpu_mem_adr_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.adr,
+            o_cpu_mem_sel_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.sel,
+            o_cpu_mem_dat_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.dat_w,
+            i_cpu_mem_dat_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.dat_r,
+            i_cpu_mem_ack_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.ack,
+            i_cpu_mem_err_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.err,
+            i_cpu_mem_rty_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.rty,
+            i_cpu_mem_stall_i     = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.stall,
             i_cpu_mem_ready_i     = 1      if not external_cpu_memory else memory_ready_wr,
+
+            # Optional LiteX WR CPU peripheral master, interrupt and reset.
+            i_cpu_ext_cyc_i       = 0 if not external_cpu else wr_cpu_peripheral.cyc,
+            i_cpu_ext_stb_i       = 0 if not external_cpu else wr_cpu_peripheral.stb,
+            i_cpu_ext_we_i        = 0 if not external_cpu else wr_cpu_peripheral.we,
+            i_cpu_ext_adr_i       = 0 if not external_cpu else Cat(
+                Constant(0, 2), wr_cpu_peripheral.adr),
+            i_cpu_ext_sel_i       = 0 if not external_cpu else wr_cpu_peripheral.sel,
+            i_cpu_ext_dat_i       = 0 if not external_cpu else wr_cpu_peripheral.dat_w,
+            o_cpu_ext_dat_o       = Open() if not external_cpu else wr_cpu_peripheral.dat_r,
+            o_cpu_ext_ack_o       = Open() if not external_cpu else wr_cpu_peripheral.ack,
+            o_cpu_ext_err_o       = Open() if not external_cpu else wr_cpu_peripheral.err,
+            o_cpu_ext_rty_o       = Open() if not external_cpu else wr_cpu_peripheral.rty,
+            o_cpu_ext_stall_o     = Open() if not external_cpu else wr_cpu_peripheral.stall,
+            o_cpu_ext_irq_o       = Open() if not external_cpu else wr_cpu_irq,
+            o_cpu_ext_reset_o     = Open() if not external_cpu else wr_cpu_reset,
 
             # PPS / Leds.
             i_pps_ext_i           = self.pps_in,

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
@@ -69,6 +69,7 @@ entity xwrc_board_litex_wr_nic is
     g_dpram_initf               : string               := "default_xilinx";
     g_dpram_size                : integer              := 131072/4;
     g_external_cpu_memory       : boolean              := false;
+    g_external_cpu              : boolean              := false;
     -- identification (id and ver) of the layout of words in the generic diag interface
     g_diag_id                   : integer              := 0;
     g_diag_ver                  : integer              := 0;
@@ -248,6 +249,12 @@ entity xwrc_board_litex_wr_nic is
     cpu_mem_i       : in  t_wishbone_master_in := cc_dummy_master_in;
     cpu_mem_ready_i : in  std_logic := '1';
 
+    -- Optional CPU instantiated outside the WR core.
+    cpu_ext_master_i : in  t_wishbone_master_out := cc_dummy_master_out;
+    cpu_ext_master_o : out t_wishbone_master_in;
+    cpu_ext_irq_o    : out std_logic;
+    cpu_ext_reset_o  : out std_logic;
+
     GT0_EXT_QPLL_RESET  : out std_logic;
     GT0_EXT_QPLL_CLK    : in  std_logic;
     GT0_EXT_QPLL_REFCLK : in  std_logic;
@@ -417,6 +424,7 @@ begin  -- architecture struct
       g_dpram_initf               => g_dpram_initf,
       g_dpram_size                => g_dpram_size,
       g_external_cpu_memory       => g_external_cpu_memory,
+      g_external_cpu              => g_external_cpu,
       g_interface_mode            => PIPELINED,
       g_address_granularity       => BYTE,
       g_aux_sdb                   => c_wrc_periph3_sdb,
@@ -494,6 +502,10 @@ begin  -- architecture struct
       cpu_mem_o            => cpu_mem_o,
       cpu_mem_i            => cpu_mem_i,
       cpu_mem_ready_i      => cpu_mem_ready_i,
+      cpu_ext_master_i     => cpu_ext_master_i,
+      cpu_ext_master_o     => cpu_ext_master_o,
+      cpu_ext_irq_o        => cpu_ext_irq_o,
+      cpu_ext_reset_o      => cpu_ext_reset_o,
       tm_dac_value_o       => tm_dac_value_o,
       tm_dac_wr_o          => tm_dac_wr_o,
       tm_clk_aux_lock_en_i => tm_clk_aux_lock_en_i,

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
@@ -41,6 +41,7 @@ entity xwrc_board_litex_wr_nic_wrapper is
     g_dpram_initf               : string  := "default_xilinx";
     g_dpram_size                : integer := 131072/4;
     g_external_cpu_memory       : boolean := false;
+    g_external_cpu              : boolean := false;
     -- identification (id and ver) of the layout of words in the generic diag interface
     g_diag_id                   : integer := 0;
     g_diag_ver                  : integer := 0;
@@ -111,6 +112,21 @@ entity xwrc_board_litex_wr_nic_wrapper is
     cpu_mem_rty_i        : in  std_logic := '0';
     cpu_mem_stall_i      : in  std_logic := '0';
     cpu_mem_ready_i      : in  std_logic := '1';
+
+    -- Optional CPU instantiated by LiteX.
+    cpu_ext_cyc_i        : in  std_logic := '0';
+    cpu_ext_stb_i        : in  std_logic := '0';
+    cpu_ext_we_i         : in  std_logic := '0';
+    cpu_ext_adr_i        : in  std_logic_vector(31 downto 0) := (others => '0');
+    cpu_ext_sel_i        : in  std_logic_vector(3 downto 0) := (others => '0');
+    cpu_ext_dat_i        : in  std_logic_vector(31 downto 0) := (others => '0');
+    cpu_ext_dat_o        : out std_logic_vector(31 downto 0);
+    cpu_ext_ack_o        : out std_logic;
+    cpu_ext_err_o        : out std_logic;
+    cpu_ext_rty_o        : out std_logic;
+    cpu_ext_stall_o      : out std_logic;
+    cpu_ext_irq_o        : out std_logic;
+    cpu_ext_reset_o      : out std_logic;
 
     -- WRF
     wrf_src_adr          : out std_logic_vector(1 downto 0);
@@ -206,6 +222,9 @@ architecture wrapper of xwrc_board_litex_wr_nic_wrapper is
   signal cpu_mem_out : t_wishbone_master_out;
   signal cpu_mem_in  : t_wishbone_master_in := cc_dummy_master_in;
 
+  signal cpu_ext_master_out : t_wishbone_master_out := cc_dummy_master_out;
+  signal cpu_ext_master_in  : t_wishbone_master_in := cc_dummy_master_in;
+
 begin
 
   -- wrf_src Record -> Signals.
@@ -264,6 +283,19 @@ begin
   cpu_mem_in.rty  <= cpu_mem_rty_i;
   cpu_mem_in.stall <= cpu_mem_stall_i;
 
+  -- External-CPU Signals <-> Record.
+  cpu_ext_master_out.cyc <= cpu_ext_cyc_i;
+  cpu_ext_master_out.stb <= cpu_ext_stb_i;
+  cpu_ext_master_out.we  <= cpu_ext_we_i;
+  cpu_ext_master_out.adr <= cpu_ext_adr_i;
+  cpu_ext_master_out.sel <= cpu_ext_sel_i;
+  cpu_ext_master_out.dat <= cpu_ext_dat_i;
+  cpu_ext_dat_o          <= cpu_ext_master_in.dat;
+  cpu_ext_ack_o          <= cpu_ext_master_in.ack;
+  cpu_ext_err_o          <= cpu_ext_master_in.err;
+  cpu_ext_rty_o          <= cpu_ext_master_in.rty;
+  cpu_ext_stall_o        <= cpu_ext_master_in.stall;
+
   -- xwrc_board_litex_wr_nic Instance.
   u_xwrc_board_litex_wr_nic : entity work.xwrc_board_litex_wr_nic
     generic map (
@@ -279,6 +311,7 @@ begin
       g_dpram_initf               => g_dpram_initf,
       g_dpram_size                => g_dpram_size,
       g_external_cpu_memory       => g_external_cpu_memory,
+      g_external_cpu              => g_external_cpu,
       g_diag_id                   => g_diag_id,
       g_diag_ver                  => g_diag_ver,
       g_diag_ro_size              => g_diag_ro_size,
@@ -322,6 +355,10 @@ begin
       cpu_mem_o            => cpu_mem_out,
       cpu_mem_i            => cpu_mem_in,
       cpu_mem_ready_i      => cpu_mem_ready_i,
+      cpu_ext_master_i     => cpu_ext_master_out,
+      cpu_ext_master_o     => cpu_ext_master_in,
+      cpu_ext_irq_o        => cpu_ext_irq_o,
+      cpu_ext_reset_o      => cpu_ext_reset_o,
 
       wrf_src_o            => wrf_src_o,
       wrf_src_i            => wrf_src_i,

--- a/litex_wr_nic/gateware/wr-cores/modules/wrc_core/wrc_external_cpu_control.vhd
+++ b/litex_wr_nic/gateware/wr-cores/modules/wrc_core/wrc_external_cpu_control.vhd
@@ -1,0 +1,43 @@
+-------------------------------------------------------------------------------
+-- SPDX-FileCopyrightText: 2026 Enjoy-Digital
+--
+-- SPDX-License-Identifier: CERN-OHL-W-2.0+
+-------------------------------------------------------------------------------
+-- Keep the WRPC host CPU-control register block when the CPU itself is
+-- instantiated by LiteX. Only RESET remains meaningful in this mode.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.wishbone_pkg.all;
+use work.wrc_cpu_csr_pkg.all;
+
+entity wrc_external_cpu_control is
+  port(
+    clk_sys_i    : in  std_logic;
+    rst_n_i      : in  std_logic;
+    reset_o      : out std_logic;
+    host_slave_i : in  t_wishbone_slave_in;
+    host_slave_o : out t_wishbone_slave_out);
+end wrc_external_cpu_control;
+
+architecture arch of wrc_external_cpu_control is
+  signal regs_in  : t_wrc_cpu_csr_regs_master_out;
+  signal regs_out : t_wrc_cpu_csr_regs_master_in;
+begin
+  U_CPU_CSR : entity work.wrc_cpu_csr
+    port map (
+      rst_n_i            => rst_n_i,
+      clk_i              => clk_sys_i,
+      wb_i               => host_slave_i,
+      wb_o               => host_slave_o,
+      wrc_cpu_csr_regs_i => regs_out,
+      wrc_cpu_csr_regs_o => regs_in);
+
+  reset_o                 <= regs_in.reset(0);
+  regs_out.udata          <= (others => '0');
+  regs_out.dbg_status     <= (others => '0');
+  regs_out.dbg_insn_ready <= (others => '0');
+  regs_out.dbg_core0_mbx  <= (others => '0');
+end architecture arch;

--- a/litex_wr_nic/gateware/wr_common.py
+++ b/litex_wr_nic/gateware/wr_common.py
@@ -109,22 +109,34 @@ def patch_wr_clock_monitor_presc_cdc():
         "        if(clks(i).presc_cnt = unsigned(clks(i).presc_value(4 downto 0))) then"
     )
 
-def _replace_once(path, before, after):
-    """Apply a pinned-source patch once and fail clearly on signature drift."""
+def _replace_once(path, before, after, intermediate=None):
+    """Apply a pinned-source patch once and fail clearly on signature drift.
+
+    ``intermediate`` lets a checkout whose ignored wr-cores tree was already
+    patched by the CPU-memory branch migrate to the combined CPU patch.
+    """
     with open(path, "r", encoding="utf-8") as f:
         contents = f.read()
     if after in contents:
         return
-    if contents.count(before) != 1:
+    candidates = [before]
+    if intermediate is not None:
+        candidates.append(intermediate)
+    matches = [candidate for candidate in candidates if contents.count(candidate) == 1]
+    if len(matches) != 1:
         raise RuntimeError(f"WR-core patch signature mismatch in {path}: {before[:80]!r}")
     with open(path, "w", encoding="utf-8") as f:
-        f.write(contents.replace(before, after, 1))
+        f.write(contents.replace(matches[0], after, 1))
 
 def patch_wr_external_cpu_memory():
-    """Propagate the optional WR CPU-memory Wishbone master through wr-cores."""
+    """Propagate optional external WR CPU interfaces through wr-cores."""
     _replace_once(
         WR_CORE_VHD,
         """    g_dpram_size                : integer                        := 131072/4;  --in 32-bit words
+    g_use_platform_specific_dpram""",
+        """    g_dpram_size                : integer                        := 131072/4;  --in 32-bit words
+    g_external_cpu_memory        : boolean                        := false;
+    g_external_cpu               : boolean                        := false;
     g_use_platform_specific_dpram""",
         """    g_dpram_size                : integer                        := 131072/4;  --in 32-bit words
     g_external_cpu_memory        : boolean                        := false;
@@ -133,6 +145,18 @@ def patch_wr_external_cpu_memory():
     _replace_once(
         WR_CORE_VHD,
         """    aux_diag_o    : out t_generic_word_array(g_diag_rw_size-1 downto 0);
+
+    link_ok_o : out std_logic""",
+        """    aux_diag_o    : out t_generic_word_array(g_diag_rw_size-1 downto 0);
+
+    cpu_mem_o       : out t_wishbone_master_out;
+    cpu_mem_i       : in  t_wishbone_master_in := cc_dummy_master_in;
+    cpu_mem_ready_i : in  std_logic := '1';
+
+    cpu_ext_master_i : in  t_wishbone_master_out := cc_dummy_master_out;
+    cpu_ext_master_o : out t_wishbone_master_in;
+    cpu_ext_irq_o    : out std_logic;
+    cpu_ext_reset_o  : out std_logic;
 
     link_ok_o : out std_logic""",
         """    aux_diag_o    : out t_generic_word_array(g_diag_rw_size-1 downto 0);
@@ -160,6 +184,63 @@ def patch_wr_external_cpu_memory():
       host_slave_i => cpu_csr_wb_in,
       host_slave_o => cpu_csr_wb_out
       );""",
+        """  cpu_ext_master_o <= cpu_dwb_in;
+  cpu_ext_irq_o    <= softpll_irq;
+
+  assert not (g_external_cpu and not g_external_cpu_memory)
+    report "External WR CPU requires external CPU memory"
+    severity failure;
+
+  gen_private_cpu_memory : if not g_external_cpu and not g_external_cpu_memory generate
+    cpu_mem_o       <= cc_dummy_master_out;
+    cpu_ext_reset_o <= '0';
+
+    U_CPU_PRIVATE: entity work.wrc_urv_wrapper
+      generic map (
+        g_IRAM_SIZE => g_dpram_size,
+        g_IRAM_INIT => g_dpram_initf,
+        g_CPU_ID => 0)
+      port map (
+        clk_sys_i    => clk_sys_i,
+        rst_n_i      => rst_n_i,
+        irq_i        => softpll_irq,
+        dwb_o        => cpu_dwb_out,
+        dwb_i        => cpu_dwb_in,
+        host_slave_i => cpu_csr_wb_in,
+        host_slave_o => cpu_csr_wb_out);
+  end generate;
+
+  gen_external_cpu_memory : if not g_external_cpu and g_external_cpu_memory generate
+    cpu_ext_reset_o <= '0';
+
+    U_CPU_EXTERNAL: entity work.wrc_urv_external_memory
+      generic map (
+        g_CPU_ID => 0)
+      port map (
+        clk_sys_i      => clk_sys_i,
+        rst_n_i        => rst_n_i,
+        irq_i          => softpll_irq,
+        memory_ready_i => cpu_mem_ready_i,
+        cpu_mem_o      => cpu_mem_o,
+        cpu_mem_i      => cpu_mem_i,
+        dwb_o          => cpu_dwb_out,
+        dwb_i          => cpu_dwb_in,
+        host_slave_i   => cpu_csr_wb_in,
+        host_slave_o   => cpu_csr_wb_out);
+  end generate;
+
+  gen_external_cpu : if g_external_cpu generate
+    cpu_mem_o   <= cc_dummy_master_out;
+    cpu_dwb_out <= cpu_ext_master_i;
+
+    U_CPU_CONTROL: entity work.wrc_external_cpu_control
+      port map (
+        clk_sys_i    => clk_sys_i,
+        rst_n_i      => rst_n_i,
+        reset_o      => cpu_ext_reset_o,
+        host_slave_i => cpu_csr_wb_in,
+        host_slave_o => cpu_csr_wb_out);
+  end generate;""",
         """  gen_private_cpu_memory : if not g_external_cpu_memory generate
     cpu_mem_o <= cc_dummy_master_out;
 
@@ -202,11 +283,27 @@ def patch_wr_external_cpu_memory():
     g_interface_mode""",
         """    g_dpram_size                : integer                        := 131072/4;
     g_external_cpu_memory        : boolean                        := false;
+    g_external_cpu               : boolean                        := false;
+    g_interface_mode""",
+        """    g_dpram_size                : integer                        := 131072/4;
+    g_external_cpu_memory        : boolean                        := false;
     g_interface_mode"""
     )
     _replace_once(
         WR_BOARD_VHD,
         """    link_ok_o : out std_logic;
+
+    aux_timing_serdes_locked_i""",
+        """    link_ok_o : out std_logic;
+
+    cpu_mem_o       : out t_wishbone_master_out;
+    cpu_mem_i       : in  t_wishbone_master_in := cc_dummy_master_in;
+    cpu_mem_ready_i : in  std_logic := '1';
+
+    cpu_ext_master_i : in  t_wishbone_master_out := cc_dummy_master_out;
+    cpu_ext_master_o : out t_wishbone_master_in;
+    cpu_ext_irq_o    : out std_logic;
+    cpu_ext_reset_o  : out std_logic;
 
     aux_timing_serdes_locked_i""",
         """    link_ok_o : out std_logic;
@@ -223,11 +320,24 @@ def patch_wr_external_cpu_memory():
       g_interface_mode""",
         """      g_dpram_size                => g_dpram_size,
       g_external_cpu_memory        => g_external_cpu_memory,
+      g_external_cpu               => g_external_cpu,
+      g_interface_mode""",
+        """      g_dpram_size                => g_dpram_size,
+      g_external_cpu_memory        => g_external_cpu_memory,
       g_interface_mode"""
     )
     _replace_once(
         WR_BOARD_VHD,
         """      aux_diag_o                  => aux_diag_out,
+      link_ok_o                   => link_ok);""",
+        """      aux_diag_o                  => aux_diag_out,
+      cpu_mem_o                   => cpu_mem_o,
+      cpu_mem_i                   => cpu_mem_i,
+      cpu_mem_ready_i             => cpu_mem_ready_i,
+      cpu_ext_master_i            => cpu_ext_master_i,
+      cpu_ext_master_o            => cpu_ext_master_o,
+      cpu_ext_irq_o               => cpu_ext_irq_o,
+      cpu_ext_reset_o             => cpu_ext_reset_o,
       link_ok_o                   => link_ok);""",
         """      aux_diag_o                  => aux_diag_out,
       cpu_mem_o                   => cpu_mem_o,
@@ -427,6 +537,7 @@ wr_core_files += [
     "wr-cores/modules/wrc_core/wrc_syscon_map.vhd",
     "wr-cores/modules/wrc_core/wrc_urv_wrapper.vhd",
     os.path.join(cdir, "wr-cores/modules/wrc_core/wrc_urv_external_memory.vhd"),
+    os.path.join(cdir, "wr-cores/modules/wrc_core/wrc_external_cpu_control.vhd"),
     "wr-cores/modules/wrc_core/wrcore_pkg.vhd",
     "wr-cores/modules/wrc_core/xwr_core.vhd",
     "wr-cores/modules/wrc_core/xwr_subsystem.vhd",

--- a/litex_wr_nic/gateware/wr_cpu.py
+++ b/litex_wr_nic/gateware/wr_cpu.py
@@ -23,8 +23,224 @@ from litex_wr_nic.wr_boot import (
 
 # Constants ----------------------------------------------------------------------------------------
 
-WR_CPU_MEMORY_ORIGIN = 0x4000_0000
-WR_CPU_MEMORY_SIZE   = WR_BOOT_MAX_PAYLOAD
+WR_CPU_MEMORY_ORIGIN     = 0x4000_0000
+WR_CPU_MEMORY_SIZE       = WR_BOOT_MAX_PAYLOAD
+WR_CPU_PERIPHERAL_ORIGIN = 0x0010_0000
+
+WR_CPU_TYPES = ("urv", "vexriscv")
+WR_CPU_ADAPTERS = {
+    "vexriscv": {
+        "variants"        : ("lite",),
+        "default_variant" : "lite",
+    },
+}
+
+# WR CPU Configuration -----------------------------------------------------------------------------
+
+def resolve_wr_cpu_variant(cpu_type, variant=None):
+    """Validate a WR CPU selection and return its canonical variant."""
+    if cpu_type not in WR_CPU_TYPES:
+        raise ValueError(f"Unsupported WR CPU type: {cpu_type}")
+    if cpu_type == "urv":
+        if variant is not None:
+            raise ValueError("The embedded uRV CPU does not accept --wr-cpu-variant.")
+        return None
+    adapter = WR_CPU_ADAPTERS[cpu_type]
+    if variant is None:
+        variant = adapter["default_variant"]
+    if variant not in adapter["variants"]:
+        supported = ", ".join(adapter["variants"])
+        raise ValueError(f"Unsupported {cpu_type} WR CPU variant: {variant}; supported: {supported}")
+    return variant
+
+
+def validate_wr_cpu_config(cpu_type, variant=None, memory="private"):
+    """Validate the CPU/memory combination and return the canonical variant."""
+    variant = resolve_wr_cpu_variant(cpu_type, variant)
+    if cpu_type != "urv" and memory == "private":
+        raise ValueError(f"WR CPU type {cpu_type} requires integrated or HyperRAM memory.")
+    return variant
+
+
+def wr_cpu_firmware_filename(cpu_type, extension, target="spec_a7"):
+    """Return the distinct firmware artifact used by a WR CPU profile."""
+    resolve_wr_cpu_variant(cpu_type)
+    suffix = "" if cpu_type == "urv" else f"_{cpu_type}"
+    return f"{target}_wrc{suffix}.{extension}"
+
+# WR CPU Interconnect ------------------------------------------------------------------------------
+
+class WRCPUInterconnect(LiteXModule):
+    """Split a LiteX CPU's WRPC memory and peripheral accesses."""
+
+    def __init__(self, ibus, dbus):
+        if ibus.data_width != 32 or dbus.data_width != 32:
+            raise ValueError("WR CPUs require 32-bit instruction and data Wishbone buses.")
+        if ibus.addressing != "word" or dbus.addressing != "word":
+            raise ValueError("The VexRiscv WR CPU adapter expects word-addressed Wishbone buses.")
+
+        self.memory_bus     = wishbone.Interface.like(dbus)
+        self.peripheral_bus = wishbone.Interface.like(dbus)
+        data_memory_bus     = wishbone.Interface.like(dbus)
+
+        # # #
+
+        peripheral_word = WR_CPU_PERIPHERAL_ORIGIN // 4
+        self.submodules.data_decoder = wishbone.Decoder(dbus, [
+            (lambda address: address < peripheral_word, data_memory_bus),
+            (lambda address: address >= peripheral_word, self.peripheral_bus),
+        ])
+        # Match the existing uRV bridge's preference for data when an
+        # instruction fill and a load/store arrive together.
+        self.submodules.memory_arbiter = wishbone.Arbiter(
+            masters = [data_memory_bus, ibus],
+            target  = self.memory_bus,
+        )
+
+# WR CPU Peripheral Bridge -------------------------------------------------------------------------
+
+class WRCPUPeripheralBridge(LiteXModule):
+    """Adapt a LiteX classic Wishbone master to WR's pipelined bus."""
+
+    def __init__(self, bus):
+        self.cyc   = Signal()
+        self.stb   = Signal()
+        self.we    = Signal()
+        self.adr   = Signal.like(bus.adr)
+        self.sel   = Signal.like(bus.sel)
+        self.dat_w = Signal.like(bus.dat_w)
+        self.dat_r = Signal.like(bus.dat_r)
+        self.ack   = Signal()
+        self.err   = Signal()
+        self.rty   = Signal()
+        self.stall = Signal()
+
+        # # #
+
+        request_accepted = Signal()
+        response_data    = Signal.like(bus.dat_r)
+        response_error   = Signal()
+
+        self.fsm = fsm = ResetInserter()(FSM(reset_state="IDLE"))
+        fsm.act("IDLE",
+            NextValue(request_accepted, 0),
+            If(bus.cyc & bus.stb,
+                NextValue(self.we, bus.we),
+                NextValue(self.adr, bus.adr),
+                NextValue(self.sel, bus.sel),
+                NextValue(self.dat_w, bus.dat_w),
+                NextState("ACCESS"),
+            ),
+        )
+        fsm.act("ACCESS",
+            self.cyc.eq(1),
+            self.stb.eq(~request_accepted),
+            If(~request_accepted & ~self.stall,
+                NextValue(request_accepted, 1),
+            ),
+            If(self.ack | self.err | self.rty,
+                NextValue(response_data, Mux(self.ack, self.dat_r, 0)),
+                NextValue(response_error, self.err | self.rty),
+                NextState("RESPONSE"),
+            ),
+        )
+        fsm.act("RESPONSE",
+            # VexRiscv-lite ignores Wishbone ERR, so every terminal response
+            # also asserts ACK. ERR is retained for future LiteX CPU adapters.
+            bus.ack.eq(1),
+            bus.err.eq(response_error),
+            bus.dat_r.eq(response_data),
+            NextState("WAIT_RELEASE"),
+        )
+        fsm.act("WAIT_RELEASE",
+            If(~bus.cyc | ~bus.stb,
+                NextState("IDLE"),
+            ),
+        )
+
+# LiteX WR CPU -------------------------------------------------------------------------------------
+
+class WRLiteXCPU(LiteXModule):
+    """Instantiate a supported LiteX CPU for WRPC firmware."""
+
+    def __init__(self, platform, cpu_type,
+        variant        = None,
+        irq            = 0,
+        software_reset = 0,
+        memory_ready   = 1,
+    ):
+        variant = resolve_wr_cpu_variant(cpu_type, variant)
+
+        from litex.soc.cores import cpu as litex_cpu
+
+        cpu_cls = litex_cpu.CPUS[cpu_type]
+        core    = cpu_cls(platform, variant=variant)
+        for name, expected in (
+            ("family", "riscv"),
+            ("data_width", 32),
+            ("endianness", "little"),
+        ):
+            if getattr(core, name, None) != expected:
+                raise ValueError(f"WR CPU {cpu_type} requires {name}={expected!r}.")
+        for name in ("ibus", "dbus", "interrupt", "reset"):
+            if not hasattr(core, name):
+                raise ValueError(f"WR CPU {cpu_type} does not expose {name}.")
+
+        core.set_reset_address(0x0000_0000)
+        self.submodules.core = ClockDomainsRenamer("wr_sys")(core)
+        # The arbiter is sequential too; keep the complete CPU adapter in the
+        # core's system domain, independently of the resettable PHY reference.
+        self.submodules.interconnect = interconnect = ClockDomainsRenamer("wr_sys")(
+            WRCPUInterconnect(core.ibus, core.dbus)
+        )
+        self.submodules.peripheral_bridge = peripheral_bridge = ClockDomainsRenamer("wr_sys")(
+            WRCPUPeripheralBridge(interconnect.peripheral_bus)
+        )
+        self.memory_bus        = interconnect.memory_bus
+        self.peripheral_bridge = peripheral_bridge
+        self.cpu_type          = cpu_type
+        self.cpu_variant       = variant
+
+        # # #
+
+        self.comb += [
+            core.reset.eq(software_reset | ~memory_ready),
+            peripheral_bridge.fsm.reset.eq(software_reset | ~memory_ready),
+            # VexRiscv aggregates enabled array inputs into standard machine
+            # external interrupt cause 11. Firmware selects line 0 in CSR BC0.
+            core.interrupt.eq(irq),
+        ]
+
+# WR CPU Memory Monitor ----------------------------------------------------------------------------
+
+class WRCPUMemoryMonitor(LiteXModule, AutoCSR):
+    """Expose diagnostics for a WR CPU's system-side memory bus."""
+
+    def __init__(self, monitor_bus):
+        self._status = CSRStatus(fields=[
+            CSRField("error", description="A WR CPU memory transaction failed."),
+            CSRField("busy",  description="A WR CPU memory transaction is active."),
+        ])
+        self._error_count        = CSRStatus(32, description="Number of WR CPU memory bus errors/timeouts.")
+        self._last_error_address = CSRStatus(32, description="Address of the most recent failed transaction.")
+
+        # # #
+
+        error_sticky = Signal()
+        error_count  = Signal(32)
+        error_addr   = Signal(32)
+
+        self.comb += [
+            self._status.fields.error.eq(error_sticky),
+            self._status.fields.busy.eq(monitor_bus.cyc),
+            self._error_count.status.eq(error_count),
+            self._last_error_address.status.eq(error_addr),
+        ]
+        self.sync += If(monitor_bus.err,
+            error_sticky.eq(1),
+            error_count.eq(error_count + 1),
+            error_addr.eq(monitor_bus.adr),
+        )
 
 # WR CPU Word Addressing ---------------------------------------------------------------------------
 

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -55,6 +55,9 @@ from litex_wr_nic.gateware.wr_cpu            import (
     WRCPUFlashBoot,
     WR_CPU_MEMORY_ORIGIN,
     WR_CPU_MEMORY_SIZE,
+    WR_CPU_TYPES,
+    validate_wr_cpu_config,
+    wr_cpu_firmware_filename,
     wr_cpu_word_bus,
 )
 from litex_wr_nic.wr_boot import WR_BOOT_FLASH_OFFSET, WR_SDB_FLASH_OFFSET, validate_flash_layout
@@ -120,9 +123,11 @@ class BaseSoC(LiteXWRNICSoC):
         # ------------------------
         with_white_rabbit          = True,
         white_rabbit_sfp_connector = 0,
-        white_rabbit_cpu_firmware  = "litex_wr_nic/firmware/spec_a7_wrc.bram",
-        white_rabbit_cpu_binary    = "litex_wr_nic/firmware/spec_a7_wrc.bin",
-        wr_cpu_memory              = "private",
+        white_rabbit_cpu_firmware  = None,
+        white_rabbit_cpu_binary    = None,
+        wr_cpu_type               = "urv",
+        wr_cpu_variant            = None,
+        wr_cpu_memory             = "private",
 
         # Sync-In Parameters.
         # -------------------
@@ -183,8 +188,16 @@ class BaseSoC(LiteXWRNICSoC):
 
         if wr_cpu_memory not in ("private", "integrated", "hyperram"):
             raise ValueError(f"Unsupported WR CPU memory mode: {wr_cpu_memory}")
+        wr_cpu_variant = validate_wr_cpu_config(
+            wr_cpu_type, wr_cpu_variant, wr_cpu_memory)
         if not with_white_rabbit and wr_cpu_memory != "private":
             raise ValueError("External WR CPU memory requires White Rabbit support.")
+        if white_rabbit_cpu_firmware is None:
+            white_rabbit_cpu_firmware = os.path.join("litex_wr_nic", "firmware",
+                wr_cpu_firmware_filename(wr_cpu_type, "bram"))
+        if white_rabbit_cpu_binary is None:
+            white_rabbit_cpu_binary = os.path.join("litex_wr_nic", "firmware",
+                wr_cpu_firmware_filename(wr_cpu_type, "bin"))
 
         wr_cpu_region = None
         wr_cpu_ready  = 1
@@ -278,6 +291,8 @@ class BaseSoC(LiteXWRNICSoC):
             self.add_wr_core(
                 # CPU.
                 cpu_firmware      = white_rabbit_cpu_firmware,
+                cpu_type          = wr_cpu_type,
+                cpu_variant       = wr_cpu_variant,
                 cpu_memory_region = wr_cpu_region,
                 cpu_memory_ready  = wr_cpu_ready,
                 cpu_boot_loader   = wr_cpu_loader,
@@ -674,6 +689,11 @@ def main():
     parser.add_argument("--wr-cpu-memory", default="private",
         choices=["private", "integrated", "hyperram"],
         help="WR CPU memory implementation (default: private).")
+    parser.add_argument("--wr-cpu-type", default="urv",
+        choices=WR_CPU_TYPES,
+        help="WR CPU implementation (default: embedded uRV).")
+    parser.add_argument("--wr-cpu-variant", default=None,
+        help="LiteX WR CPU variant (VexRiscv defaults to lite).")
     parser.add_argument("--output-dir", default=None,
         help="Build directory (useful for resource comparisons).")
     parser.add_argument("--skip-firmware-build", action="store_true",
@@ -694,13 +714,18 @@ def main():
     # ---------------
     if args.build and not args.skip_firmware_build:
         print("Building firmware...")
-        r = os.system("cd litex_wr_nic/firmware && ./build.py")
+        r = os.system("cd litex_wr_nic/firmware && ./build.py --wr-cpu-type {}".format(
+            args.wr_cpu_type))
         if r != 0:
             raise RuntimeError("Firmware build failed.")
 
     # Build SoC/Gateware (with integrated Firmware).
     # ----------------------------------------------
-    soc = BaseSoC(wr_cpu_memory=args.wr_cpu_memory)
+    soc = BaseSoC(
+        wr_cpu_type    = args.wr_cpu_type,
+        wr_cpu_variant = args.wr_cpu_variant,
+        wr_cpu_memory  = args.wr_cpu_memory,
+    )
     if args.with_wishbone_fabric_interface_probe:
         soc.add_wishbone_fabric_interface_probe()
     if args.with_wishbone_slave_probe:
@@ -742,7 +767,8 @@ def main():
     if args.flash:
         bitstream = builder.get_bitstream_filename(mode="flash")
         sdb_image = "litex_wr_nic/firmware/sdb-wrpc.bin"
-        boot_image = "litex_wr_nic/firmware/spec_a7_wrc.boot" if args.wr_cpu_memory == "hyperram" else None
+        boot_image = os.path.join("litex_wr_nic", "firmware",
+            wr_cpu_firmware_filename(args.wr_cpu_type, "boot")) if args.wr_cpu_memory == "hyperram" else None
         validate_flash_layout(bitstream, sdb_image, boot_image)
         prog = soc.platform.create_programmer()
         prog.flash(0x0000_0000, bitstream)

--- a/test/test_wr_cpu_resources.py
+++ b/test/test_wr_cpu_resources.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from tools.compare_wr_cpu_resources import parse_timing, parse_utilization
+from tools.compare_wr_cpu_types import parse_intra_clock_wns
 
 # Resource Report Tests ----------------------------------------------------------------------------
 
@@ -40,3 +41,14 @@ WNS(ns) TNS(ns) TNS Failing Endpoints TNS Total Endpoints WHS(ns) THS(ns) THS Fa
     assert values["wns_ns"] == 0.125
     assert values["setup_failing_endpoints"] == 0
     assert values["whs_ns"] == 0.050
+
+
+def test_parse_wr_cpu_clock_timing(tmp_path):
+    report = tmp_path / "timing.rpt"
+    report.write_text("""
+| Intra Clock Table
+clk_sys 5.125 0.000 0 100 0.050 0.000 0 100
+| Inter Clock Table
+clk_sys other_clock -0.250 -1.000 4 100 0.050 0.000 0 100
+""", encoding="utf-8")
+    assert parse_intra_clock_wns(report, "clk_sys") == 5.125

--- a/test/test_wr_litex_cpu.py
+++ b/test/test_wr_litex_cpu.py
@@ -1,0 +1,196 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import pytest
+
+from migen.sim import run_simulation
+
+from litex.soc.interconnect import wishbone
+
+from litex_wr_nic.gateware.wr_cpu import (
+    WRCPUInterconnect,
+    WRCPUPeripheralBridge,
+    resolve_wr_cpu_variant,
+    validate_wr_cpu_config,
+    wr_cpu_firmware_filename,
+)
+
+# Helpers ------------------------------------------------------------------------------------------
+
+def _make_interconnect():
+    ibus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+    dbus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+    return WRCPUInterconnect(ibus, dbus), ibus, dbus
+
+# LiteX WR CPU Tests -------------------------------------------------------------------------------
+
+def test_wr_cpu_configuration_validation():
+    assert resolve_wr_cpu_variant("urv") is None
+    assert resolve_wr_cpu_variant("vexriscv") == "lite"
+    assert validate_wr_cpu_config("vexriscv", "lite", "integrated") == "lite"
+    assert validate_wr_cpu_config("vexriscv", "lite", "hyperram") == "lite"
+    assert wr_cpu_firmware_filename("urv", "bin") == "spec_a7_wrc.bin"
+    assert wr_cpu_firmware_filename("vexriscv", "boot") == "spec_a7_wrc_vexriscv.boot"
+
+    with pytest.raises(ValueError, match="requires integrated or HyperRAM"):
+        validate_wr_cpu_config("vexriscv", memory="private")
+    with pytest.raises(ValueError, match="does not accept"):
+        resolve_wr_cpu_variant("urv", "lite")
+    with pytest.raises(ValueError, match="Unsupported vexriscv"):
+        resolve_wr_cpu_variant("vexriscv", "standard")
+    with pytest.raises(ValueError, match="Unsupported WR CPU type"):
+        resolve_wr_cpu_variant("serv")
+
+
+@pytest.mark.parametrize("byte_address", [0x0000_0000, 0x000f_fffc])
+def test_data_low_memory_routing(byte_address):
+    dut, _, dbus = _make_interconnect()
+
+    def generator():
+        yield dbus.adr.eq(byte_address // 4)
+        yield dbus.cyc.eq(1)
+        yield dbus.stb.eq(1)
+        yield dbus.sel.eq(0b1010)
+        yield dbus.we.eq(1)
+        yield dbus.dat_w.eq(0x1234_5678)
+        yield
+        assert (yield dut.memory_bus.cyc) == 1
+        assert (yield dut.peripheral_bus.cyc) == 0
+        assert (yield dut.memory_bus.adr) == byte_address // 4
+        assert (yield dut.memory_bus.sel) == 0b1010
+        assert (yield dut.memory_bus.dat_w) == 0x1234_5678
+        yield dut.memory_bus.ack.eq(1)
+        yield
+        assert (yield dbus.ack) == 1
+
+    run_simulation(dut, generator())
+
+
+@pytest.mark.parametrize("byte_address", [0x0010_0000, 0xffff_fffc])
+def test_data_peripheral_routing(byte_address):
+    dut, _, dbus = _make_interconnect()
+
+    def generator():
+        yield dbus.adr.eq(byte_address // 4)
+        yield dbus.cyc.eq(1)
+        yield dbus.stb.eq(1)
+        yield
+        assert (yield dut.memory_bus.cyc) == 0
+        assert (yield dut.peripheral_bus.cyc) == 1
+        assert (yield dut.peripheral_bus.adr) == byte_address // 4
+        yield dut.peripheral_bus.err.eq(1)
+        yield
+        assert (yield dbus.err) == 1
+
+    run_simulation(dut, generator())
+
+
+def test_instruction_bus_always_uses_memory():
+    dut, ibus, _ = _make_interconnect()
+
+    def generator():
+        yield ibus.adr.eq(0x0010_0000 // 4)
+        yield ibus.cyc.eq(1)
+        yield ibus.stb.eq(1)
+        # Allow the round-robin arbiter to select its only requester.
+        yield
+        yield
+        assert (yield dut.memory_bus.cyc) == 1
+        assert (yield dut.peripheral_bus.cyc) == 0
+        yield dut.memory_bus.dat_r.eq(0x0000_0013)
+        yield dut.memory_bus.ack.eq(1)
+        yield
+        assert (yield ibus.ack) == 1
+        assert (yield ibus.dat_r) == 0x0000_0013
+
+    run_simulation(dut, generator())
+
+
+def test_data_request_has_initial_arbitration_priority():
+    dut, ibus, dbus = _make_interconnect()
+
+    def generator():
+        yield ibus.adr.eq(4)
+        yield ibus.cyc.eq(1)
+        yield ibus.stb.eq(1)
+        yield dbus.adr.eq(8)
+        yield dbus.cyc.eq(1)
+        yield dbus.stb.eq(1)
+        yield
+        assert (yield dut.memory_bus.adr) == 8
+        yield dut.memory_bus.ack.eq(1)
+        yield
+        assert (yield dbus.ack) == 1
+        assert (yield ibus.ack) == 0
+
+    run_simulation(dut, generator())
+
+
+def test_peripheral_bridge_honors_stall_and_completes_error():
+    bus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+    dut = WRCPUPeripheralBridge(bus)
+
+    def generator():
+        yield dut.stall.eq(1)
+        yield bus.cyc.eq(1)
+        yield bus.stb.eq(1)
+        yield bus.we.eq(1)
+        yield bus.adr.eq(0x0010_0020 // 4)
+        yield bus.sel.eq(0b0101)
+        yield bus.dat_w.eq(0x89ab_cdef)
+        yield
+        yield
+        assert (yield dut.cyc) == 1
+        assert (yield dut.stb) == 1
+        assert (yield dut.adr) == 0x0010_0020 // 4
+        assert (yield dut.sel) == 0b0101
+        assert (yield dut.dat_w) == 0x89ab_cdef
+
+        # Keep STB asserted until the pipelined WR bus accepts the request.
+        yield
+        assert (yield dut.stb) == 1
+        yield dut.stall.eq(0)
+        yield
+        yield
+        assert (yield dut.cyc) == 1
+        assert (yield dut.stb) == 0
+
+        # LiteX VexRiscv ignores ERR, so an error is returned with ACK too.
+        yield dut.dat_r.eq(0xdead_beef)
+        yield dut.err.eq(1)
+        yield
+        yield
+        assert (yield bus.ack) == 1
+        assert (yield bus.err) == 1
+        assert (yield bus.dat_r) == 0
+        yield dut.err.eq(0)
+        yield
+        assert (yield bus.ack) == 0
+
+        # The CPU holds its classic request through ACK. Do not launch a
+        # duplicate WR transaction until it releases CYC/STB.
+        yield
+        assert (yield dut.cyc) == 0
+        yield bus.cyc.eq(0)
+        yield bus.stb.eq(0)
+        yield
+
+        # A later successful access returns the WR response data.
+        yield bus.cyc.eq(1)
+        yield bus.stb.eq(1)
+        yield bus.we.eq(0)
+        yield bus.adr.eq(0x0010_0040 // 4)
+        yield
+        yield
+        yield dut.dat_r.eq(0x1234_5678)
+        yield dut.ack.eq(1)
+        yield
+        yield
+        assert (yield bus.ack) == 1
+        assert (yield bus.err) == 0
+        assert (yield bus.dat_r) == 0x1234_5678
+
+    run_simulation(dut, generator())

--- a/test/test_wr_litex_cpu_clock.py
+++ b/test/test_wr_litex_cpu_clock.py
@@ -1,0 +1,79 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""The LiteX CPU adapter must run entirely in the WR system domain."""
+
+from types import SimpleNamespace
+
+from migen import ClockDomain, Signal, run_simulation
+
+from litex.gen import LiteXModule
+
+from litex.soc.interconnect import wishbone
+from litex.soc.cores import cpu as litex_cpu
+
+from litex_wr_nic.gateware.wr_cpu import WRLiteXCPU
+
+# LiteX WR CPU Clock Test --------------------------------------------------------------------------
+
+def test_litex_cpu_adapter_without_phy_clock(monkeypatch):
+    class ModelCPU(LiteXModule):
+        family     = "riscv"
+        data_width = 32
+        endianness = "little"
+
+        def __init__(self, platform, variant):
+            self.ibus      = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+            self.dbus      = wishbone.Interface.like(self.ibus)
+            self.interrupt = Signal(32)
+            self.reset     = Signal()
+            self.heartbeat = Signal(16)
+            self.sync += self.heartbeat.eq(self.heartbeat + 1)
+
+        def set_reset_address(self, address):
+            assert address == 0
+
+    monkeypatch.setitem(litex_cpu.CPUS, "vexriscv", ModelCPU)
+    dut           = LiteXModule()
+    dut.cd_wr_sys = ClockDomain("wr_sys")
+    dut.cd_wr     = ClockDomain("wr")
+    dut.cd_sys    = ClockDomain("sys")
+    dut.adapter   = adapter = WRLiteXCPU(SimpleNamespace(), "vexriscv")
+
+    memory     = adapter.memory_bus
+    peripheral = adapter.peripheral_bridge
+    dut.comb += [
+        memory.ack.eq(memory.cyc & memory.stb),
+        memory.dat_r.eq(0x12345678),
+        peripheral.ack.eq(peripheral.cyc & peripheral.stb),
+        peripheral.dat_r.eq(0xabcdef01),
+    ]
+
+    def access(bus, address, expected):
+        yield bus.adr.eq(address // 4)
+        yield bus.cyc.eq(1)
+        yield bus.stb.eq(1)
+        for _ in range(30):
+            yield
+            if (yield bus.ack):
+                assert (yield bus.dat_r) == expected
+                break
+        else:
+            raise AssertionError(f"CPU access at {address:#x} needs a non-WR-system clock")
+        yield bus.cyc.eq(0)
+        yield bus.stb.eq(0)
+        for _ in range(5):
+            yield
+
+    def cpu():
+        # The initial arbiter grant is data; an instruction fetch forces it
+        # to switch, then the data access forces it back again.
+        yield from access(adapter.core.ibus, 0, 0x12345678)
+        yield from access(adapter.core.dbus, 0x1000, 0x12345678)
+        yield from access(adapter.core.dbus, 0x100020, 0xabcdef01)
+        assert (yield adapter.core.heartbeat) > 0
+
+    run_simulation(dut, {"wr_sys": cpu()}, clocks={"wr_sys": 16})

--- a/tools/build_wr_cpu_type_matrix.py
+++ b/tools/build_wr_cpu_type_matrix.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Build the reproducible SPEC-A7 uRV/VexRiscv WR CPU matrix."""
+
+import sys
+import time
+import argparse
+import subprocess
+from pathlib import Path
+
+# Constants ----------------------------------------------------------------------------------------
+
+CONFIGS = {
+    "urv-integrated"           :             ("urv",       None,   "integrated"),
+    "vexriscv-lite-integrated" :   ("vexriscv", "lite", "integrated"),
+    "urv-hyperram"             :               ("urv",       None,   "hyperram"),
+    "vexriscv-lite-hyperram"   :     ("vexriscv", "lite", "hyperram"),
+}
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Main ---------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", default="build/wr_cpu_types")
+    parser.add_argument("--skip-firmware-build", action="store_true")
+    parser.add_argument("--configs", nargs="+", choices=CONFIGS, default=tuple(CONFIGS),
+        help="Build only selected configurations; comparison still requires all reports.")
+    args = parser.parse_args()
+
+    if not args.skip_firmware_build:
+        for cpu_type in ("urv", "vexriscv"):
+            subprocess.run([
+                sys.executable, str(REPO_ROOT / "litex_wr_nic/firmware/build.py"),
+                "--target", "spec_a7", "--wr-cpu-type", cpu_type,
+            ], check=True, cwd=REPO_ROOT)
+
+    root = Path(args.output_root).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    for name in args.configs:
+        cpu_type, variant, memory = CONFIGS[name]
+        output_dir                = root / name
+        log_path                  = root / f"{name}.log"
+        command = [
+            sys.executable, str(REPO_ROOT / "spec_a7_wr_nic.py"),
+            "--build", "--skip-firmware-build", "--skip-software-headers",
+            "--wr-cpu-type", cpu_type,
+            "--wr-cpu-memory", memory,
+            "--output-dir", str(output_dir),
+        ]
+        if variant is not None:
+            command += ["--wr-cpu-variant", variant]
+        print(f"Building {name} -> {output_dir}", flush=True)
+        started = time.monotonic()
+        with log_path.open("w", encoding="utf-8") as log:
+            subprocess.run(command,
+                check  = True,
+                cwd    = REPO_ROOT,
+                stdout = log,
+                stderr = subprocess.STDOUT,
+            )
+        duration = time.monotonic() - started
+        (root / f"{name}.seconds").write_text(f"{duration:.3f}\n", encoding="utf-8")
+        print(f"Completed {name} in {duration:.1f}s (log: {log_path})", flush=True)
+
+    subprocess.run([
+        sys.executable, str(REPO_ROOT / "tools/compare_wr_cpu_types.py"), str(root),
+        "--firmware-dir", str(REPO_ROOT / "litex_wr_nic/firmware"),
+    ], check=True, cwd=REPO_ROOT)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_wr_cpu_types.py
+++ b/tools/compare_wr_cpu_types.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Compare placed SPEC-A7 utilization for uRV and LiteX WR CPUs."""
+
+import csv
+import json
+import hashlib
+import argparse
+import subprocess
+from pathlib import Path
+
+from tools.compare_wr_cpu_resources import _delta, collect_mode, parse_hierarchy
+
+# Constants ----------------------------------------------------------------------------------------
+
+CONFIGS = (
+    "urv-integrated",
+    "vexriscv-lite-integrated",
+    "urv-hyperram",
+    "vexriscv-lite-hyperram",
+)
+PAIRS = {
+    "integrated" : ("urv-integrated", "vexriscv-lite-integrated"),
+    "hyperram"   :   ("urv-hyperram",   "vexriscv-lite-hyperram"),
+}
+DELTA_KEYS = (
+    "slice_luts", "logic_luts", "lut_memory", "ffs", "ramb36", "ramb18",
+    "bram18_equivalent", "dsps", "bit_bytes",
+)
+
+# Helpers ------------------------------------------------------------------------------------------
+
+def _sha256(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def parse_intra_clock_wns(path, clock):
+    """Return a clock's intra-domain WNS from a Vivado timing summary."""
+    in_table = False
+    for line in Path(path).read_text(encoding="utf-8", errors="replace").splitlines():
+        if "| Intra Clock Table" in line:
+            in_table = True
+            continue
+        if in_table and "| Inter Clock Table" in line:
+            break
+        fields = line.split()
+        if in_table and fields and fields[0] == clock:
+            return float(fields[1])
+    raise ValueError(f"could not find intra-clock timing for {clock} in {path}")
+
+# Comparison ---------------------------------------------------------------------------------------
+
+def make_comparison(root, firmware_dir=None):
+    root    = Path(root)
+    configs = {}
+    for name in CONFIGS:
+        build_dir = root / name
+        values    = collect_mode(build_dir)
+        values["wr_clk_wns_ns"] = parse_intra_clock_wns(
+            build_dir / values["reports"]["timing"], "clk_sys")
+        values["hierarchy"] = parse_hierarchy(
+            build_dir / values["reports"]["hierarchy"], (
+                r"U_CPU_PRIVATE", r"U_CPU_EXTERNAL", r"VexRiscv",
+                r"wrc_external_cpu_control", r"wr_cpu", r"hyperram",
+                r"cache", r"boot",
+            ))
+        configs[name] = values
+    reference = configs[CONFIGS[0]]
+    for name, values in configs.items():
+        if values["device"] != reference["device"]:
+            raise ValueError(f"{name} used {values['device']}, expected {reference['device']}")
+        if values["tool_version"] != reference["tool_version"]:
+            raise ValueError(
+                f"{name} used {values['tool_version']}, expected {reference['tool_version']}")
+
+    deltas = {}
+    for memory, (urv_name, vex_name) in PAIRS.items():
+        urv            = configs[urv_name]
+        vex            = configs[vex_name]
+        deltas[memory] = {key: _delta(vex[key], urv[key]) for key in DELTA_KEYS}
+        deltas[memory].update({
+            "wns_ns"        :        vex["wns_ns"] - urv["wns_ns"],
+            "whs_ns"        :        vex["whs_ns"] - urv["whs_ns"],
+            "wr_clk_wns_ns" : vex["wr_clk_wns_ns"] - urv["wr_clk_wns_ns"],
+        })
+
+    try:
+        git_sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True,
+            stderr=subprocess.DEVNULL).strip()
+        git_dirty = bool(subprocess.check_output(
+            ["git", "status", "--porcelain"], text=True,
+            stderr=subprocess.DEVNULL).strip())
+    except (OSError, subprocess.CalledProcessError):
+        git_sha   = "unknown"
+        git_dirty = None
+
+    firmware_hashes = {}
+    if firmware_dir is not None:
+        firmware_dir = Path(firmware_dir)
+        for cpu_type, filename in (
+            ("urv", "spec_a7_wrc.bin"),
+            ("vexriscv-lite", "spec_a7_wrc_vexriscv.bin"),
+        ):
+            firmware_hashes[cpu_type] = _sha256(firmware_dir / filename)
+
+    return {
+        "metadata": {
+            "git_sha"         : git_sha,
+            "git_dirty"       : git_dirty,
+            "target"          : "spec_a7_wr_nic",
+            "device"          : reference["device"],
+            "tool_version"    : reference["tool_version"],
+            "firmware_sha256" : firmware_hashes,
+            "wr_cpu_clk_hz"   : 62_500_000,
+            "directives"      : {
+                "place"               : "Explore",
+                "route"               : "Explore",
+                "post_route_phys_opt" : "Explore",
+            },
+        },
+        "configs"               : configs,
+        "vexriscv_delta_vs_urv" : deltas,
+    }
+
+# Report Output ------------------------------------------------------------------------------------
+
+def _format_delta(delta):
+    text = f"{delta['absolute']:+g}"
+    if delta["percent"] is not None:
+        text += f" ({delta['percent']:+.1f}%)"
+    return text
+
+
+def write_markdown(comparison, path):
+    memory_labels = {"integrated": "Integrated", "hyperram": "HyperRAM"}
+    metrics = (
+        ("Slice LUTs", "slice_luts"),
+        ("Logic LUTs", "logic_luts"),
+        ("LUT memory", "lut_memory"),
+        ("Flip-flops", "ffs"),
+        ("RAMB36", "ramb36"),
+        ("RAMB18", "ramb18"),
+        ("BRAM18 equivalents", "bram18_equivalent"),
+        ("DSPs", "dsps"),
+        ("Bitstream bytes", "bit_bytes"),
+        ("WR clock WNS (ns)", "wr_clk_wns_ns"),
+        ("WNS (ns)", "wns_ns"),
+        ("WHS (ns)", "whs_ns"),
+        ("Build time (s)", "build_seconds"),
+    )
+    meta = comparison["metadata"]
+    lines = [
+        "# WR CPU Type Resource Comparison", "",
+        f"- Target: `{meta['target']}` / `{meta['device']}`",
+        f"- Tool: `{meta['tool_version']}`",
+        f"- Git: `{meta['git_sha']}`{' (dirty)' if meta['git_dirty'] else ''}",
+        f"- CPU clock: `{meta['wr_cpu_clk_hz']/1e6:g} MHz`", "",
+    ]
+    for memory, (urv_name, vex_name) in PAIRS.items():
+        urv   = comparison["configs"][urv_name]
+        vex   = comparison["configs"][vex_name]
+        delta = comparison["vexriscv_delta_vs_urv"][memory]
+        lines += [
+            f"## {memory_labels[memory]} memory", "",
+            "| Metric | uRV | VexRiscv lite | VexRiscv Δ |",
+            "|---|---:|---:|---:|",
+        ]
+        for label, key in metrics:
+            if key in DELTA_KEYS:
+                delta_text = _format_delta(delta[key])
+            elif key in ("wns_ns", "whs_ns", "wr_clk_wns_ns"):
+                delta_text = f"{delta[key]:+.3f}"
+            elif urv[key] is not None and vex[key] is not None:
+                delta_text = f"{vex[key] - urv[key]:+.3f}"
+            else:
+                delta_text = "n/a"
+            lines.append(f"| {label} | {urv[key]} | {vex[key]} | {delta_text} |")
+        lines += [
+            "",
+            f"Resource result: VexRiscv changes Slice LUTs by "
+            f"{_format_delta(delta['slice_luts'])}, DSPs by "
+            f"{_format_delta(delta['dsps'])}, and BRAM18 equivalents by "
+            f"{_format_delta(delta['bram18_equivalent'])}.", "",
+            f"Timing: uRV {'MET' if urv['wns_ns'] >= 0 else 'VIOLATED'} "
+            f"({urv['wns_ns']:+.3f} ns WNS), VexRiscv "
+            f"{'MET' if vex['wns_ns'] >= 0 else 'VIOLATED'} "
+            f"({vex['wns_ns']:+.3f} ns WNS).", "",
+            f"WR-clock timing: uRV {'MET' if urv['wr_clk_wns_ns'] >= 0 else 'VIOLATED'} "
+            f"({urv['wr_clk_wns_ns']:+.3f} ns WNS), VexRiscv "
+            f"{'MET' if vex['wr_clk_wns_ns'] >= 0 else 'VIOLATED'} "
+            f"({vex['wr_clk_wns_ns']:+.3f} ns WNS).", "",
+        ]
+    lines += [
+        "All utilization figures are from placed designs; timing is from the final timing report.", "",
+    ]
+    Path(path).write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_csv(comparison, path):
+    keys = (
+        "slice_luts", "logic_luts", "lut_memory", "ffs", "ramb36", "ramb18",
+        "bram18_equivalent", "dsps", "wns_ns", "tns_ns", "whs_ns", "ths_ns",
+        "wr_clk_wns_ns", "bit_bytes", "build_seconds",
+    )
+    with Path(path).open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=("config",) + keys, lineterminator="\n")
+        writer.writeheader()
+        for name in CONFIGS:
+            writer.writerow({
+                "config": name,
+                **{key: comparison["configs"][name].get(key) for key in keys},
+            })
+
+# Main ---------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", help="Directory containing the four build directories.")
+    parser.add_argument("--firmware-dir")
+    parser.add_argument("--markdown", default="doc/wr_cpu_type_resource_comparison.md")
+    parser.add_argument("--json", default="doc/wr_cpu_type_resource_comparison.json")
+    parser.add_argument("--csv", default="doc/wr_cpu_type_resource_comparison.csv")
+    args = parser.parse_args()
+
+    comparison = make_comparison(args.root, firmware_dir=args.firmware_dir)
+    for path in (args.markdown, args.json, args.csv):
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+    write_markdown(comparison, args.markdown)
+    Path(args.json).write_text(json.dumps(comparison, indent=2) + "\n", encoding="utf-8")
+    write_csv(comparison, args.csv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a LiteX-managed VexRiscv `lite` CPU option for WRPC, executing from integrated SoC RAM or SPI-loaded HyperRAM. Both configurations now boot and provide a working WR console on physical SPEC-A7 hardware. Existing defaults remain uRV/private RAM.

This PR includes and depends on #67, which provides the CPU-memory and HyperRAM boot infrastructure. Merge #67 first.

## Architecture and firmware

- Run the VexRiscv core, instruction/data arbiter, and peripheral bridge in the 62.5 MHz WR system domain, `wr_sys`, independently of the resettable PHY reference clock.
- Route instruction fetches and data below `0x00100000` to CPU memory; route higher data addresses to WR peripherals.
- Adapt classic Wishbone to the WR pipelined peripheral bus, handling STALL and terminal ACK/ERR/RTY responses.
- Preserve WR interrupts, software reset and host CPU-control CSRs. The uRV-specific debug/upload fields are inert with an external CPU.
- Validate the 32-bit, little-endian RISC-V interface. VexRiscv currently supports only `lite` with `integrated` or `hyperram` memory; private WR-core RAM is uRV-only.
- Add a VexRiscv firmware profile that initializes `mtvec` and enables LiteX external interrupt line 0 through CSR `0xbc0`. Keep separate `spec_a7_wrc_vexriscv.{bin,bram,boot}` artifacts.
- Add `--wr-cpu-type` and `--wr-cpu-variant` options to SPEC-A7, Acorn and HyVision.

```console
./spec_a7_wr_nic.py --build --wr-cpu-type vexriscv --wr-cpu-variant lite --wr-cpu-memory integrated
./spec_a7_wr_nic.py --build --wr-cpu-type vexriscv --wr-cpu-variant lite --wr-cpu-memory hyperram
```

Qualification incorporates #67's fixes for clock crossings, pending uRV requests, RAM-address remapping, STARTUPE2 handoff, flash-loader handshakes/completion, and final routing. This PR additionally fixes the VexRiscv core, arbiter and peripheral bridge clock connections; a regression exercises them with only `wr_sys` running.

## SPEC-A7 hardware qualification

All five configurations were built and tested separately from #67, on 8 September 2026, at revision `dedf4060f319c2f8c5da613d3a0128ac79e9b0ed`.

| CPU | Memory | FPGA reloads | CPU reset after soak | WNS / WHS (ns) |
| --- | --- | --- | --- | --- |
| uRV | Private | 3/3 pass | Pass | -0.041 / +0.028 |
| uRV | Integrated | 3/3 pass | Pass | +0.036 / +0.028 |
| uRV | HyperRAM | 3/3 pass | Pass | -0.124 / +0.028 |
| VexRiscv-lite | Integrated | 3/3 pass | Pass | -0.008 / +0.008 |
| VexRiscv-lite | HyperRAM | 3/3 pass | Pass | -0.015 / +0.028 |

Every reload produced a fresh WR startup banner, responsive `help`, `ver`, `time` and `uptime`, GUI entry/exit, and advancing uptime over 120 seconds without spontaneous restart. CPU-only reset after the soak restarted firmware and restored the console. External-memory error counters stayed zero.

Both HyperRAM profiles reported done+ready, error zero, all 131072 payload bytes loaded, and matching firmware CRCs on every reload: uRV `979689564`; VexRiscv `1490600599`. Matching per-CPU boot images were programmed for each test.

## Regression validation and build environment

- Cleaned history: implementation and regressions in `4585185`, followed by documentation and resource-comparison tooling in `4011dc5`. The final Git tree is identical to pre-cleanup `41d69c1`; hardware build hashes above retain their original provenance.
- LiteX style review completed through `41d69c1`: grouped imports, aligned declarations and argument tables, section separators, and clearer gateware/test formatting. Python syntax trees match the qualified revision after canonicalizing import groups; VHDL tokens are unchanged. The full suite was rerun: **36 passed, no skips**. The hardware results above refer to the original archived bitstreams; no new FPGA build was needed for this source-only cleanup.
- Full isolated suite: **36 tests passed**, covering CPU/memory selection, routing/arbitration, peripheral STALL and error completion, duplicate prevention, WR-system clock operation, and the inherited CPU-memory/boot regressions.
- Both firmware profiles build; VexRiscv disassembly contains the required `mtvec` and CSR `0xbc0` initialization.
- Vivado/XSim 2024.1; pinned WR cores `c3f8288`, WRPC `baf77496`, and LiteEth `5de3d0f`. All five full builds generated bitstreams.
- Build commands, firmware/bitstream/CSR hashes, UART transcripts, JTAG diagnostics and timing reports were retained in the qualification archive.
- The original flash was restored and all 16 MiB verified against the pre-test backup. The board was left running validated uRV/private gateware in SRAM.

Earlier matched resource comparisons and tooling remain in `doc/wr_cpu_type_resource_comparison.{md,json,csv}` and `tools/build_wr_cpu_type_matrix.py`; the table above records the hardware-qualified build timing.

## Scope and remaining limitations

This passes the CPU-execution/WR-console acceptance criterion. Full timing closure is not established; small setup violations remain, including on the main reference. No SFP was connected, so Ethernet/PTP/PPS/PTM behavior was not qualified. Acorn and HyVision were not hardware-tested in this session.

An additional direct CPU-only reset at about 17 seconds uptime intermittently hung uRV/private. The same failure and debug state reproduced on **unmodified main**, and reducing JTAG speed did not resolve it. FPGA reload consistently restored execution. A controlled sequence—halt uRV and wait for debug acknowledgment, assert reset, clear debug force while reset is held, then release reset—passed **five consecutive checks**. This is a tested workaround; the underlying pre-existing direct-reset issue remains unresolved.
