### PR TITLE
wr: check out the pinned wr-cores commit on a fresh clone

### DIFF
--- a/litex_wr_nic/gateware/wr_common.py
+++ b/litex_wr_nic/gateware/wr_common.py
@@ -21,14 +21,14 @@ WR_CLOCK_MONITOR_VHD = "wr-cores/ip_cores/general-cores/modules/wishbone/wb_cloc
 
 def wr_core_init():
     print("Cloning wr-cores repository...")
-    subprocess.run(["git", "clone", WR_CORES_URL])
+    subprocess.run(["git", "clone", WR_CORES_URL], check=True)
     os.chdir("wr-cores")
     print("Checking out the specified commit...")
-    subprocess.run(["git", "checkout", WR_CORES_SHA1, "-b", WR_CORES_BRANCH])
+    subprocess.run(["git", "checkout", "-B", WR_CORES_BRANCH, WR_CORES_SHA1], check=True)
     print("Fixing submodules URL...")
     tools.replace_in_file(".gitmodules", "ohwr.org", "gitlab.com/ohwr")
     print("Updating submodules...")
-    subprocess.run(["git", "submodule", "update", "--init"])
+    subprocess.run(["git", "submodule", "update", "--init"], check=True)
     print("wr-cores initialization complete.")
     os.chdir("..")
 


### PR DESCRIPTION
## Problem

`wr_core_init()` clones `wr-cores` and then runs:

```python
subprocess.run(["git", "checkout", WR_CORES_SHA1, "-b", WR_CORES_BRANCH])
```

On a fresh clone `master` is already checked out, so creating it again fails with
`fatal: a branch named 'master' already exists`. The return code isn't checked, so this is
silent: the pinned commit is never checked out and the build continues on upstream
`wr-cores` HEAD.

That HEAD has since moved the `general-cores` submodule, so
`ip_cores/general-cores/.../xwb_clock_monitor.vhd` no longer exists and the build later dies
with a `FileNotFoundError` pointing nowhere near the real cause.

This currently breaks CI in `enjoy-digital/litex_m2sdr`, whose White Rabbit smoke tests clone
`wr-cores` fresh on every run.

## Fix

`-B` instead of `-b` (resets the branch onto the pinned commit), plus `check=True` on the git
calls so a future failure surfaces where it happens. The pinned commit has no `wrpc-sw`
submodule, so checking the submodule call adds no new failure mode.

## Verification

From a clean state (`rm -rf wr-cores`): the clone now lands on `c3f8288` instead of upstream
HEAD, submodules initialise, firmware builds, SoC elaborates. All five of litex_m2sdr's White
Rabbit smoke tests pass, including the two that deliberately reject a bad `wr-cores` tree.