### PR TITLE
wr: avoid CPU reboot loop on PHY reset

### DIFF
--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
@@ -260,7 +260,6 @@ architecture struct of xwrc_board_litex_wr_nic is
   -- PLLs, clocks
   signal clk_pll_62m5   : std_logic;
   signal clk_ref_62m5   : std_logic;
-  signal clk_ref_locked : std_logic;
   signal pll_locked     : std_logic;
   signal clk_10m_ext    : std_logic;
 
@@ -329,7 +328,7 @@ begin  -- architecture struct
       sfp_tx_disable_o      => sfp_tx_disable_o,
       clk_62m5_sys_o        => clk_pll_62m5,
       clk_125m_ref_o        => clk_ref_62m5,  -- Note: This is a 62m5 Clock for 16 bit PHYs!
-      clk_ref_locked_o      => clk_ref_locked,
+      clk_ref_locked_o      => open,
       clk_62m5_dmtd_o       => clk_dmtd,
       pll_locked_o          => pll_locked,
       clk_10m_ext_o         => clk_10m_ext,
@@ -364,8 +363,10 @@ begin  -- architecture struct
       data_i   => areset_edge_n_i,
       ppulse_o => areset_edge_ppulse);
 
-  -- logic AND of all async reset sources (active low)
-  rstlogic_arst_n <= pll_locked and clk_ref_locked and areset_n_i and (not areset_edge_ppulse);
+  -- Keep the WR core reset independent of the transceiver PLL lock: firmware
+  -- resets the PHY during endpoint initialization, which drops that lock.
+  -- Including it here would reset the CPU and repeat initialization forever.
+  rstlogic_arst_n <= pll_locked and areset_n_i and (not areset_edge_ppulse);
 
   -- concatenation of all clocks required to have synced resets
   rstlogic_clk_in(0) <= clk_pll_62m5;

--- a/test/test_wr_reset.py
+++ b/test/test_wr_reset.py
@@ -1,0 +1,120 @@
+"""Simulate the board reset circuit with GHDL and the pinned wr-cores checkout."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOARD = ROOT / "litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd"
+COMMON = ROOT / "wr-cores/ip_cores/general-cores/modules/common"
+
+
+def test_wr_reset_survives_phy_pll_unlock(tmp_path):
+    if shutil.which("ghdl") is None:
+        pytest.skip("GHDL is required for the WR reset simulation")
+    if not (COMMON / "gc_reset.vhd").is_file():
+        pytest.skip("Initialize the pinned wr-cores checkout before running this simulation")
+
+    # Exercise the actual board reset circuit without simulating the CPU or
+    # vendor transceiver primitives. Model their independent clocks/lock inputs.
+    board = BOARD.read_text()
+    start = board.index("  cmp_arst_edge:")
+    end = board.index("  rst_62m5_n <= rstlogic_rst_out(0);")
+    reset_logic = board[start:end] + "  rst_62m5_n <= rstlogic_rst_out(0);\n"
+    testbench = tmp_path / "wr_reset_tb.vhd"
+    testbench.write_text("""
+library ieee;
+use ieee.std_logic_1164.all;
+use work.gencores_pkg.all;
+
+entity wr_reset_tb is end;
+
+architecture test of wr_reset_tb is
+  signal clk_pll_62m5, clk_ref_62m5, clk_62m5_dmtd_i : std_logic := '0';
+  signal pll_locked, clk_ref_locked, areset_n_i : std_logic := '0';
+  signal areset_edge_n_i : std_logic := '0';
+  signal areset_edge_ppulse, rstlogic_arst_n, rst_62m5_n : std_logic;
+  signal rstlogic_clk_in, rstlogic_rst_out : std_logic_vector(1 downto 0);
+begin
+  clk_pll_62m5 <= not clk_pll_62m5 after 8 ns;
+  clk_62m5_dmtd_i <= not clk_62m5_dmtd_i after 8.1 ns;
+  clk_ref_62m5 <= not clk_ref_62m5 after 8 ns when clk_ref_locked = '1' else '0';
+""" + reset_logic + """
+  stimulus : process
+    procedure expect_reset(value : std_logic; cycles : positive) is
+    begin
+      for i in 1 to cycles loop
+        wait until falling_edge(clk_pll_62m5);
+        assert rst_62m5_n = value
+          report "Unexpected WR CPU reset state" severity failure;
+      end loop;
+    end procedure;
+  begin
+    -- Power-on reset must wait for the system PLL and external reset release.
+    expect_reset('0', 32);
+    clk_ref_locked <= '1';
+    areset_n_i <= '1';
+    expect_reset('0', 32);
+    pll_locked <= '1';
+    wait for 1 us;
+    expect_reset('1', 32);
+
+    -- Firmware resets the PHY during endpoint initialization. This drops the
+    -- transceiver PLL lock and can stop its TX clock, but must not reboot WR.
+    for attempt in 1 to 3 loop
+      clk_ref_locked <= '0';
+      expect_reset('1', 128);
+      clk_ref_locked <= '1';
+      expect_reset('1', 128);
+    end loop;
+
+    -- Loss of system PLL lock must still reset WR, even with the PHY stopped.
+    clk_ref_locked <= '0';
+    pll_locked <= '0';
+    wait for 1 us;
+    expect_reset('0', 32);
+    pll_locked <= '1';
+    wait for 1 us;
+    expect_reset('1', 32);
+
+    -- Explicit board reset remains effective.
+    areset_n_i <= '0';
+    wait for 1 us;
+    expect_reset('0', 32);
+    areset_n_i <= '1';
+    wait for 1 us;
+    expect_reset('1', 32);
+
+    -- PCIe reset being held low must allow standalone operation. Its rising
+    -- edge must still generate a reset pulse, followed by normal operation.
+    areset_edge_n_i <= '1';
+    wait until rst_62m5_n = '0' for 1 us;
+    assert rst_62m5_n = '0' report "Missing PCIe reset pulse" severity failure;
+    wait for 1 us;
+    expect_reset('1', 32);
+    areset_edge_n_i <= '0';
+    expect_reset('1', 64);
+
+    report "WR reset checks passed";
+    std.env.stop;
+    wait;
+  end process;
+end;
+""")
+
+    def run(*args):
+        result = subprocess.run(
+            ["ghdl", args[0], "--std=08", "-frelaxed-rules", *args[1:]],
+            cwd=tmp_path, capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stdout + result.stderr
+        return result.stdout
+
+    run("-a", *[str(COMMON / name) for name in (
+        "gencores_pkg.vhd", "gc_sync.vhd", "gc_edge_detect.vhd",
+        "gc_sync_ffs.vhd", "gc_reset.vhd")], str(testbench))
+    run("-e", "wr_reset_tb")
+    output = run("-r", "wr_reset_tb", "--assert-level=error", "--stop-time=30us")
+    assert "WR reset checks passed" in output


### PR DESCRIPTION
The WR firmware resets the PHY during endpoint initialization (`ep_enable()` -> `ep_reset_phy()`). On Artix-7, the PHY reset logic resets the external GTP PLL, dropping `clk_ref_locked`. Since 43fc38f84c18fed941d637a243d083b19fb41126, that lock feeds the board reset generator, so a normal PHY reset also resets the WR CPU and starts initialization again. This provides a reset feedback loop consistent with the continuous reboots reported on Acorn.

Remove the transceiver PLL lock from the WR core reset condition and leave its unused output open. System PLL lock, board reset, and the optional PCIe reset edge still control WR reset. The GTP fabric BUFG introduced by the same commit is retained.

Add a GHDL regression that simulates the actual board reset section with the pinned general-cores reset/synchronizer implementations. It exercises repeated transceiver PLL unlocks with the TX clock stopped, system PLL loss, explicit board reset, and the optional PCIe reset edge/standalone behavior.

Validation:

- `pytest -q test/test_wr_reset.py test/test_integration.py`: **7 passed**, including the GHDL simulation.
- Running the same regression against unmodified `main` fails at the first transceiver PLL unlock (2576 ns), when the WR CPU is unexpectedly reset.
- Acorn gateware generation passed using LiteEth `5de3d0f638b8d458f4418fadc8c2a7e873c3b630`. The currently installed LiteEth revision has a separate `rx_drop_when_disabled` API incompatibility with this repository's SRAM wrapper.
- Vivado 2024.1 RTL elaboration of `xwrc_board_litex_wr_nic_wrapper` for Artix-7 passed with the pinned WR cores and an existing firmware image.

Hardware boot/link validation on the affected Acorn is still needed; this PR has not been tested on hardware or through place-and-route.
