### PR TITLE
wr: extract a reusable WhiteRabbitCore component

### DIFF
--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -261,7 +261,6 @@ class BaseSoC(LiteXWRNICSoC):
                 # Flash.
                 flash_pads      = platform.request("flash", 1),
             )
-            self.add_sources()
 
             # RefClk MMCM Phase Shift.
             # ------------------------

--- a/doc/wr_integration.md
+++ b/doc/wr_integration.md
@@ -2,27 +2,127 @@
 
 `WhiteRabbitCore` is a `LiteXModule` that can be used without the PCIe NIC,
 LiteEth SRAM replacement, or the NIC target's address map. It currently wraps
-the existing Xilinx 7-series WR board implementation. Supply the board clocks,
-SFP/I2C pads, optional UART/flash/one-wire pads, and oscillator tuning wiring.
+the existing Xilinx 7-series WR board implementation. HDL sources are added
+automatically by `do_finalize()`; no separate `add_sources()` call is needed.
+
+The examples below belong inside an existing SoC constructor, after its
+platform, bus and board clocking have been created. Choose one CPU setup.
+They use SPEC-A7 resource names and firmware; adapt pads and firmware target
+for another board. Your SoC supplies the host bus master (for example a LiteX
+CPU or JTAGBone).
+
+## Board requirements
+
+The board must supply `sys`, `clk_62m5_dmtd`, `clk_125m_gtp` and `clk10m_in`.
+The WR wrapper produces `wr_sys` and `wr`, including their resets. Connect its
+oscillator tuning outputs to the board's DAC/MMCM implementation, and wire
+PPS and the optional UART/flash/one-wire interfaces as required. The examples
+show SFP/I2C and direct UART connections; they do not replace the board CRG or
+oscillator wiring. When sharing transceiver PLL resources, also pass the
+board's `qpll`, as in `spec_a7_wr_nic.py`.
+
+## uRV with private RAM
+
+Build the matching embedded firmware from the repository root:
+
+```sh
+python3 litex_wr_nic/firmware/build.py --target spec_a7 --wr-cpu-type urv
+```
+
+Attach the core and register its host slave in one call:
+
+```python
+from litex.soc.integration.soc import SoCRegion
+from litex_wr_nic.gateware.wr_core import add_white_rabbit
+
+platform = self.platform
+wr = add_white_rabbit(self,
+    cpu_type        = "urv",
+    cpu_firmware    = "litex_wr_nic/firmware/spec_a7_wrc.bram",
+    wb_slave_region = SoCRegion(origin=0x20000000, size=0x01000000, cached=False),
+    sfp_pads        = platform.request("sfp", 0),
+    sfp_i2c_pads    = platform.request("sfp_i2c", 0),
+    serial_pads     = platform.request("serial"),
+)
+```
+
+Private RAM belongs to the WR wrapper and is initialized from the `.bram`
+file. There is no CPU memory master to register and no external memory
+readiness signal to supply. The default CPU/memory choice remains uRV/private.
+
+## VexRiscv with integrated RAM
+
+Build the VexRiscv firmware first:
+
+```sh
+python3 litex_wr_nic/firmware/build.py --target spec_a7 --wr-cpu-type vexriscv
+```
+
+Allocate and initialize the 128 KiB SoC RAM before attaching WR:
+
+```python
+from litex.soc.integration.common import get_mem_data
+from litex.soc.integration.soc import SoCRegion
+from litex_wr_nic.gateware.wr_core import add_white_rabbit
+
+platform = self.platform
+contents = get_mem_data("litex_wr_nic/firmware/spec_a7_wrc_vexriscv.bin",
+    data_width = 32,
+    endianness = "little",
+    mem_size   = 0x20000,
+)
+self.add_ram("wr_cpu_mem", origin=0x50000000, size=0x20000, contents=contents)
+wr = add_white_rabbit(self,
+    cpu_type          = "vexriscv",
+    cpu_variant       = "lite",
+    cpu_firmware      = "litex_wr_nic/firmware/spec_a7_wrc_vexriscv.bram",
+    cpu_memory_region = self.bus.regions["wr_cpu_mem"],
+    cpu_memory_ready  = 1,
+    wb_slave_region   = SoCRegion(origin=0x20000000, size=0x01000000, cached=False),
+    sfp_pads          = platform.request("sfp", 0),
+    sfp_i2c_pads      = platform.request("sfp_i2c", 0),
+    serial_pads       = platform.request("serial"),
+)
+```
+
+The helper registers both the host slave and `wr.cpu_bus`, mapping the CPU's
+local memory addresses into `wr_cpu_mem`. `cpu_memory_ready=1` is appropriate
+here because integrated RAM contains firmware at FPGA configuration. With an
+external memory controller, keep readiness low until initialization completes
+and firmware is present. VexRiscv requires SoC memory and its matching firmware;
+the current adapter supports the `lite` variant.
+
+Both helper examples create `self.wr_core` and retain the historical
+attributes and CSR names. `wr` is a local reference to that module; do not
+register it again as another SoC submodule. `LiteXWRNICSoC.add_wr_core(...)`
+delegates to the same helper. `wb_slave_region` preserves the supplied region's
+attributes and takes precedence over the legacy `wb_slave_origin` and
+`wb_slave_size` arguments, which remain supported. LiteX rounds the decoded
+region to a power of two; the core uses that same size for local addressing.
+
+## Direct component integration
+
+To choose a different hierarchy or CSR layout, instantiate the component
+and register its interfaces yourself:
 
 ```python
 from litex.soc.integration.soc import SoCRegion
 from litex_wr_nic.gateware.wr_core import WhiteRabbitCore
 
-self.wr = WhiteRabbitCore(platform,
+self.wr = WhiteRabbitCore(self.platform,
     cpu_firmware = "litex_wr_nic/firmware/spec_a7_wrc.bram",
-    sfp_pads     = platform.request("sfp", 0),
-    sfp_i2c_pads = platform.request("sfp_i2c", 0),
-    serial_pads  = platform.request("serial"),
+    sfp_pads     = self.platform.request("sfp", 0),
+    sfp_i2c_pads = self.platform.request("sfp_i2c", 0),
+    serial_pads  = self.platform.request("serial"),
 )
 self.bus.add_slave("wr", self.wr.bus,
-    SoCRegion(origin=0x20000000, size=0x01000000))
-WhiteRabbitCore.add_sources(platform)
+    SoCRegion(origin=0x20000000, size=0x01000000, cached=False))
 ```
 
-The board must supply `sys`, `clk_62m5_dmtd`, `clk_125m_gtp` and `clk10m_in`.
-The wrapper produces `wr_sys` and `wr`, including their resets. Use Migen's
-`ClockDomainsRenamer` on the component when a design needs different names.
+Automatic source registration applies to this form too. Historical explicit
+`WhiteRabbitCore.add_sources(platform)` and `self.add_sources()` calls remain
+supported and register the WR sources only once per platform. Use Migen's
+`ClockDomainsRenamer` when a design needs different clock-domain names.
 
 | Interface | Clock | Contract |
 | --- | --- | --- |
@@ -32,16 +132,9 @@ The wrapper produces `wr_sys` and `wr`, including their resets. Use Migen's
 | `dac_*_data`, `dac_*_load` | `wr_sys` | Oscillator tuning commands |
 | `tm_seconds`, `tm_cycles`, `tm_time_valid`, `pps_*` | `wr` | PHY reference time and PPS |
 
-For SoC memory, pass `with_cpu_memory=True`, register `cpu_bus` against a
-reserved `SoCRegion`, and supply `cpu_memory_ready`. Keep readiness low until
-memory initialization completes. VexRiscv additionally needs
-`cpu_type="vexriscv"` and its matching `spec_a7_wrc_vexriscv.bram` firmware.
-The current VexRiscv adapter supports the `lite` variant.
-
-`add_white_rabbit(soc, ...)` registers the buses and preserves the historical
-top-level attributes and CSR names. `LiteXWRNICSoC.add_wr_core(...)` delegates
-to this helper, so existing targets need no changes. New designs can use
-the component directly and choose their own hierarchy and CSR layout.
+For direct SoC-memory integration, pass `with_cpu_memory=True`, register
+`cpu_bus` against the reserved `SoCRegion`, and supply `cpu_memory_ready`.
+Keep the host slave's decoded size consistent with `wb_slave_size` on the core.
 
 External build integrations can pass `wr_cpu_type`, `wr_cpu_variant`, and
 `wr_cpu_memory` to `prepare_wr_environment`. The returned configuration

--- a/doc/wr_integration.md
+++ b/doc/wr_integration.md
@@ -1,0 +1,50 @@
+# Integrating White Rabbit in a LiteX design
+
+`WhiteRabbitCore` is a `LiteXModule` that can be used without the PCIe NIC,
+LiteEth SRAM replacement, or the NIC target's address map. It currently wraps
+the existing Xilinx 7-series WR board implementation. Supply the board clocks,
+SFP/I2C pads, optional UART/flash/one-wire pads, and oscillator tuning wiring.
+
+```python
+from litex.soc.integration.soc import SoCRegion
+from litex_wr_nic.gateware.wr_core import WhiteRabbitCore
+
+self.wr = WhiteRabbitCore(platform,
+    cpu_firmware = "litex_wr_nic/firmware/spec_a7_wrc.bram",
+    sfp_pads     = platform.request("sfp", 0),
+    sfp_i2c_pads = platform.request("sfp_i2c", 0),
+    serial_pads  = platform.request("serial"),
+)
+self.bus.add_slave("wr", self.wr.bus,
+    SoCRegion(origin=0x20000000, size=0x01000000))
+WhiteRabbitCore.add_sources(platform)
+```
+
+The board must supply `sys`, `clk_62m5_dmtd`, `clk_125m_gtp` and `clk10m_in`.
+The wrapper produces `wr_sys` and `wr`, including their resets. Use Migen's
+`ClockDomainsRenamer` on the component when a design needs different names.
+
+| Interface | Clock | Contract |
+| --- | --- | --- |
+| `bus` | `sys` | 32-bit word-addressed host Wishbone slave |
+| `cpu_bus` | `sys` | Optional 32-bit word-addressed CPU memory master |
+| `sink` / `source` | `sys` | Application Ethernet byte streams |
+| `dac_*_data`, `dac_*_load` | `wr_sys` | Oscillator tuning commands |
+| `tm_seconds`, `tm_cycles`, `tm_time_valid`, `pps_*` | `wr` | PHY reference time and PPS |
+
+For SoC memory, pass `with_cpu_memory=True`, register `cpu_bus` against a
+reserved `SoCRegion`, and supply `cpu_memory_ready`. Keep readiness low until
+memory initialization completes. VexRiscv additionally needs
+`cpu_type="vexriscv"` and its matching `spec_a7_wrc_vexriscv.bram` firmware.
+The current VexRiscv adapter supports the `lite` variant.
+
+`add_white_rabbit(soc, ...)` registers the buses and preserves the historical
+top-level attributes and CSR names. `LiteXWRNICSoC.add_wr_core(...)` delegates
+to this helper, so existing targets need no changes. New designs can use
+the component directly and choose their own hierarchy and CSR layout.
+
+External build integrations can pass `wr_cpu_type`, `wr_cpu_variant`, and
+`wr_cpu_memory` to `prepare_wr_environment`. The returned configuration
+contains the validated selection; the caller must pass that selection to its
+SoC constructor. Firmware lookup and rebuild select the corresponding CPU
+profile. Defaults remain uRV with private memory.

--- a/hyvision_pcie_opt01_revf.py
+++ b/hyvision_pcie_opt01_revf.py
@@ -237,8 +237,6 @@ class BaseSoC(LiteXWRNICSoC):
                 serial_pads      = self.uart.shared_pads,
              )
 
-            self.add_sources()
-
             # RefClk MMCM Phase Shift.
             # ------------------------
             self.refclk_mmcm_ps_gen = Instance("ps_gen",

--- a/litex_wr_nic/gateware/soc.py
+++ b/litex_wr_nic/gateware/soc.py
@@ -6,14 +6,12 @@
 # Copyright (c) 2022 Tongchen126 <https://github.com/tongchen126>
 # SPDX-License-Identifier: BSD-2-Clause
 
-import os
 import sys
 
 from migen import *
-from migen.genlib.cdc import MultiReg
 
 from litex.build    import tools
-from litex.build.io import SDRTristate, SDROutput
+from litex.build.io import SDROutput
 
 from litex.gen import *
 
@@ -31,29 +29,12 @@ from litex_wr_nic.gateware.nic import sram
 sys.modules["liteeth.mac.sram"] = sram #  Replace Liteeth SRAM with our custom implementation.
 from litex_wr_nic.gateware.nic.dma import LitePCIe2WishboneDMA
 
-from litex_wr_nic.gateware.wr_common         import (
-    wr_core_init,
-    wr_core_files,
-    patch_wr_subsystem_mux_class,
-    patch_wr_pps_gen_iob,
-    patch_wr_clock_monitor_presc_cdc,
-    patch_wr_external_cpu_memory,
-)
-from litex_wr_nic.gateware.wr_cpu            import (
-    WRCPUMemoryBridge,
-    WRCPUMemoryMonitor,
-    WRLiteXCPU,
-    resolve_wr_cpu_variant,
-    wr_cpu_word_bus,
-)
-from litex_wr_nic.gateware.wrf_stream2wb     import Stream2Wishbone
-from litex_wr_nic.gateware.wrf_wb2stream     import Wishbone2Stream
-from litex_wr_nic.gateware.wb_clock_crossing import WishboneClockCrossing
+from litex_wr_nic.gateware.wr_core import WhiteRabbitCore, add_white_rabbit
 
 # LiteX WR NIC SoC ---------------------------------------------------------------------------------
 
 class LiteXWRNICSoC(SoCMini):
-    SoCMini.csr_map = {
+    csr_map = {
         # Common (0-7).
         "identifier_mem"          : 1,
         "ctrl"                    : 2,
@@ -88,352 +69,15 @@ class LiteXWRNICSoC(SoCMini):
         "wr_cpu_boot"             : 6,
         "hyperram"                : 7,
     }
-    SoCMini.mem_map = {
+    mem_map = {
         "csr"      : 0x0000_0000,
         "ethmac0"  : 0x0002_0000,
         "ethmac1"  : 0x0004_0000,
     }
 
     # Add White Rabbit Core ------------------------------------------------------------------------
-    def add_wr_core(self,
-        # CPU.
-        cpu_firmware,
-        cpu_type          = "urv",
-        cpu_variant       = None,
-        cpu_memory_region = None,
-        cpu_memory_ready  = 1,
-        cpu_boot_loader   = None,
-
-        # Board name.
-        board_name  = "NA  ",
-
-        # SFP.
-        sfp_pads         = None,
-        sfp_i2c_pads     = None,
-        sfp_tx_polarity  = 0,
-        sfp_rx_polarity  = 0,
-        sfp_disable_pads = None,
-        sfp_fault_pads   = None,
-        sfp_los_pads     = None,
-        sfp_det_pads     = None,
-
-        # Clocking.
-        qpll         = None,
-        with_ext_clk = True,
-
-        # Serial.
-        serial_pads = None,
-
-        # Flash.
-        flash_pads = None,
-
-        # Temp 1Wire.
-        temp_1wire_pads = None,
-
-        # Wishbone Slave.
-        wb_slave_origin = 0x2000_0000,
-        wb_slave_size   = 0x0100_0000,
-
-        dac_bits      = 16
-    ):
-
-        # Clks.
-        # -----
-        # Keep PPS/timecode in the PHY reference domain. The WR CPU, fabric,
-        # Wishbone and DAC commands run on the independent WR system clock.
-        self.cd_wr     = ClockDomain("wr")
-        self.cd_wr_sys = ClockDomain("wr_sys")
-
-        # Signals.
-        # --------
-        self.led_pps         = Signal()
-        self.led_link        = Signal()
-        self.led_act         = Signal()
-        self.dac_refclk_load = Signal()
-        self.dac_refclk_data = Signal(dac_bits)
-        self.dac_dmtd_load   = Signal()
-        self.dac_dmtd_data   = Signal(dac_bits)
-        self.pps_in          = Signal()
-        self.pps_out_valid   = Signal()
-        self.pps_out         = Signal()
-        self.pps_out_pulse   = Signal()
-        self.tm_link_up      = Signal()
-        self.tm_time_valid   = Signal()
-        self.tm_seconds      = Signal(40)
-        self.tm_cycles       = Signal(28)
-
-        # Optional WR CPU Memory Master.
-        # ------------------------------
-        cpu_variant         = resolve_wr_cpu_variant(cpu_type, cpu_variant)
-        external_cpu        = cpu_type != "urv"
-        external_cpu_memory = cpu_memory_region is not None
-        if external_cpu and not external_cpu_memory:
-            raise ValueError(f"WR CPU type {cpu_type} requires external CPU memory.")
-
-        memory_ready_wr   = Signal(reset=not external_cpu_memory)
-        wr_cpu_bridge     = None
-        wr_cpu_peripheral = None
-        wr_cpu_irq        = Signal()
-        wr_cpu_reset      = Signal()
-        if external_cpu_memory:
-            if external_cpu:
-                self.wr_cpu = WRLiteXCPU(self.platform,
-                    cpu_type       = cpu_type,
-                    variant        = cpu_variant,
-                    irq            = wr_cpu_irq,
-                    software_reset = wr_cpu_reset,
-                    memory_ready   = memory_ready_wr,
-                )
-                wr_cpu_bus_wr     = self.wr_cpu.memory_bus
-                wr_cpu_bus_sys    = wishbone.Interface.like(wr_cpu_bus_wr)
-                wr_cpu_peripheral = self.wr_cpu.peripheral_bridge
-                self.wr_cpu_bridge = wr_cpu_bridge = WRCPUMemoryMonitor(monitor_bus=wr_cpu_bus_sys)
-            else:
-                wr_cpu_bus_sys = wishbone.Interface(
-                    data_width    = 32,
-                    address_width = 32,
-                    addressing    = "byte",
-                )
-                self.wr_cpu_bridge = wr_cpu_bridge = WRCPUMemoryBridge(monitor_bus=wr_cpu_bus_sys)
-                wr_cpu_bus_wr = wr_cpu_bridge.bus
-            self.submodules.wr_cpu_memory_cdc = WishboneClockCrossing(self.platform,
-                wb_from        = wr_cpu_bus_wr,
-                cd_from        = "wr_sys",
-                wb_to          = wr_cpu_bus_sys,
-                cd_to          = "sys",
-                timeout_cycles = 1024,
-            )
-            self.bus.add_master(name="wr_cpu",
-                master = wr_cpu_word_bus(self, wr_cpu_bus_sys),
-                region = cpu_memory_region,
-            )
-            self.specials += MultiReg(cpu_memory_ready, memory_ready_wr, "wr_sys")
-
-        # White Rabbit Fabric Interface.
-        # ------------------------------
-        self.wrf_stream2wb = wrf_stream2wb = Stream2Wishbone(  cd_to="wr_sys")
-        self.wrf_wb2stream = wrf_wb2stream = Wishbone2Stream(cd_from="wr_sys")
-
-        # White Rabbit Slave Interface.
-        # -----------------------------
-        wb_slave_mask = (wb_slave_size - 1)
-        self.wb_slave_sys = wb_slave_sys = wishbone.Interface(data_width=32, address_width=32, adressing="byte")
-        self.wb_slave_wr  = wb_slave_wr  = wishbone.Interface(data_width=32, address_width=32, adressing="byte")
-        self.bus.add_slave(name="wr_wb_slave", slave=wb_slave_sys, region=SoCRegion(
-             origin = wb_slave_origin,
-             size   = wb_slave_size,
-         ))
-        self.submodules += WishboneClockCrossing(self.platform,
-            wb_from = wb_slave_sys,
-            cd_from = "sys",
-            wb_to   = wb_slave_wr,
-            cd_to   = "wr_sys",
-        )
-
-        # Temp 1-Wire Logic.
-        # ------------------
-        if temp_1wire_pads is not None:
-            temp_1wire_oe_n = Signal()
-            temp_1wire_i    = Signal()
-            self.specials += SDRTristate(
-                io = temp_1wire_pads,
-                o  = Constant(0b0, 1),
-                oe = ~temp_1wire_oe_n,
-                i  = temp_1wire_i,
-                clk = ClockSignal("wr_sys"),
-            )
-
-        # Flash Logic.
-        # ------------
-        if flash_pads is not None:
-            flash_clk     = Signal()
-            wr_flash_clk  = Signal()
-            wr_flash_cs   = Signal(reset=1)
-            wr_flash_mosi = Signal()
-            if cpu_boot_loader is None:
-                self.comb += [
-                    flash_clk.eq(wr_flash_clk),
-                    flash_pads.cs_n.eq(wr_flash_cs),
-                    flash_pads.mosi.eq(wr_flash_mosi),
-                ]
-            else:
-                self.comb += [
-                    cpu_boot_loader.miso.eq(flash_pads.miso),
-                    flash_clk.eq(Mux(cpu_boot_loader.owner,
-                        cpu_boot_loader.clk, wr_flash_clk)),
-                    flash_pads.cs_n.eq(Mux(cpu_boot_loader.owner,
-                        cpu_boot_loader.cs_n, wr_flash_cs)),
-                    flash_pads.mosi.eq(Mux(cpu_boot_loader.owner,
-                        cpu_boot_loader.mosi, wr_flash_mosi)),
-                ]
-            self.specials += Instance("STARTUPE2",
-                i_CLK       = 0,
-                i_GSR       = 0,
-                i_GTS       = 0,
-                i_KEYCLEARB = 0,
-                i_PACK      = 0,
-                i_USRCCLKO  = flash_clk,
-                i_USRCCLKTS = 0,
-                i_USRDONEO  = 1,
-                i_USRDONETS = 1,
-            )
-            # Keep optional WP#/HOLD# lines deasserted in 1-bit SPI mode.
-            if hasattr(flash_pads, "wp"):
-                self.comb += flash_pads.wp.eq(1)
-            if hasattr(flash_pads, "hold"):
-                self.comb += flash_pads.hold.eq(1)
-
-        # White Rabbit Core Instance.
-        # ---------------------------
-        self.specials += Instance("xwrc_board_litex_wr_nic_wrapper",
-            # Parameters.
-            p_g_dpram_initf               = os.path.abspath(cpu_firmware),
-            p_g_dpram_size                = 131072//4,
-            # Vivado binds quoted "FALSE" to true across the Verilog/VHDL
-            # boundary; use a numeric boolean for deterministic elaboration.
-            p_g_external_cpu_memory       = int(external_cpu_memory),
-            p_g_external_cpu              = int(external_cpu),
-            p_txpolarity                  = sfp_tx_polarity,
-            p_rxpolarity                  = sfp_rx_polarity,
-            p_g_with_external_clock_input = str(with_ext_clk).upper(),
-            p_g_fpga_family               = {True: "artix7", False: "kintex7"}[self.platform.device.startswith("xc7a")],
-            p_g_board_name                = board_name,
-            p_g_dac_bits                  = dac_bits,
-
-            # Clocks/resets.
-            i_areset_n_i          = ~ResetSignal("sys"),
-            i_clk_62m5_dmtd_i     = ClockSignal("clk_62m5_dmtd"),
-            i_clk_125m_gtp_i      = ClockSignal("clk_125m_gtp"),
-            i_clk_10m_ext_i       = ClockSignal("clk10m_in"),
-            o_clk_62m5_sys_o      = ClockSignal("wr_sys"),
-            o_rst_62m5_sys_o      = ResetSignal("wr_sys"),
-            o_clk_62m5_ref_o      = ClockSignal("wr"),
-            o_rst_62m5_ref_o      = ResetSignal("wr"),
-
-            # DAC RefClk Interface.
-            o_dac_refclk_load     = self.dac_refclk_load,
-            o_dac_refclk_data     = self.dac_refclk_data,
-
-            # DAC DMTD Interface.
-            o_dac_dmtd_load       = self.dac_dmtd_load,
-            o_dac_dmtd_data       = self.dac_dmtd_data,
-
-            # SFP Interface.
-            o_sfp_txp_o           = sfp_pads.txp,
-            o_sfp_txn_o           = sfp_pads.txn,
-            i_sfp_rxp_i           = sfp_pads.rxp,
-            i_sfp_rxn_i           = sfp_pads.rxn,
-            i_sfp_det_i           = 0      if sfp_det_pads is None else sfp_det_pads,
-            io_sfp_sda            = sfp_i2c_pads.sda,
-            io_sfp_scl            = sfp_i2c_pads.scl,
-            i_sfp_tx_fault_i      = 0      if   sfp_fault_pads is None else   sfp_fault_pads,
-            i_sfp_tx_los_i        = 0      if     sfp_los_pads is None else     sfp_los_pads,
-            o_sfp_tx_disable_o    = Open() if sfp_disable_pads is None else sfp_disable_pads,
-
-            # One-Wire Interface.
-            i_onewire_i           = 0      if temp_1wire_pads is None else temp_1wire_i,
-            o_onewire_oen_o       = Open() if temp_1wire_pads is None else temp_1wire_oe_n,
-
-            # UART Interface.
-            i_uart_rxd_i          = 0      if serial_pads is None else serial_pads.rx,
-            o_uart_txd_o          = Open() if serial_pads is None else serial_pads.tx,
-
-            # SPI Flash Interface.
-            o_spi_sclk_o          = Open() if flash_pads is None else wr_flash_clk,
-            o_spi_ncs_o           = Open() if flash_pads is None else wr_flash_cs,
-            o_spi_mosi_o          = Open() if flash_pads is None else wr_flash_mosi,
-            i_spi_miso_i          = 0      if flash_pads is None else flash_pads.miso,
-
-            # Optional WR CPU Memory Master.
-            o_cpu_mem_cyc_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.cyc,
-            o_cpu_mem_stb_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.stb,
-            o_cpu_mem_we_o        = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.we,
-            o_cpu_mem_adr_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.adr,
-            o_cpu_mem_sel_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.sel,
-            o_cpu_mem_dat_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.dat_w,
-            i_cpu_mem_dat_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.dat_r,
-            i_cpu_mem_ack_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.ack,
-            i_cpu_mem_err_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.err,
-            i_cpu_mem_rty_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.rty,
-            i_cpu_mem_stall_i     = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.stall,
-            i_cpu_mem_ready_i     = 1      if not external_cpu_memory else memory_ready_wr,
-
-            # Optional LiteX WR CPU peripheral master, interrupt and reset.
-            i_cpu_ext_cyc_i       = 0 if not external_cpu else wr_cpu_peripheral.cyc,
-            i_cpu_ext_stb_i       = 0 if not external_cpu else wr_cpu_peripheral.stb,
-            i_cpu_ext_we_i        = 0 if not external_cpu else wr_cpu_peripheral.we,
-            i_cpu_ext_adr_i       = 0 if not external_cpu else Cat(
-                Constant(0, 2), wr_cpu_peripheral.adr),
-            i_cpu_ext_sel_i       = 0 if not external_cpu else wr_cpu_peripheral.sel,
-            i_cpu_ext_dat_i       = 0 if not external_cpu else wr_cpu_peripheral.dat_w,
-            o_cpu_ext_dat_o       = Open() if not external_cpu else wr_cpu_peripheral.dat_r,
-            o_cpu_ext_ack_o       = Open() if not external_cpu else wr_cpu_peripheral.ack,
-            o_cpu_ext_err_o       = Open() if not external_cpu else wr_cpu_peripheral.err,
-            o_cpu_ext_rty_o       = Open() if not external_cpu else wr_cpu_peripheral.rty,
-            o_cpu_ext_stall_o     = Open() if not external_cpu else wr_cpu_peripheral.stall,
-            o_cpu_ext_irq_o       = Open() if not external_cpu else wr_cpu_irq,
-            o_cpu_ext_reset_o     = Open() if not external_cpu else wr_cpu_reset,
-
-            # PPS / Leds.
-            i_pps_ext_i           = self.pps_in,
-            o_pps_valid_o         = self.pps_out_valid,
-            o_pps_csync_o         = self.pps_out_pulse,
-            o_pps_p_o             = self.pps_out,
-            o_pps_led_o           = self.led_pps,
-            o_led_link_o          = self.led_link,
-            o_led_act_o           = self.led_act,
-
-            # QPLL Interface (for GTPE2_Common Sharing).
-            o_gt0_ext_qpll_reset  = Open() if qpll is None else qpll.get_channel("eth").reset,
-            i_gt0_ext_qpll_clk    = 0      if qpll is None else qpll.get_channel("eth").clk,
-            i_gt0_ext_qpll_refclk = 0      if qpll is None else qpll.get_channel("eth").refclk,
-            i_gt0_ext_qpll_lock   = 0      if qpll is None else qpll.get_channel("eth").lock,
-
-            # Wishbone Slave Interface (MMAP).
-            i_wb_slave_cyc        = wb_slave_wr.cyc,
-            i_wb_slave_stb        = wb_slave_wr.stb,
-            i_wb_slave_we         = wb_slave_wr.we,
-            i_wb_slave_adr        = Cat(Signal(2), (wb_slave_wr.adr & wb_slave_mask)),
-            i_wb_slave_sel        = wb_slave_wr.sel,
-            i_wb_slave_dat_i      = wb_slave_wr.dat_w,
-            o_wb_slave_dat_o      = wb_slave_wr.dat_r,
-            o_wb_slave_ack        = wb_slave_wr.ack,
-            o_wb_slave_err        = wb_slave_wr.err,
-            o_wb_slave_rty        = Open(),
-            o_wb_slave_stall      = Open(),
-
-            # Wishbone Fabric Source Interface.
-            o_wrf_src_adr         = wrf_wb2stream.bus.adr,
-            o_wrf_src_dat         = wrf_wb2stream.bus.dat_w,
-            o_wrf_src_cyc         = wrf_wb2stream.bus.cyc,
-            o_wrf_src_stb         = wrf_wb2stream.bus.stb,
-            o_wrf_src_we          = wrf_wb2stream.bus.we,
-            o_wrf_src_sel         = wrf_wb2stream.bus.sel,
-
-            i_wrf_src_ack         = wrf_wb2stream.bus.ack,
-            i_wrf_src_stall       = 0, # Not Used.
-            i_wrf_src_err         = wrf_wb2stream.bus.err,
-            i_wrf_src_rty         = 0, # Not Used.
-
-            # Wishbone Fabric Sink Interface.
-            i_wrf_snk_adr         = wrf_stream2wb.bus.adr,
-            i_wrf_snk_dat         = wrf_stream2wb.bus.dat_w,
-            i_wrf_snk_cyc         = wrf_stream2wb.bus.cyc,
-            i_wrf_snk_stb         = wrf_stream2wb.bus.stb,
-            i_wrf_snk_we          = wrf_stream2wb.bus.we,
-            i_wrf_snk_sel         = wrf_stream2wb.bus.sel,
-
-            o_wrf_snk_ack         = wrf_stream2wb.bus.ack,
-            o_wrf_snk_stall       = Open(), # Not Used.
-            o_wrf_snk_err         = wrf_stream2wb.bus.err,
-            o_wrf_snk_rty         = Open(), # Not Used.
-
-            # Time.
-            o_tm_link_up_o        = self.tm_link_up,
-            o_tm_time_valid_o     = self.tm_time_valid,
-            o_tm_tai_o            = self.tm_seconds,
-            o_tm_cycles_o         = self.tm_cycles,
-        )
+    def add_wr_core(self, *args, **kwargs):
+        return add_white_rabbit(self, *args, **kwargs)
 
     # Add PCIe NIC ---------------------------------------------------------------------------------
 
@@ -617,14 +261,7 @@ class LiteXWRNICSoC(SoCMini):
     # Add Sources ----------------------------------------------------------------------------------
 
     def add_sources(self):
-        if not os.path.exists("wr-cores"):
-            wr_core_init()
-        patch_wr_subsystem_mux_class()
-        patch_wr_pps_gen_iob()
-        patch_wr_clock_monitor_presc_cdc()
-        patch_wr_external_cpu_memory()
-        for file in wr_core_files:
-            self.platform.add_source(file)
+        WhiteRabbitCore.add_sources(self.platform)
 
     # Add Probes -----------------------------------------------------------------------------------
 

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -12,7 +12,9 @@ from migen import *
 from migen.genlib.cdc import MultiReg
 
 from litex.gen import *
+
 from litex.build.io import SDRTristate
+
 from litex.soc.interconnect import wishbone
 
 from litex_wr_nic.gateware.wr_common         import (
@@ -57,7 +59,7 @@ class WhiteRabbitCore(LiteXModule):
         cpu_boot_loader   = None,
 
         # Board name.
-        board_name  = "NA  ",
+        board_name = "NA  ",
 
         # SFP.
         sfp_pads         = None,
@@ -83,13 +85,15 @@ class WhiteRabbitCore(LiteXModule):
         temp_1wire_pads = None,
 
         # Wishbone Slave.
-        wb_slave_size   = 0x0100_0000,
+        wb_slave_size = 0x0100_0000,
 
         dac_bits      = 16
     ):
 
         self.platform = platform
         self.cpu_bus  = None
+
+        # # #
 
         # Clks.
         # -----
@@ -169,8 +173,10 @@ class WhiteRabbitCore(LiteXModule):
         # -----------------------------
         # The host bus uses word addresses; the region size is in bytes.
         wb_slave_mask = (wb_slave_size // 4) - 1
-        self.wb_slave_sys = wb_slave_sys = wishbone.Interface(data_width=32, address_width=32, addressing="word")
-        self.wb_slave_wr  = wb_slave_wr  = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        self.wb_slave_sys = wb_slave_sys = wishbone.Interface(
+            data_width=32, address_width=32, addressing="word")
+        self.wb_slave_wr  = wb_slave_wr  = wishbone.Interface(
+            data_width=32, address_width=32, addressing="word")
         self.bus    = wb_slave_sys
         self.sink   = wrf_stream2wb.sink
         self.source = wrf_wb2stream.source
@@ -187,10 +193,10 @@ class WhiteRabbitCore(LiteXModule):
             temp_1wire_oe_n = Signal()
             temp_1wire_i    = Signal()
             self.specials += SDRTristate(
-                io = temp_1wire_pads,
-                o  = Constant(0b0, 1),
-                oe = ~temp_1wire_oe_n,
-                i  = temp_1wire_i,
+                io  = temp_1wire_pads,
+                o   = Constant(0b0, 1),
+                oe  = ~temp_1wire_oe_n,
+                i   = temp_1wire_i,
                 clk = ClockSignal("wr_sys"),
             )
 
@@ -427,7 +433,7 @@ def add_white_rabbit(soc, cpu_firmware, cpu_memory_region=None,
     soc.wr_core = core = WhiteRabbitCore(soc.platform,
         cpu_firmware    = cpu_firmware,
         with_cpu_memory = cpu_memory_region is not None,
-        wb_slave_size   = wb_slave_region.size_pow2,
+        wb_slave_size = wb_slave_region.size_pow2,
         **kwargs,
     )
     soc.bus.add_slave(name="wr_wb_slave", slave=core.bus, region=wb_slave_region)

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -1,0 +1,439 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2024 Warsaw University of Technology
+# Copyright (c) 2024 Enjoy-Digital <enjoy-digital.fr>
+# Copyright (c) 2022 Tongchen126 <https://github.com/tongchen126>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+
+from migen import *
+from migen.genlib.cdc import MultiReg
+
+from litex.gen import *
+from litex.build.io import SDRTristate
+from litex.soc.interconnect import wishbone
+
+from litex_wr_nic.gateware.wr_common         import (
+    wr_core_init,
+    wr_core_files,
+    patch_wr_subsystem_mux_class,
+    patch_wr_pps_gen_iob,
+    patch_wr_clock_monitor_presc_cdc,
+    patch_wr_external_cpu_memory,
+)
+from litex_wr_nic.gateware.wr_cpu            import (
+    WRCPUMemoryBridge,
+    WRCPUMemoryMonitor,
+    WRLiteXCPU,
+    resolve_wr_cpu_variant,
+    wr_cpu_word_bus,
+)
+from litex_wr_nic.gateware.wrf_stream2wb     import Stream2Wishbone
+from litex_wr_nic.gateware.wrf_wb2stream     import Wishbone2Stream
+from litex_wr_nic.gateware.wb_clock_crossing import WishboneClockCrossing
+
+# White Rabbit Core -------------------------------------------------------------------------------
+
+class WhiteRabbitCore(LiteXModule):
+    """White Rabbit without a NIC or a SoC address-map dependency.
+
+    ``bus`` is a word-addressed host slave and ``cpu_bus`` an optional
+    word-addressed memory master, both in ``sys``. ``sink``/``source`` carry
+    application Ethernet bytes in ``sys``. Control/fabric/DAC signals use
+    ``wr_sys``; PPS and timecode use ``wr`` (the PHY reference clock).
+    The caller supplies board pads and clocks and registers the bus regions.
+    """
+
+    def __init__(self, platform,
+        # CPU.
+        cpu_firmware,
+        cpu_type          = "urv",
+        cpu_variant       = None,
+        with_cpu_memory   = False,
+        cpu_memory_ready  = 1,
+        cpu_boot_loader   = None,
+
+        # Board name.
+        board_name  = "NA  ",
+
+        # SFP.
+        sfp_pads         = None,
+        sfp_i2c_pads     = None,
+        sfp_tx_polarity  = 0,
+        sfp_rx_polarity  = 0,
+        sfp_disable_pads = None,
+        sfp_fault_pads   = None,
+        sfp_los_pads     = None,
+        sfp_det_pads     = None,
+
+        # Clocking.
+        qpll         = None,
+        with_ext_clk = True,
+
+        # Serial.
+        serial_pads = None,
+
+        # Flash.
+        flash_pads = None,
+
+        # Temp 1Wire.
+        temp_1wire_pads = None,
+
+        # Wishbone Slave.
+        wb_slave_size   = 0x0100_0000,
+
+        dac_bits      = 16
+    ):
+
+        self.platform = platform
+        self.cpu_bus  = None
+
+        # Clks.
+        # -----
+        # Keep PPS/timecode in the PHY reference domain. The WR CPU, fabric,
+        # Wishbone and DAC commands run on the independent WR system clock.
+        self.cd_wr     = ClockDomain("wr")
+        self.cd_wr_sys = ClockDomain("wr_sys")
+
+        # Signals.
+        # --------
+        self.led_pps         = Signal()
+        self.led_link        = Signal()
+        self.led_act         = Signal()
+        self.dac_refclk_load = Signal()
+        self.dac_refclk_data = Signal(dac_bits)
+        self.dac_dmtd_load   = Signal()
+        self.dac_dmtd_data   = Signal(dac_bits)
+        self.pps_in          = Signal()
+        self.pps_out_valid   = Signal()
+        self.pps_out         = Signal()
+        self.pps_out_pulse   = Signal()
+        self.tm_link_up      = Signal()
+        self.tm_time_valid   = Signal()
+        self.tm_seconds      = Signal(40)
+        self.tm_cycles       = Signal(28)
+
+        # Optional WR CPU Memory Master.
+        # ------------------------------
+        cpu_variant         = resolve_wr_cpu_variant(cpu_type, cpu_variant)
+        external_cpu        = cpu_type != "urv"
+        external_cpu_memory = with_cpu_memory
+        if external_cpu and not external_cpu_memory:
+            raise ValueError(f"WR CPU type {cpu_type} requires external CPU memory.")
+
+        memory_ready_wr   = Signal(reset=not external_cpu_memory)
+        wr_cpu_bridge     = None
+        wr_cpu_peripheral = None
+        wr_cpu_irq        = Signal()
+        wr_cpu_reset      = Signal()
+        if external_cpu_memory:
+            if external_cpu:
+                self.wr_cpu = WRLiteXCPU(self.platform,
+                    cpu_type       = cpu_type,
+                    variant        = cpu_variant,
+                    irq            = wr_cpu_irq,
+                    software_reset = wr_cpu_reset,
+                    memory_ready   = memory_ready_wr,
+                )
+                wr_cpu_bus_wr     = self.wr_cpu.memory_bus
+                wr_cpu_bus_sys    = wishbone.Interface.like(wr_cpu_bus_wr)
+                wr_cpu_peripheral = self.wr_cpu.peripheral_bridge
+                self.wr_cpu_bridge = wr_cpu_bridge = WRCPUMemoryMonitor(monitor_bus=wr_cpu_bus_sys)
+            else:
+                wr_cpu_bus_sys = wishbone.Interface(
+                    data_width    = 32,
+                    address_width = 32,
+                    addressing    = "byte",
+                )
+                self.wr_cpu_bridge = wr_cpu_bridge = WRCPUMemoryBridge(monitor_bus=wr_cpu_bus_sys)
+                wr_cpu_bus_wr = wr_cpu_bridge.bus
+            self.submodules.wr_cpu_memory_cdc = WishboneClockCrossing(self.platform,
+                wb_from        = wr_cpu_bus_wr,
+                cd_from        = "wr_sys",
+                wb_to          = wr_cpu_bus_sys,
+                cd_to          = "sys",
+                timeout_cycles = 1024,
+            )
+            self.cpu_bus = wr_cpu_word_bus(self, wr_cpu_bus_sys)
+            self.specials += MultiReg(cpu_memory_ready, memory_ready_wr, "wr_sys")
+
+        # White Rabbit Fabric Interface.
+        # ------------------------------
+        self.wrf_stream2wb = wrf_stream2wb = Stream2Wishbone(  cd_to="wr_sys")
+        self.wrf_wb2stream = wrf_wb2stream = Wishbone2Stream(cd_from="wr_sys")
+
+        # White Rabbit Slave Interface.
+        # -----------------------------
+        wb_slave_mask = (wb_slave_size - 1)
+        self.wb_slave_sys = wb_slave_sys = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        self.wb_slave_wr  = wb_slave_wr  = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        self.bus    = wb_slave_sys
+        self.sink   = wrf_stream2wb.sink
+        self.source = wrf_wb2stream.source
+        self.submodules += WishboneClockCrossing(self.platform,
+            wb_from = wb_slave_sys,
+            cd_from = "sys",
+            wb_to   = wb_slave_wr,
+            cd_to   = "wr_sys",
+        )
+
+        # Temp 1-Wire Logic.
+        # ------------------
+        if temp_1wire_pads is not None:
+            temp_1wire_oe_n = Signal()
+            temp_1wire_i    = Signal()
+            self.specials += SDRTristate(
+                io = temp_1wire_pads,
+                o  = Constant(0b0, 1),
+                oe = ~temp_1wire_oe_n,
+                i  = temp_1wire_i,
+                clk = ClockSignal("wr_sys"),
+            )
+
+        # Flash Logic.
+        # ------------
+        if flash_pads is not None:
+            flash_clk     = Signal()
+            wr_flash_clk  = Signal()
+            wr_flash_cs   = Signal(reset=1)
+            wr_flash_mosi = Signal()
+            if cpu_boot_loader is None:
+                self.comb += [
+                    flash_clk.eq(wr_flash_clk),
+                    flash_pads.cs_n.eq(wr_flash_cs),
+                    flash_pads.mosi.eq(wr_flash_mosi),
+                ]
+            else:
+                self.comb += [
+                    cpu_boot_loader.miso.eq(flash_pads.miso),
+                    flash_clk.eq(Mux(cpu_boot_loader.owner,
+                        cpu_boot_loader.clk, wr_flash_clk)),
+                    flash_pads.cs_n.eq(Mux(cpu_boot_loader.owner,
+                        cpu_boot_loader.cs_n, wr_flash_cs)),
+                    flash_pads.mosi.eq(Mux(cpu_boot_loader.owner,
+                        cpu_boot_loader.mosi, wr_flash_mosi)),
+                ]
+            self.specials += Instance("STARTUPE2",
+                i_CLK       = 0,
+                i_GSR       = 0,
+                i_GTS       = 0,
+                i_KEYCLEARB = 0,
+                i_PACK      = 0,
+                i_USRCCLKO  = flash_clk,
+                i_USRCCLKTS = 0,
+                i_USRDONEO  = 1,
+                i_USRDONETS = 1,
+            )
+            # Keep optional WP#/HOLD# lines deasserted in 1-bit SPI mode.
+            if hasattr(flash_pads, "wp"):
+                self.comb += flash_pads.wp.eq(1)
+            if hasattr(flash_pads, "hold"):
+                self.comb += flash_pads.hold.eq(1)
+
+        # White Rabbit Core Instance.
+        # ---------------------------
+        self.specials += Instance("xwrc_board_litex_wr_nic_wrapper",
+            # Parameters.
+            p_g_dpram_initf               = os.path.abspath(cpu_firmware),
+            p_g_dpram_size                = 131072//4,
+            # Vivado binds quoted "FALSE" to true across the Verilog/VHDL
+            # boundary; use a numeric boolean for deterministic elaboration.
+            p_g_external_cpu_memory       = int(external_cpu_memory),
+            p_g_external_cpu              = int(external_cpu),
+            p_txpolarity                  = sfp_tx_polarity,
+            p_rxpolarity                  = sfp_rx_polarity,
+            p_g_with_external_clock_input = str(with_ext_clk).upper(),
+            p_g_fpga_family               = {True: "artix7", False: "kintex7"}[self.platform.device.startswith("xc7a")],
+            p_g_board_name                = board_name,
+            p_g_dac_bits                  = dac_bits,
+
+            # Clocks/resets.
+            i_areset_n_i          = ~ResetSignal("sys"),
+            i_clk_62m5_dmtd_i     = ClockSignal("clk_62m5_dmtd"),
+            i_clk_125m_gtp_i      = ClockSignal("clk_125m_gtp"),
+            i_clk_10m_ext_i       = ClockSignal("clk10m_in"),
+            o_clk_62m5_sys_o      = ClockSignal("wr_sys"),
+            o_rst_62m5_sys_o      = ResetSignal("wr_sys"),
+            o_clk_62m5_ref_o      = ClockSignal("wr"),
+            o_rst_62m5_ref_o      = ResetSignal("wr"),
+
+            # DAC RefClk Interface.
+            o_dac_refclk_load     = self.dac_refclk_load,
+            o_dac_refclk_data     = self.dac_refclk_data,
+
+            # DAC DMTD Interface.
+            o_dac_dmtd_load       = self.dac_dmtd_load,
+            o_dac_dmtd_data       = self.dac_dmtd_data,
+
+            # SFP Interface.
+            o_sfp_txp_o           = sfp_pads.txp,
+            o_sfp_txn_o           = sfp_pads.txn,
+            i_sfp_rxp_i           = sfp_pads.rxp,
+            i_sfp_rxn_i           = sfp_pads.rxn,
+            i_sfp_det_i           = 0      if sfp_det_pads is None else sfp_det_pads,
+            io_sfp_sda            = sfp_i2c_pads.sda,
+            io_sfp_scl            = sfp_i2c_pads.scl,
+            i_sfp_tx_fault_i      = 0      if   sfp_fault_pads is None else   sfp_fault_pads,
+            i_sfp_tx_los_i        = 0      if     sfp_los_pads is None else     sfp_los_pads,
+            o_sfp_tx_disable_o    = Open() if sfp_disable_pads is None else sfp_disable_pads,
+
+            # One-Wire Interface.
+            i_onewire_i           = 0      if temp_1wire_pads is None else temp_1wire_i,
+            o_onewire_oen_o       = Open() if temp_1wire_pads is None else temp_1wire_oe_n,
+
+            # UART Interface.
+            i_uart_rxd_i          = 1      if serial_pads is None else serial_pads.rx,
+            o_uart_txd_o          = Open() if serial_pads is None else serial_pads.tx,
+
+            # SPI Flash Interface.
+            o_spi_sclk_o          = Open() if flash_pads is None else wr_flash_clk,
+            o_spi_ncs_o           = Open() if flash_pads is None else wr_flash_cs,
+            o_spi_mosi_o          = Open() if flash_pads is None else wr_flash_mosi,
+            i_spi_miso_i          = 0      if flash_pads is None else flash_pads.miso,
+
+            # Optional WR CPU Memory Master.
+            o_cpu_mem_cyc_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.cyc,
+            o_cpu_mem_stb_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.stb,
+            o_cpu_mem_we_o        = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.we,
+            o_cpu_mem_adr_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.adr,
+            o_cpu_mem_sel_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.sel,
+            o_cpu_mem_dat_o       = Open() if not external_cpu_memory or external_cpu else wr_cpu_bridge.dat_w,
+            i_cpu_mem_dat_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.dat_r,
+            i_cpu_mem_ack_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.ack,
+            i_cpu_mem_err_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.err,
+            i_cpu_mem_rty_i       = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.rty,
+            i_cpu_mem_stall_i     = 0      if not external_cpu_memory or external_cpu else wr_cpu_bridge.stall,
+            i_cpu_mem_ready_i     = 1      if not external_cpu_memory else memory_ready_wr,
+
+            # Optional LiteX WR CPU peripheral master, interrupt and reset.
+            i_cpu_ext_cyc_i       = 0 if not external_cpu else wr_cpu_peripheral.cyc,
+            i_cpu_ext_stb_i       = 0 if not external_cpu else wr_cpu_peripheral.stb,
+            i_cpu_ext_we_i        = 0 if not external_cpu else wr_cpu_peripheral.we,
+            i_cpu_ext_adr_i       = 0 if not external_cpu else Cat(
+                Constant(0, 2), wr_cpu_peripheral.adr),
+            i_cpu_ext_sel_i       = 0 if not external_cpu else wr_cpu_peripheral.sel,
+            i_cpu_ext_dat_i       = 0 if not external_cpu else wr_cpu_peripheral.dat_w,
+            o_cpu_ext_dat_o       = Open() if not external_cpu else wr_cpu_peripheral.dat_r,
+            o_cpu_ext_ack_o       = Open() if not external_cpu else wr_cpu_peripheral.ack,
+            o_cpu_ext_err_o       = Open() if not external_cpu else wr_cpu_peripheral.err,
+            o_cpu_ext_rty_o       = Open() if not external_cpu else wr_cpu_peripheral.rty,
+            o_cpu_ext_stall_o     = Open() if not external_cpu else wr_cpu_peripheral.stall,
+            o_cpu_ext_irq_o       = Open() if not external_cpu else wr_cpu_irq,
+            o_cpu_ext_reset_o     = Open() if not external_cpu else wr_cpu_reset,
+
+            # PPS / Leds.
+            i_pps_ext_i           = self.pps_in,
+            o_pps_valid_o         = self.pps_out_valid,
+            o_pps_csync_o         = self.pps_out_pulse,
+            o_pps_p_o             = self.pps_out,
+            o_pps_led_o           = self.led_pps,
+            o_led_link_o          = self.led_link,
+            o_led_act_o           = self.led_act,
+
+            # QPLL Interface (for GTPE2_Common Sharing).
+            o_gt0_ext_qpll_reset  = Open() if qpll is None else qpll.get_channel("eth").reset,
+            i_gt0_ext_qpll_clk    = 0      if qpll is None else qpll.get_channel("eth").clk,
+            i_gt0_ext_qpll_refclk = 0      if qpll is None else qpll.get_channel("eth").refclk,
+            i_gt0_ext_qpll_lock   = 0      if qpll is None else qpll.get_channel("eth").lock,
+
+            # Wishbone Slave Interface (MMAP).
+            i_wb_slave_cyc        = wb_slave_wr.cyc,
+            i_wb_slave_stb        = wb_slave_wr.stb,
+            i_wb_slave_we         = wb_slave_wr.we,
+            i_wb_slave_adr        = Cat(Signal(2), (wb_slave_wr.adr & wb_slave_mask)),
+            i_wb_slave_sel        = wb_slave_wr.sel,
+            i_wb_slave_dat_i      = wb_slave_wr.dat_w,
+            o_wb_slave_dat_o      = wb_slave_wr.dat_r,
+            o_wb_slave_ack        = wb_slave_wr.ack,
+            o_wb_slave_err        = wb_slave_wr.err,
+            o_wb_slave_rty        = Open(),
+            o_wb_slave_stall      = Open(),
+
+            # Wishbone Fabric Source Interface.
+            o_wrf_src_adr         = wrf_wb2stream.bus.adr,
+            o_wrf_src_dat         = wrf_wb2stream.bus.dat_w,
+            o_wrf_src_cyc         = wrf_wb2stream.bus.cyc,
+            o_wrf_src_stb         = wrf_wb2stream.bus.stb,
+            o_wrf_src_we          = wrf_wb2stream.bus.we,
+            o_wrf_src_sel         = wrf_wb2stream.bus.sel,
+
+            i_wrf_src_ack         = wrf_wb2stream.bus.ack,
+            i_wrf_src_stall       = 0, # Not Used.
+            i_wrf_src_err         = wrf_wb2stream.bus.err,
+            i_wrf_src_rty         = 0, # Not Used.
+
+            # Wishbone Fabric Sink Interface.
+            i_wrf_snk_adr         = wrf_stream2wb.bus.adr,
+            i_wrf_snk_dat         = wrf_stream2wb.bus.dat_w,
+            i_wrf_snk_cyc         = wrf_stream2wb.bus.cyc,
+            i_wrf_snk_stb         = wrf_stream2wb.bus.stb,
+            i_wrf_snk_we          = wrf_stream2wb.bus.we,
+            i_wrf_snk_sel         = wrf_stream2wb.bus.sel,
+
+            o_wrf_snk_ack         = wrf_stream2wb.bus.ack,
+            o_wrf_snk_stall       = Open(), # Not Used.
+            o_wrf_snk_err         = wrf_stream2wb.bus.err,
+            o_wrf_snk_rty         = Open(), # Not Used.
+
+            # Time.
+            o_tm_link_up_o        = self.tm_link_up,
+            o_tm_time_valid_o     = self.tm_time_valid,
+            o_tm_tai_o            = self.tm_seconds,
+            o_tm_cycles_o         = self.tm_cycles,
+        )
+
+    @staticmethod
+    def add_sources(platform):
+        if not os.path.exists("wr-cores"):
+            wr_core_init()
+        patch_wr_subsystem_mux_class()
+        patch_wr_pps_gen_iob()
+        patch_wr_clock_monitor_presc_cdc()
+        patch_wr_external_cpu_memory()
+        for filename in wr_core_files:
+            platform.add_source(filename)
+
+# SoC Integration ---------------------------------------------------------------------------------
+
+def add_white_rabbit(soc, cpu_firmware, cpu_memory_region=None,
+    wb_slave_origin=0x2000_0000, wb_slave_size=0x0100_0000, **kwargs):
+    """Attach the standalone core, preserving the original target attributes.
+
+    New integrations can instantiate WhiteRabbitCore directly to choose their
+    own hierarchy and CSR names. This adapter retains the existing names used
+    by the NIC targets and their host software.
+    """
+    from litex.soc.integration.soc import SoCRegion
+
+    if hasattr(soc, "wr_core"):
+        raise ValueError("White Rabbit is already attached to this SoC.")
+    soc.wr_core = core = WhiteRabbitCore(soc.platform,
+        cpu_firmware    = cpu_firmware,
+        with_cpu_memory = cpu_memory_region is not None,
+        wb_slave_size   = wb_slave_size,
+        **kwargs,
+    )
+    soc.bus.add_slave(name="wr_wb_slave", slave=core.bus, region=SoCRegion(
+        origin = wb_slave_origin,
+        size   = wb_slave_size,
+    ))
+    if core.cpu_bus is not None:
+        soc.bus.add_master(name="wr_cpu", master=core.cpu_bus, region=cpu_memory_region)
+
+    # Aliases must not register the same Migen module twice. Exclude the nested
+    # CSR traversal so legacy register names keep a single owner.
+    soc.autocsr_exclude = set(getattr(soc, "autocsr_exclude", ())) | {"wr_core"}
+    for name in (
+        "cd_wr", "cd_wr_sys", "wr_cpu", "wr_cpu_bridge", "wr_cpu_memory_cdc",
+        "wrf_stream2wb", "wrf_wb2stream", "wb_slave_sys", "wb_slave_wr",
+        "led_pps", "led_link", "led_act", "dac_refclk_load", "dac_refclk_data",
+        "dac_dmtd_load", "dac_dmtd_data", "pps_in", "pps_out_valid", "pps_out",
+        "pps_out_pulse", "tm_link_up", "tm_time_valid", "tm_seconds", "tm_cycles",
+    ):
+        if hasattr(core, name):
+            object.__setattr__(soc, name, getattr(core, name))
+            if hasattr(getattr(core, name), "get_csrs"):
+                core.autocsr_exclude = set(getattr(core, "autocsr_exclude", ())) | {name}
+    return core

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -44,6 +44,7 @@ class WhiteRabbitCore(LiteXModule):
     application Ethernet bytes in ``sys``. Control/fabric/DAC signals use
     ``wr_sys``; PPS and timecode use ``wr`` (the PHY reference clock).
     The caller supplies board pads and clocks and registers the bus regions.
+    HDL sources are registered automatically during finalization.
     """
 
     def __init__(self, platform,
@@ -166,7 +167,8 @@ class WhiteRabbitCore(LiteXModule):
 
         # White Rabbit Slave Interface.
         # -----------------------------
-        wb_slave_mask = (wb_slave_size - 1)
+        # The host bus uses word addresses; the region size is in bytes.
+        wb_slave_mask = (wb_slave_size // 4) - 1
         self.wb_slave_sys = wb_slave_sys = wishbone.Interface(data_width=32, address_width=32, addressing="word")
         self.wb_slave_wr  = wb_slave_wr  = wishbone.Interface(data_width=32, address_width=32, addressing="word")
         self.bus    = wb_slave_sys
@@ -384,8 +386,15 @@ class WhiteRabbitCore(LiteXModule):
             o_tm_cycles_o         = self.tm_cycles,
         )
 
+    def do_finalize(self):
+        self.add_sources(self.platform)
+
     @staticmethod
     def add_sources(platform):
+        # Keep explicit calls from older integrations harmless when the core
+        # subsequently registers its sources during finalization.
+        if getattr(platform, "_wr_core_sources_added", False):
+            return
         if not os.path.exists("wr-cores"):
             wr_core_init()
         patch_wr_subsystem_mux_class()
@@ -394,31 +403,34 @@ class WhiteRabbitCore(LiteXModule):
         patch_wr_external_cpu_memory()
         for filename in wr_core_files:
             platform.add_source(filename)
+        platform._wr_core_sources_added = True
 
 # SoC Integration ---------------------------------------------------------------------------------
 
 def add_white_rabbit(soc, cpu_firmware, cpu_memory_region=None,
-    wb_slave_origin=0x2000_0000, wb_slave_size=0x0100_0000, **kwargs):
+    wb_slave_origin=0x2000_0000, wb_slave_size=0x0100_0000, wb_slave_region=None, **kwargs):
     """Attach the standalone core, preserving the original target attributes.
 
     New integrations can instantiate WhiteRabbitCore directly to choose their
     own hierarchy and CSR names. This adapter retains the existing names used
     by the NIC targets and their host software.
+
+    wb_slave_region supplies the host mapping and overrides the legacy
+    wb_slave_origin/wb_slave_size arguments when provided.
     """
     from litex.soc.integration.soc import SoCRegion
 
     if hasattr(soc, "wr_core"):
         raise ValueError("White Rabbit is already attached to this SoC.")
+    if wb_slave_region is None:
+        wb_slave_region = SoCRegion(origin=wb_slave_origin, size=wb_slave_size)
     soc.wr_core = core = WhiteRabbitCore(soc.platform,
         cpu_firmware    = cpu_firmware,
         with_cpu_memory = cpu_memory_region is not None,
-        wb_slave_size   = wb_slave_size,
+        wb_slave_size   = wb_slave_region.size_pow2,
         **kwargs,
     )
-    soc.bus.add_slave(name="wr_wb_slave", slave=core.bus, region=SoCRegion(
-        origin = wb_slave_origin,
-        size   = wb_slave_size,
-    ))
+    soc.bus.add_slave(name="wr_wb_slave", slave=core.bus, region=wb_slave_region)
     if core.cpu_bus is not None:
         soc.bus.add_master(name="wr_cpu", master=core.cpu_bus, region=cpu_memory_region)
 

--- a/litex_wr_nic/integration.py
+++ b/litex_wr_nic/integration.py
@@ -4,9 +4,9 @@
 # Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-import hashlib
 import os
 import re
+import hashlib
 import subprocess
 from pathlib import Path
 
@@ -21,11 +21,11 @@ WR_NIC_DIR_CANDIDATE_PATTERNS = (
 
 WR_FIRMWARE_BUILD_SCRIPT_REL = os.path.join("firmware", "build.py")
 WR_FIRMWARE_IMAGE_REL        = os.path.join("firmware", "spec_a7_wrc.bram")
-WR_COMMON_REL                = os.path.join("gateware", "wr_common.py")
+WR_COMMON_REL               = os.path.join("gateware", "wr_common.py")
 
 WR_CORES_DIRNAME        = "wr-cores"
 WR_SUBSYSTEM_VHD_REL    = os.path.join("modules", "wrc_core", "xwr_subsystem.vhd")
-WR_PATCHED_SIGNATURE    = 'mux_class_i(1) => x"ff");'
+WR_PATCHED_SIGNATURE   = 'mux_class_i(1) => x"ff");'
 
 WR_CORES_RENAME_HINT      = "Rename/remove local wr-cores (for example: 'mv wr-cores wr-cores.old') and rerun."
 WR_CORES_INIT_RENAME_HINT = "Rename/remove it (for example: 'mv wr-cores wr-cores.old') and rerun so the expected WR-cores can be initialized."

--- a/litex_wr_nic/integration.py
+++ b/litex_wr_nic/integration.py
@@ -78,11 +78,11 @@ def _get_available_sfps_for_variant(variant, baseboard_io):
     })
 
 
-def _resolve_firmware_output_path(wr_nic_dir, wr_firmware):
+def _resolve_firmware_output_path(wr_nic_dir, wr_firmware, cpu_type="urv"):
     if wr_firmware:
         return os.path.abspath(wr_firmware)
     if wr_nic_dir:
-        return os.path.join(wr_nic_dir, WR_FIRMWARE_IMAGE_REL)
+        return os.path.join(wr_nic_dir, _firmware_image(cpu_type))
     return None
 
 
@@ -117,7 +117,12 @@ def _normalize_wr_nic_dir(wr_nic_dir):
 # Public API ---------------------------------------------------------------------------------------
 
 
-def resolve_wr_paths(root_dir, wr_nic_dir=None, wr_firmware=None):
+def _firmware_image(cpu_type):
+    from litex_wr_nic.gateware.wr_cpu import wr_cpu_firmware_filename
+    return os.path.join("firmware", wr_cpu_firmware_filename(cpu_type, "bram"))
+
+
+def resolve_wr_paths(root_dir, wr_nic_dir=None, wr_firmware=None, cpu_type="urv"):
     wr_nic_dir = _normalize_wr_nic_dir(wr_nic_dir)
 
     if wr_nic_dir is None:
@@ -128,25 +133,27 @@ def resolve_wr_paths(root_dir, wr_nic_dir=None, wr_firmware=None):
                 break
 
     if wr_firmware is None and wr_nic_dir:
-        candidate = os.path.join(wr_nic_dir, WR_FIRMWARE_IMAGE_REL)
+        candidate = os.path.join(wr_nic_dir, _firmware_image(cpu_type))
         if os.path.isfile(candidate):
             wr_firmware = candidate
 
     return wr_nic_dir, wr_firmware
 
 
-def build_wr_firmware(wr_nic_dir, wr_firmware, wr_firmware_target, enforce_fresh=True):
+def build_wr_firmware(wr_nic_dir, wr_firmware, wr_firmware_target, enforce_fresh=True, cpu_type="urv"):
     if wr_nic_dir is None and wr_firmware is None:
         raise ValueError(ERR_NO_WR_FIRMWARE_PATH)
 
     firmware_dir = os.path.dirname(os.path.abspath(wr_firmware)) if wr_firmware else os.path.join(wr_nic_dir, "firmware")
     build_script = os.path.join(firmware_dir, os.path.basename(WR_FIRMWARE_BUILD_SCRIPT_REL))
-    firmware_out = _resolve_firmware_output_path(wr_nic_dir, wr_firmware)
+    firmware_out = _resolve_firmware_output_path(wr_nic_dir, wr_firmware, cpu_type)
 
     before = _fingerprint_file(firmware_out) if firmware_out else _fingerprint_file("")
 
     print(f"Building White Rabbit firmware in {firmware_dir}...")
-    result = subprocess.run([build_script, "--target", wr_firmware_target], cwd=firmware_dir)
+    result = subprocess.run([
+        build_script, "--target", wr_firmware_target, "--wr-cpu-type", cpu_type,
+    ], cwd=firmware_dir)
     if result.returncode != 0:
         raise RuntimeError(ERR_WR_FIRMWARE_BUILD_FAIL)
 
@@ -291,8 +298,14 @@ def prepare_wr_environment(*,
     wr_firmware_target,
     build,
     status,
+    wr_cpu_type    = "urv",
+    wr_cpu_variant = None,
+    wr_cpu_memory  = "private",
 ):
+    from litex_wr_nic.gateware.wr_cpu import validate_wr_cpu_config
+    wr_cpu_variant = validate_wr_cpu_config(wr_cpu_type, wr_cpu_variant, wr_cpu_memory)
     wr_nic_dir, wr_firmware = resolve_wr_paths(
+        cpu_type    = wr_cpu_type,
         root_dir    = root_dir,
         wr_nic_dir  = wr_nic_dir,
         wr_firmware = wr_firmware,
@@ -320,9 +333,11 @@ def prepare_wr_environment(*,
                 wr_nic_dir         = wr_nic_dir,
                 wr_firmware        = wr_firmware,
                 wr_firmware_target = wr_firmware_target,
+                cpu_type           = wr_cpu_type,
                 enforce_fresh      = False,
             )
             _, wr_firmware = resolve_wr_paths(
+                cpu_type    = wr_cpu_type,
                 root_dir    = root_dir,
                 wr_nic_dir  = wr_nic_dir,
                 wr_firmware = wr_firmware,
@@ -333,6 +348,7 @@ def prepare_wr_environment(*,
                 wr_nic_dir         = wr_nic_dir,
                 wr_firmware        = wr_firmware,
                 wr_firmware_target = wr_firmware_target,
+                cpu_type           = wr_cpu_type,
                 enforce_fresh      = True,
             )
 
@@ -368,6 +384,9 @@ def prepare_wr_environment(*,
         )
 
     return {
+        "wr_cpu_type"    : wr_cpu_type,
+        "wr_cpu_variant" : wr_cpu_variant,
+        "wr_cpu_memory"  : wr_cpu_memory,
         "wr_nic_dir"     : wr_nic_dir,
         "wr_firmware"    : wr_firmware,
         "wr_sfp"         : resolved_wr_sfp,

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -323,7 +323,6 @@ class BaseSoC(LiteXWRNICSoC):
                 # Temp 1Wire.
                 temp_1wire_pads  = platform.request("temp_1wire"),
             )
-            self.add_sources()
 
             # Pads.
             # -----

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -3,6 +3,7 @@
 import pytest
 
 from litex_wr_nic.integration import (
+    build_wr_firmware,
     prepare_wr_environment,
     preflight_wr_cores,
     resolve_wr_paths,
@@ -85,3 +86,24 @@ def test_prepare_wr_environment_status_only_prints(capsys, tmp_path):
     captured = capsys.readouterr()
     assert "White Rabbit status:" in captured.out
     assert wr_env["wr_sfp"] is None
+
+
+def test_vexriscv_firmware_selection_and_build(tmp_path, monkeypatch):
+    firmware = tmp_path / "firmware"
+    firmware.mkdir()
+    (firmware / "build.py").touch()
+    (firmware / "spec_a7_wrc.bram").write_text("urv")
+    image = firmware / "spec_a7_wrc_vexriscv.bram"
+    image.write_text("vexriscv")
+    directory, selected = resolve_wr_paths(str(tmp_path), str(tmp_path), cpu_type="vexriscv")
+    assert selected == str(image)
+    commands = []
+
+    def run(command, **kwargs):
+        from types import SimpleNamespace
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("litex_wr_nic.integration.subprocess.run", run)
+    build_wr_firmware(directory, selected, "acorn", enforce_fresh=False, cpu_type="vexriscv")
+    assert commands == [[str(firmware / "build.py"), "--target", "acorn", "--wr-cpu-type", "vexriscv"]]

--- a/test/test_wr_clock_domains.py
+++ b/test/test_wr_clock_domains.py
@@ -8,6 +8,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from migen import ClockDomain, ClockSignal, Instance, Record, run_simulation
 from migen.fhdl.structure import _Assign
 
@@ -16,8 +18,15 @@ from litex.gen import LiteXModule
 from litex.soc.integration.soc import SoCRegion
 
 from litex_wr_nic.gateware.soc import LiteXWRNICSoC
+from litex_wr_nic.gateware.wr_core import WhiteRabbitCore
 
 # WR Clock Domain Tests ----------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def skip_hdl_sources(monkeypatch):
+    # These simulations replace the WR HDL instance with bus response models.
+    monkeypatch.setattr(WhiteRabbitCore, "add_sources", staticmethod(lambda platform: None))
+
 
 def test_wr_interfaces_without_phy_clock():
     dut          = LiteXModule()

--- a/test/test_wr_core.py
+++ b/test/test_wr_core.py
@@ -15,12 +15,14 @@ import pytest
 from migen import Instance, Record, Signal, run_simulation
 
 from litex.gen import LiteXModule
-from litex.soc.integration.soc import SoCRegion
+
 from litex.soc.interconnect.csr_bus import CSRBankArray
+from litex.soc.integration.soc import SoCRegion
 
-from litex_wr_nic.gateware.wr_core import WhiteRabbitCore, add_white_rabbit
 from litex_wr_nic.gateware import wr_core
+from litex_wr_nic.gateware.wr_core import WhiteRabbitCore, add_white_rabbit
 
+# Helpers ------------------------------------------------------------------------------------------
 
 def core_kwargs():
     return dict(
@@ -32,16 +34,21 @@ def core_kwargs():
 
 @pytest.fixture
 def platform(monkeypatch):
-    sources = []
+    sources  = []
     prepared = []
     for name in (
         "wr_core_init", "patch_wr_subsystem_mux_class", "patch_wr_pps_gen_iob",
         "patch_wr_clock_monitor_presc_cdc", "patch_wr_external_cpu_memory",
     ):
         monkeypatch.setattr(wr_core, name, lambda name=name: prepared.append(name))
-    return SimpleNamespace(device="xc7a50t", add_source=sources.append,
-        sources=sources, prepared=prepared)
+    return SimpleNamespace(
+        device     = "xc7a50t",
+        add_source = sources.append,
+        sources    = sources,
+        prepared   = prepared,
+    )
 
+# Reusable Core Tests ------------------------------------------------------------------------------
 
 def test_core_import_has_no_nic_or_soc_side_effects():
     # Use a fresh interpreter: other tests import the compatibility NIC class.
@@ -153,13 +160,13 @@ def test_documented_cpu_setups_elaborate(platform, monkeypatch, tmp_path, cpu_ty
     from spec_a7_platform import Platform
 
     documentation = Path(__file__).resolve().parents[1] / "doc/wr_integration.md"
-    example = documentation.read_text().split("## " + section + "\n", 1)[1]
-    code = example.split("```python\n", 1)[1].split("```", 1)[0]
+    example = documentation.read_text(encoding="utf-8").split("## " + section + "\n", 1)[1]
+    code    = example.split("```python\n", 1)[1].split("```", 1)[0]
     monkeypatch.chdir(tmp_path)
     firmware = tmp_path / "litex_wr_nic/firmware"
     firmware.mkdir(parents=True)
     stem = "spec_a7_wrc" + ("_vexriscv" if cpu_type == "vexriscv" else "")
-    (firmware / (stem + ".bram")).write_text("00000013\n")
+    (firmware / (stem + ".bram")).write_text("00000013\n", encoding="utf-8")
     (firmware / (stem + ".bin")).write_bytes(bytes.fromhex("13000000"))
     soc = SoCMini(Platform(), clk_freq=125e6, ident_version=False)
     exec(compile(code, str(documentation), "exec"), {"self": soc})

--- a/test/test_wr_core.py
+++ b/test/test_wr_core.py
@@ -1,0 +1,79 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import sys
+import subprocess
+from types import SimpleNamespace
+
+from migen import Instance, Record
+
+from litex.gen import LiteXModule
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.interconnect.csr_bus import CSRBankArray
+
+from litex_wr_nic.gateware.wr_core import WhiteRabbitCore, add_white_rabbit
+
+
+def core_kwargs():
+    return dict(
+        cpu_firmware = "unused.bram",
+        sfp_pads     = Record([(name, 1) for name in ("txp", "txn", "rxp", "rxn")]),
+        sfp_i2c_pads = Record([("sda", 1), ("scl", 1)]),
+    )
+
+
+def test_core_import_has_no_nic_or_soc_side_effects():
+    # Use a fresh interpreter: other tests import the compatibility NIC class.
+    script = """
+import sys
+from litex.soc.integration.soc_core import SoCMini
+before = (dict(SoCMini.csr_map), dict(SoCMini.mem_map))
+from litex_wr_nic.gateware.wr_core import WhiteRabbitCore
+assert 'liteeth.mac.sram' not in sys.modules
+assert 'litepcie.frontend.ptm' not in sys.modules
+from litex_wr_nic.gateware.soc import LiteXWRNICSoC
+assert before == (SoCMini.csr_map, SoCMini.mem_map)
+"""
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
+    subprocess.run([sys.executable, "-c", script], env=env, check=True)
+
+
+def test_standalone_core_interfaces():
+    core = WhiteRabbitCore(SimpleNamespace(device="xc7a50t"), **core_kwargs())
+    assert core.bus.addressing == "word"
+    assert core.cpu_bus is None
+    assert core.sink is core.wrf_stream2wb.sink
+    assert core.source is core.wrf_wb2stream.source
+    fragment = core.get_fragment()
+    instances = [s for s in fragment.specials if isinstance(s, Instance)]
+    assert len(instances) == 1
+    uart = next(item.expr for item in instances[0].items if item.name == "uart_rxd_i")
+    assert uart.value == 1
+
+
+def test_compatibility_adapter_registers_memory_and_csrs_once():
+    soc          = LiteXModule()
+    soc.platform = SimpleNamespace(device="xc7a50t")
+    masters      = {}
+    slaves       = {}
+    soc.bus = SimpleNamespace(
+        add_master = lambda **kwargs: masters.update(kwargs),
+        add_slave  = lambda **kwargs: slaves.update(kwargs),
+    )
+    region = SoCRegion(origin=0x50000000, size=128*1024)
+    core = add_white_rabbit(soc, cpu_memory_region=region, **core_kwargs())
+    assert masters["region"] is region
+    assert masters["master"] is core.cpu_bus
+    assert slaves["slave"] is core.bus
+    banks = CSRBankArray(soc, lambda name, memory: 5)
+    assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge"]
+    assert [csr.name for csr in banks.banks[0][1]] == [
+        "status", "error_count", "last_error_address",
+    ]
+    fragment = soc.get_fragment()
+    assert sum(isinstance(s, Instance) and s.of == "xwrc_board_litex_wr_nic_wrapper"
+        for s in fragment.specials) == 1

--- a/test/test_wr_core.py
+++ b/test/test_wr_core.py
@@ -7,15 +7,19 @@
 import os
 import sys
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
-from migen import Instance, Record
+import pytest
+
+from migen import Instance, Record, Signal, run_simulation
 
 from litex.gen import LiteXModule
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.interconnect.csr_bus import CSRBankArray
 
 from litex_wr_nic.gateware.wr_core import WhiteRabbitCore, add_white_rabbit
+from litex_wr_nic.gateware import wr_core
 
 
 def core_kwargs():
@@ -24,6 +28,19 @@ def core_kwargs():
         sfp_pads     = Record([(name, 1) for name in ("txp", "txn", "rxp", "rxn")]),
         sfp_i2c_pads = Record([("sda", 1), ("scl", 1)]),
     )
+
+
+@pytest.fixture
+def platform(monkeypatch):
+    sources = []
+    prepared = []
+    for name in (
+        "wr_core_init", "patch_wr_subsystem_mux_class", "patch_wr_pps_gen_iob",
+        "patch_wr_clock_monitor_presc_cdc", "patch_wr_external_cpu_memory",
+    ):
+        monkeypatch.setattr(wr_core, name, lambda name=name: prepared.append(name))
+    return SimpleNamespace(device="xc7a50t", add_source=sources.append,
+        sources=sources, prepared=prepared)
 
 
 def test_core_import_has_no_nic_or_soc_side_effects():
@@ -42,8 +59,8 @@ assert before == (SoCMini.csr_map, SoCMini.mem_map)
     subprocess.run([sys.executable, "-c", script], env=env, check=True)
 
 
-def test_standalone_core_interfaces():
-    core = WhiteRabbitCore(SimpleNamespace(device="xc7a50t"), **core_kwargs())
+def test_standalone_core_interfaces(platform):
+    core = WhiteRabbitCore(platform, **core_kwargs())
     assert core.bus.addressing == "word"
     assert core.cpu_bus is None
     assert core.sink is core.wrf_stream2wb.sink
@@ -55,9 +72,9 @@ def test_standalone_core_interfaces():
     assert uart.value == 1
 
 
-def test_compatibility_adapter_registers_memory_and_csrs_once():
+def test_compatibility_adapter_registers_memory_and_csrs_once(platform):
     soc          = LiteXModule()
-    soc.platform = SimpleNamespace(device="xc7a50t")
+    soc.platform = platform
     masters      = {}
     slaves       = {}
     soc.bus = SimpleNamespace(
@@ -69,6 +86,8 @@ def test_compatibility_adapter_registers_memory_and_csrs_once():
     assert masters["region"] is region
     assert masters["master"] is core.cpu_bus
     assert slaves["slave"] is core.bus
+    assert slaves["region"].origin == 0x20000000
+    assert slaves["region"].size == 0x01000000
     banks = CSRBankArray(soc, lambda name, memory: 5)
     assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge"]
     assert [csr.name for csr in banks.banks[0][1]] == [
@@ -77,3 +96,80 @@ def test_compatibility_adapter_registers_memory_and_csrs_once():
     fragment = soc.get_fragment()
     assert sum(isinstance(s, Instance) and s.of == "xwrc_board_litex_wr_nic_wrapper"
         for s in fragment.specials) == 1
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+def test_sources_are_automatic_and_explicit_calls_are_idempotent(platform, monkeypatch, tmp_path, explicit):
+    monkeypatch.chdir(tmp_path)
+    core = WhiteRabbitCore(platform, **core_kwargs())
+    assert platform.sources == []
+    if explicit:
+        WhiteRabbitCore.add_sources(platform)
+    core.get_fragment()
+    assert platform.sources == list(wr_core.wr_core_files)
+    assert len(platform.prepared) == 5
+    assert platform.prepared[0] == "wr_core_init"
+    WhiteRabbitCore.add_sources(platform)
+    assert platform.sources == list(wr_core.wr_core_files)
+    assert len(platform.prepared) == 5
+
+
+@pytest.mark.parametrize("size", [0x100000, 0x60000])
+def test_host_region_preserves_attributes_and_decodes_local_addresses(platform, size):
+    soc          = LiteXModule()
+    soc.platform = platform
+    slaves       = {}
+    soc.bus      = SimpleNamespace(add_slave=lambda **kwargs: slaves.update(kwargs))
+    region = SoCRegion(origin=0x20100000, size=size, mode="rw", cached=False)
+    core = add_white_rabbit(soc, wb_slave_region=region, **core_kwargs())
+    assert slaves["region"] is region
+    assert slaves["slave"] is core.bus
+
+    # Check the address actually presented to WR, including a base that is
+    # aligned to the decoded region but not to four times that region.
+    fragment = core.get_fragment()
+    instance = next(s for s in fragment.specials
+        if isinstance(s, Instance) and s.of == "xwrc_board_litex_wr_nic_wrapper")
+    address = next(item.expr for item in instance.items if item.name == "wb_slave_adr")
+    dut = LiteXModule()
+    local_address = Signal(32)
+    dut.comb += local_address.eq(address)
+
+    def check():
+        for offset in (0, 4, 0x20b00, region.size_pow2 - 4):
+            yield core.wb_slave_wr.adr.eq((region.origin + offset) // 4)
+            yield
+            assert (yield local_address) == offset
+
+    run_simulation(dut, check())
+
+
+@pytest.mark.parametrize("cpu_type, section", [
+    ("urv", "uRV with private RAM"),
+    ("vexriscv", "VexRiscv with integrated RAM"),
+])
+def test_documented_cpu_setups_elaborate(platform, monkeypatch, tmp_path, cpu_type, section):
+    from litex.soc.integration.soc_core import SoCMini
+    from spec_a7_platform import Platform
+
+    documentation = Path(__file__).resolve().parents[1] / "doc/wr_integration.md"
+    example = documentation.read_text().split("## " + section + "\n", 1)[1]
+    code = example.split("```python\n", 1)[1].split("```", 1)[0]
+    monkeypatch.chdir(tmp_path)
+    firmware = tmp_path / "litex_wr_nic/firmware"
+    firmware.mkdir(parents=True)
+    stem = "spec_a7_wrc" + ("_vexriscv" if cpu_type == "vexriscv" else "")
+    (firmware / (stem + ".bram")).write_text("00000013\n")
+    (firmware / (stem + ".bin")).write_bytes(bytes.fromhex("13000000"))
+    soc = SoCMini(Platform(), clk_freq=125e6, ident_version=False)
+    exec(compile(code, str(documentation), "exec"), {"self": soc})
+    soc.finalize()
+    assert soc.bus.regions["wr_wb_slave"].cached is False
+    assert soc.platform._wr_core_sources_added
+    if cpu_type == "vexriscv":
+        assert soc.wr_core.cpu_bus is not None
+        assert soc.bus.regions["wr_cpu_mem"].origin == 0x50000000
+        assert "wr_cpu" in soc.bus.masters
+    else:
+        assert soc.wr_core.cpu_bus is None
+        assert "wr_cpu" not in soc.bus.masters


### PR DESCRIPTION
White Rabbit integration currently requires methods on the NIC SoC and changes `SoCMini` class maps at import time. Extract `WhiteRabbitCore(LiteXModule)` with explicit host, CPU-memory, application-stream, timing and oscillator-control interfaces. Existing targets keep `add_wr_core`, their public attributes, and their CSR/memory maps through a compatibility adapter.

The core registers its HDL sources automatically in `do_finalize()`. The three board targets no longer need an explicit source-registration call; historical explicit calls remain supported and register sources only once per platform. `add_white_rabbit(soc, ...)` accepts a `wb_slave_region=SoCRegion(...)`, preserves its attributes, and registers the host slave and optional CPU memory master. The legacy origin/size arguments remain supported. Local WR address masking now uses word units and LiteX's rounded decode size, including when a custom host region is supplied.

`doc/wr_integration.md` includes executable uRV/private-RAM and VexRiscv/integrated-RAM examples, matching firmware build commands, memory initialization/readiness, board requirements, and direct-component usage. CPU-aware firmware preparation selects the matching firmware profile. An unused UART input is held at its idle level.

Depends on #81, which carries the already-reviewed #68 changes to main; first part of the WR flexibility series. The existing Xilinx 7-series WR board wrapper remains the hardware backend.

Validation:
- All 46 tests on this branch pass, including actual uRV execution in XSim. Six added cases cover automatic/legacy source registration, custom host address decoding, and execution of both documented CPU setup examples through real LiteX SoC finalization.
- The rebased complete stack passes all 87 tests with no skips. All 11 focused core/clock integration tests also pass separately on each intermediate branch #73–#79.
- SPEC-A7 uRV/private and VexRiscv/integrated elaboration pass. The full stack also elaborates for SPEC-A7 uRV/private and VexRiscv/HyperRAM host boot, Acorn VexRiscv/integrated, and HyVision uRV/private.
- CSR addresses, memory maps and configuration constants match the prior SPEC-A7 images for #72 VexRiscv/integrated and the final-stack uRV/private and VexRiscv/HyperRAM configurations, excluding generated timestamps/build identifiers.
- Vivado 2024.1 synthesis of the updated #72 SPEC-A7 VexRiscv/integrated design verifies automatic registration of the required HDL sources.
- Existing hardware evidence at `3a908c0`: Vivado implementation met timing (WNS +0.029 ns, WHS +0.028 ns); two SPEC-A7 reloads, CSR-console uptime/time, continued execution and CPU restart passed with zero memory errors. The subsequent integration/API refinement was checked with the tests, elaborations and synthesis above; no new bitstream was loaded for this refinement. #73 fixes the original small crossover FIFO's truncation of long console replies.
- No SFP/WR reference peer is connected, so these checks do not qualify WR servo/PPS accuracy.

LiteX style review (2026-09-08): Aligned the reusable core, imports and integration-test fixtures with LiteX conventions; text fixtures use explicit UTF-8. All 46 branch tests pass. The complete stack passes 87 tests. Six target elaborations preserve the existing CSR/memory/configuration maps, excluding generated build identifiers; management and MMCM status field widths/offsets are unchanged. This cleanup was checked in software/simulation and elaboration; the hardware/timing evidence above comes from the previously qualified bitstreams.
