### PR TITLE
gateware: correct WR clock domains and DAC gain configuration

### DIFF
--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -327,7 +327,8 @@ class BaseSoC(LiteXWRNICSoC):
             "wr_rxoutclk",
         ]
         if with_white_rabbit:
-            asynchronous_clk_domains += []
+            # Host/WR register and fabric traffic crosses asynchronous FIFOs.
+            platform.add_false_path_constraints(self.crg.cd_sys.clk, self.cd_wr_sys.clk)
 
         platform.add_false_path_constraints(*asynchronous_clk_domains)
 

--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -228,7 +228,7 @@ class BaseSoC(LiteXWRNICSoC):
             # ------------------------
             self.refclk_mmcm_ps_gen = PSGen(
                  cd_psclk    = "clk200",
-                 cd_sys      = "wr",
+                 cd_sys      = "wr_sys",
                  ctrl_size   = 16,
                  )
             self.comb += [
@@ -242,7 +242,7 @@ class BaseSoC(LiteXWRNICSoC):
             # ----------------------
             self.dmtd_mmcm_ps_gen = PSGen(
                  cd_psclk    = "clk200",
-                 cd_sys      = "wr",
+                 cd_sys      = "wr_sys",
                  ctrl_size   = 16,
                  )
             self.comb += [

--- a/litex_wr_nic/gateware/ad5683r/core.py
+++ b/litex_wr_nic/gateware/ad5683r/core.py
@@ -47,7 +47,7 @@ class AD5683RDAC(LiteXModule):
             p_g_invert_sclk    = 0,
             p_g_num_data_bits  = 16,
             p_g_num_extra_bits = 8,
-            p_g_x2_gain        = {1: 0, 2: 1}[gain],
+            p_g_enable_x2_gain = {1: 0, 2: 1}[gain],
 
             i_clk_i        = ClockSignal(clk_domain),
             i_rst_n_i      = ~ResetSignal(clk_domain),

--- a/litex_wr_nic/gateware/ad5683r/core.py
+++ b/litex_wr_nic/gateware/ad5683r/core.py
@@ -16,7 +16,7 @@ from litex.soc.interconnect.csr import *
 # AD5683R DAC --------------------------------------------------------------------------------------
 
 class AD5683RDAC(LiteXModule):
-    def __init__(self, platform, pads, load, value, gain=1):
+    def __init__(self, platform, pads, load, value, gain=1, clk_domain="wr"):
         assert gain in [1, 2]
         self._force   = CSRStorage()
         self._load    = CSRStorage(1)
@@ -30,7 +30,8 @@ class AD5683RDAC(LiteXModule):
         value_i = Signal(16)
 
         # Force/Load.
-        self.sync.wr += [
+        sync = getattr(self.sync, clk_domain)
+        sync += [
             If(self._force.storage,
                 load_i.eq(self._load.storage),
                 value_i.eq(self._value.storage),
@@ -48,8 +49,8 @@ class AD5683RDAC(LiteXModule):
             p_g_num_extra_bits = 8,
             p_g_x2_gain        = {1: 0, 2: 1}[gain],
 
-            i_clk_i        = ClockSignal("wr"),
-            i_rst_n_i      = ~ResetSignal("wr"),
+            i_clk_i        = ClockSignal(clk_domain),
+            i_rst_n_i      = ~ResetSignal(clk_domain),
 
             i_val_i        = value_i,
             i_load_i       = load_i,

--- a/litex_wr_nic/gateware/soc.py
+++ b/litex_wr_nic/gateware/soc.py
@@ -122,7 +122,10 @@ class LiteXWRNICSoC(SoCMini):
 
         # Clks.
         # -----
-        self.cd_wr = ClockDomain("wr")
+        # Keep PPS/timecode in the PHY reference domain. The WR CPU, fabric,
+        # Wishbone and DAC commands run on the independent WR system clock.
+        self.cd_wr     = ClockDomain("wr")
+        self.cd_wr_sys = ClockDomain("wr_sys")
 
         # Signals.
         # --------
@@ -144,8 +147,8 @@ class LiteXWRNICSoC(SoCMini):
 
         # White Rabbit Fabric Interface.
         # ------------------------------
-        self.wrf_stream2wb = wrf_stream2wb = Stream2Wishbone(  cd_to="wr")
-        self.wrf_wb2stream = wrf_wb2stream = Wishbone2Stream(cd_from="wr")
+        self.wrf_stream2wb = wrf_stream2wb = Stream2Wishbone(  cd_to="wr_sys")
+        self.wrf_wb2stream = wrf_wb2stream = Wishbone2Stream(cd_from="wr_sys")
 
         # White Rabbit Slave Interface.
         # -----------------------------
@@ -160,7 +163,7 @@ class LiteXWRNICSoC(SoCMini):
             wb_from = wb_slave_sys,
             cd_from = "sys",
             wb_to   = wb_slave_wr,
-            cd_to   = "wr",
+            cd_to   = "wr_sys",
         )
 
         # Temp 1-Wire Logic.
@@ -173,7 +176,7 @@ class LiteXWRNICSoC(SoCMini):
                 o  = Constant(0b0, 1),
                 oe = ~temp_1wire_oe_n,
                 i  = temp_1wire_i,
-                clk = ClockSignal("wr"),
+                clk = ClockSignal("wr_sys"),
             )
 
         # Flash Logic.
@@ -215,8 +218,10 @@ class LiteXWRNICSoC(SoCMini):
             i_clk_62m5_dmtd_i     = ClockSignal("clk_62m5_dmtd"),
             i_clk_125m_gtp_i      = ClockSignal("clk_125m_gtp"),
             i_clk_10m_ext_i       = ClockSignal("clk10m_in"),
-            o_clk_62m5_sys_o      = ClockSignal("wr"),
-            o_rst_62m5_sys_o      = ResetSignal("wr"),
+            o_clk_62m5_sys_o      = ClockSignal("wr_sys"),
+            o_rst_62m5_sys_o      = ResetSignal("wr_sys"),
+            o_clk_62m5_ref_o      = ClockSignal("wr"),
+            o_rst_62m5_ref_o      = ResetSignal("wr"),
 
             # DAC RefClk Interface.
             o_dac_refclk_load     = self.dac_refclk_load,

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
@@ -99,6 +99,8 @@ entity xwrc_board_litex_wr_nic is
 
     clk_62m5_sys_o      : out std_logic;
     rst_62m5_sys_o      : out std_logic;
+    clk_62m5_ref_o      : out std_logic;
+    rst_62m5_ref_o      : out std_logic;
 
     ---------------------------------------------------------------------------
     -- Serial DACs
@@ -344,8 +346,13 @@ begin  -- architecture struct
       GT0_EXT_QPLL_LOCK     => GT0_EXT_QPLL_LOCK
     );
 
-  clk_62m5_sys_o <= clk_ref_62m5;
-  rst_62m5_sys_o <= not pll_locked;
+  -- Wishbone, fabric and SoftPLL DAC commands use the system clock. PPS and
+  -- timecode use the PHY reference clock; these clocks can have different
+  -- phases and the PHY clock can stop during endpoint initialization.
+  clk_62m5_sys_o <= clk_pll_62m5;
+  rst_62m5_sys_o <= not rstlogic_rst_out(0);
+  clk_62m5_ref_o <= clk_ref_62m5;
+  rst_62m5_ref_o <= not rstlogic_rst_out(1);
 
   -----------------------------------------------------------------------------
   -- Reset logic

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
@@ -61,6 +61,8 @@ entity xwrc_board_litex_wr_nic_wrapper is
     pps_ext_i            : in  std_logic := '0';
     clk_62m5_sys_o       : out std_logic;
     rst_62m5_sys_o       : out std_logic;
+    clk_62m5_ref_o       : out std_logic;
+    rst_62m5_ref_o       : out std_logic;
 
     -- Serial DACs
     dac_refclk_load      : out std_logic;
@@ -261,6 +263,8 @@ begin
       pps_ext_i            => pps_ext_i,
       clk_62m5_sys_o       => clk_62m5_sys_o,
       rst_62m5_sys_o       => rst_62m5_sys_o,
+      clk_62m5_ref_o       => clk_62m5_ref_o,
+      rst_62m5_ref_o       => rst_62m5_ref_o,
       dac_refclk_load      => dac_refclk_load,
       dac_refclk_data      => dac_refclk_data,
       dac_dmtd_load        => dac_dmtd_load,

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -272,6 +272,7 @@ class BaseSoC(LiteXWRNICSoC):
                 load  = self.dac_refclk_load,
                 value = self.dac_refclk_data,
                 gain  = 2, # 2 for 0-3V range to be able to accelerate enough RefClk, not working with 1.
+                clk_domain = "wr_sys",
             )
 
             # DMTD DAC.
@@ -280,6 +281,7 @@ class BaseSoC(LiteXWRNICSoC):
                 load  = self.dac_dmtd_load,
                 value = self.dac_dmtd_data,
                 gain  = 1,
+                clk_domain = "wr_sys",
             )
 
             # White Rabbit Clk-In.

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -203,10 +203,12 @@ class BaseSoC(LiteXWRNICSoC):
                 "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout*}}] -to [get_clocks -quiet sys_clk]")
             platform.toolchain.pre_placement_commands.append(
                 "set_false_path -quiet -from [get_clocks -quiet sys_clk] -to [get_clocks -quiet {{*s7pciephy_clkout*}}]")
+            # With pclk_mux_direct_from_mmcm, CLKOUT4/5 drive the mutually
+            # exclusive 125/250 MHz inputs of the PIPE clock's BUFGCTRL.
             platform.toolchain.pre_placement_commands.append(
-                "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout0}}] -to [get_clocks -quiet {{*s7pciephy_clkout1}}]")
-            platform.toolchain.pre_placement_commands.append(
-                "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout1}}] -to [get_clocks -quiet {{*s7pciephy_clkout0}}]")
+                "set_clock_groups -logically_exclusive "
+                "-group [get_clocks {{*s7pciephy_clkout4}}] "
+                "-group [get_clocks {{*s7pciephy_clkout5}}]")
 
         # White Rabbit -----------------------------------------------------------------------------
 

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -581,6 +581,8 @@ class BaseSoC(LiteXWRNICSoC):
         ]
         if with_white_rabbit:
             asynchronous_clk_domains += [self.fine_delay.cd_fine_delay.clk]
+            # Host/WR register and fabric traffic crosses asynchronous FIFOs.
+            platform.add_false_path_constraints(self.crg.cd_sys.clk, self.cd_wr_sys.clk)
 
         platform.add_false_path_constraints(*asynchronous_clk_domains)
 

--- a/test/test_ad5683r.py
+++ b/test/test_ad5683r.py
@@ -1,0 +1,106 @@
+"""Check DAC gain binding and the commands sent to the physical SPI pins."""
+
+from pathlib import Path
+import shutil
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+from migen import Instance, Record, Signal
+
+from litex_wr_nic.gateware.ad5683r.core import AD5683RDAC
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCES = ROOT / "litex_wr_nic/gateware/ad5683r"
+
+
+@pytest.mark.parametrize("gain", [1, 2])
+def test_dac_gain_command(tmp_path, gain):
+    if shutil.which("ghdl") is None:
+        pytest.skip("GHDL is required for the DAC simulation")
+
+    platform = SimpleNamespace(add_source=lambda path: None)
+    pads = Record([(name, 1) for name in ("ldac_n", "sync_n", "sclk", "sdi")])
+    dut = AD5683RDAC(platform, pads, Signal(), Signal(16), gain=gain, clk_domain="wr_sys")
+    instance, = [s for s in dut.get_fragment().specials if isinstance(s, Instance)]
+    # Feed the actual Python instance's generic names/values to the VHDL
+    # elaborator, so an ignored or misspelled mixed-language generic fails.
+    generic_map = []
+    for item in instance.items:
+        if isinstance(item, Instance.Parameter):
+            value = item.value.value
+            if item.name in ("g_invert_sclk", "g_enable_x2_gain"):
+                value = str(bool(value)).lower()
+            generic_map.append(f"{item.name} => {value}")
+    config = "408000" if gain == 2 else "400000"
+    tb = tmp_path / "dac_tb.vhd"
+    tb.write_text(f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+entity dac_tb is end;
+architecture test of dac_tb is
+  signal clk, rst_n, load : std_logic := '0';
+  signal sync_n, sclk, sdi : std_logic;
+  signal value : std_logic_vector(15 downto 0) := x"a53c";
+begin
+  clk <= not clk after 8 ns;
+  dut : entity work.serial_dac_arb
+    generic map ({", ".join(generic_map)})
+    port map (clk_i => clk, rst_n_i => rst_n, val_i => value, load_i => load,
+      dac_ldac_n_o => open, dac_clr_n_o => open, dac_sync_n_o => sync_n,
+      dac_sclk_o => sclk, dac_din_o => sdi);
+  stimulus : process
+  begin
+    wait for 160 ns;
+    wait until falling_edge(clk);
+    rst_n <= '1';
+    -- Queue a value while the reference/gain command is being transmitted.
+    wait until falling_edge(sync_n);
+    wait until falling_edge(clk);
+    load <= '1';
+    wait until falling_edge(clk);
+    load <= '0';
+    wait;
+  end process;
+  receiver : process
+    variable command : std_logic_vector(23 downto 0);
+    variable count : natural;
+  begin
+    for transaction in 0 to 1 loop
+      wait until falling_edge(sync_n);
+      command := (others => '0');
+      count := 0;
+      loop
+        wait on sclk, sync_n;
+        exit when sync_n = '1';
+        if falling_edge(sclk) then
+          command := command(22 downto 0) & sdi;
+          count := count + 1;
+        end if;
+      end loop;
+      assert count = 24 report "Wrong SPI command length" severity failure;
+      if transaction = 0 then
+        assert command = x"{config}"
+          report "Wrong DAC reference/gain command" severity failure;
+      else
+        assert command = x"3a53c0"
+          report "Lost or corrupted queued DAC value" severity failure;
+      end if;
+    end loop;
+    std.env.stop;
+    wait;
+  end process;
+  watchdog : process
+  begin
+    wait for 20 us;
+    assert false report "DAC command timed out" severity failure;
+  end process;
+end;
+""")
+    for source in [SOURCES / "serial_dac.vhd", SOURCES / "serial_dac_arb.vhd", tb]:
+        subprocess.run(["ghdl", "-a", "--std=08", str(source)], cwd=tmp_path, check=True)
+    subprocess.run(["ghdl", "-e", "--std=08", "dac_tb"], cwd=tmp_path, check=True)
+    subprocess.run(["ghdl", "-r", "--std=08", "dac_tb", "--assert-level=error"],
+                   cwd=tmp_path, check=True)

--- a/test/test_wr_clock_domains.py
+++ b/test/test_wr_clock_domains.py
@@ -1,0 +1,103 @@
+"""WR control/fabric must operate even while the PHY reference clock is stopped."""
+
+from types import SimpleNamespace
+
+from migen import ClockDomain, ClockSignal, Instance, Record, run_simulation
+from migen.fhdl.structure import _Assign
+from litex.gen import LiteXModule
+
+from litex_wr_nic.gateware.soc import LiteXWRNICSoC
+
+
+def test_wr_interfaces_without_phy_clock():
+    dut = LiteXModule()
+    dut.cd_sys = ClockDomain("sys")
+    dut.platform = SimpleNamespace(device="xc7a50t")
+    dut.bus = SimpleNamespace(add_slave=lambda **kwargs: None)
+    LiteXWRNICSoC.add_wr_core(dut,
+        cpu_firmware="unused.bram",
+        sfp_pads=Record([(name, 1) for name in ("txp", "txn", "rxp", "rxn")]),
+        sfp_i2c_pads=Record([("sda", 1), ("scl", 1)]))
+
+    wb = dut.wb_slave_wr
+    tx = dut.wrf_stream2wb
+    rx = dut.wrf_wb2stream
+    # Model only the WR core's bus responses. Exercise the actual LiteX-side
+    # crossings and fabric adapters, with no edges on the PHY reference clock.
+    dut.comb += [
+        wb.ack.eq(wb.cyc & wb.stb),
+        wb.dat_r.eq(0x12345678),
+        tx.bus.ack.eq(tx.bus.cyc & tx.bus.stb),
+    ]
+    fragment = dut.get_fragment()
+    core = [s for s in fragment.specials if isinstance(s, Instance)
+            and s.of == "xwrc_board_litex_wr_nic_wrapper"]
+    assert len(core) == 1
+    fragment.specials.remove(core[0])
+
+    received = []
+    transmitted = []
+
+    def host():
+        host_wb = dut.wb_slave_sys
+        yield host_wb.cyc.eq(1)
+        yield host_wb.stb.eq(1)
+        for _ in range(100):
+            if (yield host_wb.ack):
+                assert (yield host_wb.err) == 0
+                assert (yield host_wb.dat_r) == 0x12345678
+                break
+            yield
+        else:
+            raise AssertionError("WR register access stalled with the PHY clock stopped")
+        yield host_wb.cyc.eq(0)
+        yield host_wb.stb.eq(0)
+
+        yield tx.sink.valid.eq(1)
+        for index, byte in enumerate([0x12, 0x34, 0x56, 0x78]):
+            yield tx.sink.data.eq(byte)
+            yield tx.sink.last.eq(index == 3)
+            for _ in range(100):
+                yield
+                if (yield tx.sink.ready):
+                    break
+            else:
+                raise AssertionError("Fabric transmit stream stalled")
+        yield tx.sink.valid.eq(0)
+        yield rx.source.ready.eq(1)
+        yield
+        for _ in range(150):
+            if (yield rx.source.valid):
+                received.append((yield rx.source.data))
+            yield
+
+    def wr_core():
+        # The WR core itself originates fabric traffic in its system domain.
+        yield rx.bus.cyc.eq(1)
+        yield rx.bus.stb.eq(1)
+        yield rx.bus.adr.eq(2)
+        yield
+        yield rx.bus.adr.eq(0)
+        yield rx.bus.sel.eq(3)
+        for word in [0xabcd, 0xef01]:
+            yield rx.bus.dat_w.eq(word)
+            yield
+        yield rx.bus.cyc.eq(0)
+        yield rx.bus.stb.eq(0)
+        for _ in range(150):
+            if (yield tx.bus.cyc) and (yield tx.bus.stb) and (yield tx.bus.adr) == 0:
+                transmitted.append((yield tx.bus.dat_w))
+            yield
+
+    clocks = {"sys": 10, "wr_sys": 16}
+    # Migen simulation needs explicit schedules for the clock aliases that
+    # stream.ClockDomainCrossing creates to share resets across its FIFO.
+    for statement in fragment.comb:
+        if isinstance(statement, _Assign) and isinstance(statement.r, ClockSignal):
+            if statement.r.cd in clocks:
+                for domain in fragment.clock_domains:
+                    if statement.l is domain.clk:
+                        clocks[domain.name] = clocks[statement.r.cd]
+    run_simulation(fragment, {"sys": host(), "wr_sys": wr_core()}, clocks=clocks)
+    assert transmitted == [0x1234, 0x5678]
+    assert received == [0xab, 0xcd, 0xef, 0x01]

--- a/test/test_wr_reset.py
+++ b/test/test_wr_reset.py
@@ -1,6 +1,7 @@
 """Simulate the board reset circuit with GHDL and the pinned wr-cores checkout."""
 
 from pathlib import Path
+import re
 import shutil
 import subprocess
 
@@ -24,6 +25,8 @@ def test_wr_reset_survives_phy_pll_unlock(tmp_path):
     start = board.index("  cmp_arst_edge:")
     end = board.index("  rst_62m5_n <= rstlogic_rst_out(0);")
     reset_logic = board[start:end] + "  rst_62m5_n <= rstlogic_rst_out(0);\n"
+    clock_exports = "\n".join(re.findall(
+        r"^  (?:clk|rst)_62m5_(?:sys|ref)_o <= .*;$", board, re.MULTILINE))
     testbench = tmp_path / "wr_reset_tb.vhd"
     testbench.write_text("""
 library ieee;
@@ -38,11 +41,26 @@ architecture test of wr_reset_tb is
   signal areset_edge_n_i : std_logic := '0';
   signal areset_edge_ppulse, rstlogic_arst_n, rst_62m5_n : std_logic;
   signal rstlogic_clk_in, rstlogic_rst_out : std_logic_vector(1 downto 0);
+  signal clk_62m5_sys_o, rst_62m5_sys_o, clk_62m5_ref_o, rst_62m5_ref_o : std_logic;
 begin
   clk_pll_62m5 <= not clk_pll_62m5 after 8 ns;
   clk_62m5_dmtd_i <= not clk_62m5_dmtd_i after 8.1 ns;
   clk_ref_62m5 <= not clk_ref_62m5 after 8 ns when clk_ref_locked = '1' else '0';
-""" + reset_logic + """
+""" + reset_logic + clock_exports + """
+  check_exports : postponed process(all)
+  begin
+    if now > 0 ns then
+    assert clk_62m5_sys_o = clk_pll_62m5
+      report "WR system clock must keep running when the PHY clock stops" severity failure;
+    assert clk_62m5_ref_o = clk_ref_62m5
+      report "PPS reference clock must come from the PHY" severity failure;
+    assert rst_62m5_sys_o = not rstlogic_rst_out(0)
+      report "WR system reset must use the synchronized board reset" severity failure;
+    assert rst_62m5_ref_o = not rstlogic_rst_out(1)
+      report "PPS reference reset must use its own synchronizer" severity failure;
+    end if;
+  end process;
+
   stimulus : process
     procedure expect_reset(value : std_logic; cycles : positive) is
     begin


### PR DESCRIPTION
The WR board wrapper exported PHY TXOUTCLK as `clk_62m5_sys_o`, although the WR core runs its Wishbone interfaces, fabric interfaces and SoftPLL DAC commands on the separate MMCM system clock. The surrounding LiteX logic therefore sampled these interfaces in the wrong clock domain. The PHY clock can also stop during endpoint initialization, stalling register accesses.

Export both clocks explicitly. Keep PPS/timecode in the existing `wr` reference domain, and run Wishbone, fabric, 1-Wire, SPEC-A7 DAC drivers and Acorn phase-control command capture in `wr_sys`. Export the existing reset synchronizers for each clock domain instead of raw PLL lock. Declare the host and WR system clocks asynchronous for their existing FIFO crossings.

The DAC wrapper also passed `g_x2_gain`, while the VHDL driver declares `g_enable_x2_gain`. Vivado ignored the requested value, so the DMTD DAC used the default x2 despite `gain=1`. Correct the generic name so both DACs use their intended gains.

The SPEC-A7 timing constraints also still referenced CLKOUT0/1 after switching to dedicated PIPE clock-mux outputs. Declare CLKOUT4/5 logically exclusive instead: they feed the complementary selections of the same BUFGCTRL. Timing within each selected clock remains checked.

This is a follow-up to #70 and is based on its branch. It addresses a concrete defect found while investigating #57; it does not establish that the reported reload-dependent PPS mean offset is resolved, and should not close that issue. The incorrect clock export dates back to November 2024 and was present in the reported builds.

Validation:
- Ten focused pytest checks pass, including GHDL board clock/reset simulation and Migen register/fabric transfers with the PHY reference clock stopped. The new regressions reject the old clock export and old bus wiring. Two GHDL SPI tests use the actual Python generic bindings and verify reference/gain commands and a queued DAC value; the original generic name fails elaboration.
- Acorn and default SPEC-A7 gateware generation pass.
- Before the DAC generic correction, full SPEC-A7 synthesis passes in Vivado 2024.1. Netlist assertions confirm all 34 DAC command registers use `clk_sys`, while the PPS output register uses `wr_txoutclk` and retains `IOB=TRUE`. No register clocks or internal maximum-delay constraints are missing.
- The same pre-DAC-correction SPEC-A7 placement and routing complete with the final clock constraints. WR system/reference setup margins are +1.356/+3.995 ns; the PPS register is at `OLOGIC_X0Y98 / OLOGICE2.OUTFF`. Global hold timing passes. Overall setup timing is **not closed**: 49 endpoints fail in the 250 MHz PIPE domain, with a worst slack of -0.174 ns on the PTM sniffer aligner-to-filter FIFO path. This remains draft; the timing failure is not evidence that the reported external PPS offset has the same cause.

Builds used the pinned wr-cores revision, an existing BRAM firmware image, and LiteEth `5de3d0f` to avoid an unrelated SRAM constructor incompatibility with the installed newer LiteEth. Hardware measurements are unavailable. CDC reports still flag other paths, including manual DAC override/status controls; this is not a complete CDC sign-off.

Additional causal review of #57:
- A stable low-jitter PPS offset is not established as a consequence of the control-clock mismatch. The core timestamp unit, DDMTD measurements and default PPS path already shared the PHY reference clock. A locked PI loop normally absorbs actuator gain/delay changes unless updates are corrupted or the loop saturates.
- The existing bitslide correction is wired through to PPSI. GHDL checks of the actual Artix alignment FSM pass all 20 starting alignments against a one-bit-per-slide PCS model; physical transceiver startup latency is not modeled.
- The RX timestamp calibration policy and fractional arithmetic are unchanged between client WRPC `5ac04dd5` and current `baf77496`. The firmware may retain stored t24p within 2000 ps of a fresh measurement. The actual C functions were checked over 128,000 phase/edge cases per revision: t24p affects fractional timestamp bias, not only edge selection. A real differential RX bias of 800 ps can produce 400 ps external PPS offset with zero internal servo residual. There are no paired per-reload calibration measurements establishing that this happened to the client.
- The NB6L295 remains in the physical output path even with macro/coarse bypass; its programming order matches the datasheet. Uncorrected PHY/output latency and calibration bias remain candidates.

The DAC-only mixed-language Vivado synthesis succeeds with the intended boolean gain values 0 and 1. Full-board routing has not been repeated for that generic correction. Fresh pinned WRPC/PPSI/UAL sources also compile and link and convert to a BRAM image; source-archive git metadata steps were bypassed. No boot or hardware PPS tests were performed.
