### PR TITLE
wr: add common host management and live diagnostics

### DIFF
--- a/doc/wr_management.md
+++ b/doc/wr_management.md
@@ -1,0 +1,56 @@
+# Managing White Rabbit
+
+Install the package with `pip install -e .` to get `litex_wr`, or run
+`python3 -m litex_wr_nic.wr` directly from this checkout. Start `litex_server`
+with your usual JTAGBone, UARTBone, Etherbone or PCIe transport, and use the
+`csr.csv` generated with the **loaded bitstream**:
+
+```sh
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv status
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv console
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv console --command ver
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv diagnose
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv restart
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv load-firmware \
+    litex_wr_nic/firmware/spec_a7_wrc_vexriscv.bin --firmware-cpu vexriscv
+```
+
+Use `--host` and `--port` for a remote server. Transport selection belongs to
+`litex_server`; the management commands use the same interface for all of them.
+`--wr-region`, `--memory-region` and `--uart-prefix` support custom integration
+names. The default regions are `wr_wb_slave` and `wr_cpu_mem`.
+
+The console selects UARTShared's crossover port while it is open and restores
+the previous selection on exit. Exit with **Ctrl-]**. Scripted commands wait
+for `wrc#`; input is paced for the WRPC polling UART. A separate UARTBone path
+must be used if the physical WR console and bridge would share the same pins.
+
+`status` reads the live WR configuration signature, CPU selection, memory mode,
+memory readiness, link/time-valid flags and host reset diagnostics. It also
+prints available boot-loader and memory-bridge diagnostic registers. The
+SHA-256 identifies the BRAM firmware file supplied **at FPGA build time**;
+it does not claim to identify a later host-loaded image. Reset reason/count
+cover system reset and writes to the WR host CPU reset register, not a
+firmware watchdog. `diagnose` additionally exercises `ver`, `uptime` and
+`time` through the console. An operational console does not establish WR
+servo lock or PPS accuracy.
+
+Older #67/#68 bitstreams have no live information bank. Private memory implies
+uRV; for external memory supply `--cpu-type urv` or `--cpu-type vexriscv` before
+the command. New bitstreams reject a CPU selection that conflicts with the
+live configuration.
+
+Firmware upload checks the declared CPU profile and size before stopping the
+CPU, zero-fills the reserved memory, writes the image, verifies every word,
+then releases reset. A failed verification leaves the CPU held in reset.
+Private uRV uses the WR host memory window's big-endian word convention;
+SoC memory uses little-endian words. Host writes use the shared memory path,
+including the HyperRAM cache; do not write directly to its backing storage.
+The VexRiscv instruction cache is reset with the CPU before a reload.
+
+For uRV, `restart` and upload request a debug halt and wait for acknowledgement
+before asserting reset. This avoids the intermittent early direct-reset hang
+also observed on the upstream private-memory implementation. A halt timeout
+restores the previous debug request without asserting reset. Recovery of an
+already hung CPU can still require FPGA reload. The underlying direct-reset
+failure is under investigation; the tool implements the tested workaround.

--- a/doc/wr_management.md
+++ b/doc/wr_management.md
@@ -24,6 +24,10 @@ The console selects UARTShared's crossover port while it is open and restores
 the previous selection on exit. Exit with **Ctrl-]**. Scripted commands wait
 for `wrc#`; input is paced for the WRPC polling UART. A separate UARTBone path
 must be used if the physical WR console and bridge would share the same pins.
+UARTShared now defaults to a 4096-byte receive FIFO (plus its output buffer),
+reports its occupancy for fixed-address burst reads and detects overflow.
+Older 128-byte FIFO images can lose long replies over slow transports; use
+short commands such as `uptime`/`time` or load an updated image.
 
 `status` reads the live WR configuration signature, CPU selection, memory mode,
 memory readiness, link/time-valid flags and host reset diagnostics. It also

--- a/litex_wr_nic/gateware/uart.py
+++ b/litex_wr_nic/gateware/uart.py
@@ -35,11 +35,11 @@ class UARTShared(LiteXModule):
         default_mode=WR_UART_AUTO_MODE, crossover_rx_depth=4096):
         # Control registers for UART mode and selection.
         self.control = CSRStorage(fields=[
-            CSRField("sel", size=1, values=[
+            CSRField("sel", size=1, description="WR UART port selection.", values=[
                 ("``0b0``", "WR UART connected to Physical UART."),
                 ("``0b1``", "WR UART connected to Crossover UART."),
             ], reset=default_sel),
-            CSRField("auto_mode", size=1, values=[
+            CSRField("auto_mode", size=1, description="WR UART selection mode.", values=[
                 ("``0b0``", "WR UART Manual Mode."),
                 ("``0b1``", "WR UART Auto Mode."),
             ], reset=default_mode),
@@ -52,8 +52,13 @@ class UARTShared(LiteXModule):
         # UARTPHY and UART for crossover interface.
         self.xover_phy = UARTPHY(crossover_pads, clk_freq=sys_clk_freq, baudrate=115200)
         self.xover     = UART(self.xover_phy, rx_fifo_depth=crossover_rx_depth, rx_fifo_rx_we=True)
-        self.rxlevel   = CSRStatus(len(Signal(max=crossover_rx_depth + 1)))
-        self.rxoverflow = CSRStatus()
+        self.rxlevel = CSRStatus(len(Signal(max=crossover_rx_depth + 1)),
+            description="Buffered crossover UART bytes, including the output buffer.")
+        self.rxoverflow = CSRStatus(
+            description="Crossover UART RX overflow; cleared by system reset.")
+
+        # # #
+
         self.comb += self.rxlevel.status.eq(self.xover.rx_fifo.level)
         self.sync += If(self.xover.sink.valid & ~self.xover.sink.ready,
             self.rxoverflow.status.eq(1),

--- a/litex_wr_nic/gateware/uart.py
+++ b/litex_wr_nic/gateware/uart.py
@@ -31,7 +31,8 @@ class UARTPads:
 # UART ---------------------------------------------------------------------------------------------
 
 class UARTShared(LiteXModule):
-    def __init__(self, pads, sys_clk_freq, default_sel=WR_UART_PHYSICAL_MODE, default_mode=WR_UART_AUTO_MODE):
+    def __init__(self, pads, sys_clk_freq, default_sel=WR_UART_PHYSICAL_MODE,
+        default_mode=WR_UART_AUTO_MODE, crossover_rx_depth=4096):
         # Control registers for UART mode and selection.
         self.control = CSRStorage(fields=[
             CSRField("sel", size=1, values=[
@@ -50,7 +51,13 @@ class UARTShared(LiteXModule):
 
         # UARTPHY and UART for crossover interface.
         self.xover_phy = UARTPHY(crossover_pads, clk_freq=sys_clk_freq, baudrate=115200)
-        self.xover     = UART(self.xover_phy, rx_fifo_depth=128, rx_fifo_rx_we=True)
+        self.xover     = UART(self.xover_phy, rx_fifo_depth=crossover_rx_depth, rx_fifo_rx_we=True)
+        self.rxlevel   = CSRStatus(len(Signal(max=crossover_rx_depth + 1)))
+        self.rxoverflow = CSRStatus()
+        self.comb += self.rxlevel.status.eq(self.xover.rx_fifo.level)
+        self.sync += If(self.xover.sink.valid & ~self.xover.sink.ready,
+            self.rxoverflow.status.eq(1),
+        )
 
         # Signal for the active UART selection.
         active_uart = Signal(reset=default_sel)  # Tracks the currently active port (last RX activity).

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
+import hashlib
 
 from migen import *
 from migen.genlib.cdc import MultiReg
@@ -35,6 +36,7 @@ from litex_wr_nic.gateware.wr_cpu            import (
 from litex_wr_nic.gateware.wrf_stream2wb     import Stream2Wishbone
 from litex_wr_nic.gateware.wrf_wb2stream     import Wishbone2Stream
 from litex_wr_nic.gateware.wb_clock_crossing import WishboneClockCrossing
+from litex_wr_nic.gateware.wr_info           import WRInfo
 
 # White Rabbit Core -------------------------------------------------------------------------------
 
@@ -180,6 +182,19 @@ class WhiteRabbitCore(LiteXModule):
         self.bus    = wb_slave_sys
         self.sink   = wrf_stream2wb.sink
         self.source = wrf_wb2stream.source
+        firmware_hash = 0
+        if os.path.isfile(cpu_firmware):
+            with open(cpu_firmware, "rb") as firmware:
+                firmware_hash = int.from_bytes(hashlib.sha256(firmware.read()).digest(), "big")
+        self.wr_info = WRInfo(wb_slave_wr,
+            cpu_type        = cpu_type,
+            with_cpu_memory = with_cpu_memory,
+            memory_ready    = memory_ready_wr,
+            link_up         = self.tm_link_up,
+            time_valid      = self.tm_time_valid,
+            firmware_hash   = firmware_hash,
+            host_size       = wb_slave_size,
+        )
         self.submodules += WishboneClockCrossing(self.platform,
             wb_from = wb_slave_sys,
             cd_from = "sys",
@@ -444,7 +459,7 @@ def add_white_rabbit(soc, cpu_firmware, cpu_memory_region=None,
     # CSR traversal so legacy register names keep a single owner.
     soc.autocsr_exclude = set(getattr(soc, "autocsr_exclude", ())) | {"wr_core"}
     for name in (
-        "cd_wr", "cd_wr_sys", "wr_cpu", "wr_cpu_bridge", "wr_cpu_memory_cdc",
+        "cd_wr", "cd_wr_sys", "wr_cpu", "wr_cpu_bridge", "wr_cpu_memory_cdc", "wr_info",
         "wrf_stream2wb", "wrf_wb2stream", "wb_slave_sys", "wb_slave_wr",
         "led_pps", "led_link", "led_act", "dac_refclk_load", "dac_refclk_data",
         "dac_dmtd_load", "dac_dmtd_data", "pps_in", "pps_out_valid", "pps_out",

--- a/litex_wr_nic/gateware/wr_info.py
+++ b/litex_wr_nic/gateware/wr_info.py
@@ -1,0 +1,61 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.cdc import MultiReg, BusSynchronizer
+
+from litex.gen import *
+from litex.soc.interconnect.csr import CSRStatus
+
+# WR Management Information ------------------------------------------------------------------------
+
+WR_INFO_MAGIC = 0x57524331 # WRC1.
+
+
+class WRInfo(LiteXModule):
+    """Live configuration and reset-request diagnostics, readable in sys.
+
+    Reset reason describes resets requested through the WR host register:
+    0 = FPGA/system reset, 1 = host CPU reset. It is not a firmware watchdog.
+    The image hash identifies the firmware supplied at FPGA build time.
+    """
+    def __init__(self, host_bus, cpu_type, with_cpu_memory, memory_ready,
+        link_up, time_valid, firmware_hash=0, host_size=0x0100_0000):
+        self.magic         = CSRStatus(32, reset=WR_INFO_MAGIC)
+        self.cpu_type      = CSRStatus(8, reset={"urv": 0, "vexriscv": 1}[cpu_type])
+        self.memory_mode   = CSRStatus(1, reset=int(with_cpu_memory))
+        self.memory_size   = CSRStatus(32, reset=128*1024)
+        self.firmware_hash = CSRStatus(256, reset=firmware_hash)
+        self.status        = CSRStatus(4)
+        self.reset_reason  = CSRStatus(1)
+        self.reset_count   = CSRStatus(32)
+
+        # # #
+
+        reset_requested = Signal()
+        reset_reason_wr = Signal()
+        reset_count_wr  = Signal(32)
+        # Monitor completed writes to RESET in the existing WR CPU CSR bank.
+        self.sync.wr_sys += If(host_bus.cyc & host_bus.stb & host_bus.ack & host_bus.we &
+            host_bus.sel[0] & ((host_bus.adr & ((host_size - 1) >> 2)) == (0x20b00 >> 2)),
+            reset_requested.eq(host_bus.dat_w[0]),
+            If(host_bus.dat_w[0] & ~reset_requested,
+                reset_reason_wr.eq(1),
+                reset_count_wr.eq(reset_count_wr + 1),
+            ),
+        )
+        self.specials += [
+            MultiReg(memory_ready,    self.status.status[0]),
+            MultiReg(reset_requested, self.status.status[1]),
+            MultiReg(link_up,         self.status.status[2]),
+            MultiReg(time_valid,      self.status.status[3]),
+            MultiReg(reset_reason_wr, self.reset_reason.status),
+        ]
+        self.count_cdc = BusSynchronizer(32, "wr_sys", "sys")
+        self.comb += [
+            self.count_cdc.i.eq(reset_count_wr),
+            self.reset_count.status.eq(self.count_cdc.o),
+        ]

--- a/litex_wr_nic/gateware/wr_info.py
+++ b/litex_wr_nic/gateware/wr_info.py
@@ -8,7 +8,8 @@ from migen import *
 from migen.genlib.cdc import MultiReg, BusSynchronizer
 
 from litex.gen import *
-from litex.soc.interconnect.csr import CSRStatus
+
+from litex.soc.interconnect.csr import CSRField, CSRStatus
 
 # WR Management Information ------------------------------------------------------------------------
 
@@ -24,14 +25,26 @@ class WRInfo(LiteXModule):
     """
     def __init__(self, host_bus, cpu_type, with_cpu_memory, memory_ready,
         link_up, time_valid, firmware_hash=0, host_size=0x0100_0000):
-        self.magic         = CSRStatus(32, reset=WR_INFO_MAGIC)
-        self.cpu_type      = CSRStatus(8, reset={"urv": 0, "vexriscv": 1}[cpu_type])
-        self.memory_mode   = CSRStatus(1, reset=int(with_cpu_memory))
-        self.memory_size   = CSRStatus(32, reset=128*1024)
-        self.firmware_hash = CSRStatus(256, reset=firmware_hash)
-        self.status        = CSRStatus(4)
-        self.reset_reason  = CSRStatus(1)
-        self.reset_count   = CSRStatus(32)
+        self.magic = CSRStatus(32, reset=WR_INFO_MAGIC,
+            description="WR management signature (WRC1).")
+        self.cpu_type = CSRStatus(8, reset={"urv": 0, "vexriscv": 1}[cpu_type],
+            description="WR CPU implementation: 0 = uRV, 1 = VexRiscv.")
+        self.memory_mode = CSRStatus(1, reset=int(with_cpu_memory),
+            description="WR CPU memory: 0 = private RAM, 1 = SoC memory.")
+        self.memory_size = CSRStatus(32, reset=128*1024,
+            description="Reserved WR CPU memory size in bytes.")
+        self.firmware_hash = CSRStatus(256, reset=firmware_hash,
+            description="SHA-256 of the firmware supplied at FPGA build time.")
+        self.status = CSRStatus(fields=[
+            CSRField("memory_ready",    size=1, description="WR CPU memory is ready."),
+            CSRField("reset_requested", size=1, description="Host CPU reset is asserted."),
+            CSRField("link_up",         size=1, description="WR link is up."),
+            CSRField("time_valid",      size=1, description="WR core marks its time valid."),
+        ])
+        self.reset_reason = CSRStatus(1,
+            description="Last reset request: 0 = system reset, 1 = host CPU reset.")
+        self.reset_count = CSRStatus(32,
+            description="Host CPU reset requests, wrapping at 32 bits.")
 
         # # #
 
@@ -48,10 +61,10 @@ class WRInfo(LiteXModule):
             ),
         )
         self.specials += [
-            MultiReg(memory_ready,    self.status.status[0]),
-            MultiReg(reset_requested, self.status.status[1]),
-            MultiReg(link_up,         self.status.status[2]),
-            MultiReg(time_valid,      self.status.status[3]),
+            MultiReg(memory_ready,    self.status.fields.memory_ready),
+            MultiReg(reset_requested, self.status.fields.reset_requested),
+            MultiReg(link_up,         self.status.fields.link_up),
+            MultiReg(time_valid,      self.status.fields.time_valid),
             MultiReg(reset_reason_wr, self.reset_reason.status),
         ]
         self.count_cdc = BusSynchronizer(32, "wr_sys", "sys")

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -164,6 +164,7 @@ class WRClient:
 
 class WRConsole:
     def __init__(self, bus, prefix=None, timeout=5.0):
+        self.bus     = bus
         self.timeout = timeout
         regs = vars(bus.regs)
         candidates = [name[:-5] for name in regs if name.endswith("xover_rxtx")]
@@ -176,6 +177,8 @@ class WRConsole:
         self.full  = regs[prefix + "_txfull"]
         parent = prefix.rsplit("_xover", 1)[0]
         self.control = regs.get(parent + "_control")
+        self.level   = regs.get(parent + "_rxlevel")
+        self.overflow = regs.get(parent + "_rxoverflow")
 
     @contextlib.contextmanager
     def selected(self):
@@ -189,6 +192,13 @@ class WRConsole:
                 self.control.write(previous)
 
     def receive(self, limit=128):
+        if self.overflow and self.overflow.read():
+            raise RuntimeError("WR console RX overflow; output was lost. Reload the FPGA or increase crossover_rx_depth.")
+        if self.level:
+            count = min(limit, self.level.read())
+            if count:
+                return bytes(word & 0xff for word in self.bus.read(self.data.addr, length=count, burst="fixed"))
+            return b""
         data = bytearray()
         for _ in range(limit):
             if self.empty.read():
@@ -206,7 +216,7 @@ class WRConsole:
             self.data.write(byte)
             time.sleep(0.03) # WRPC polls its UART; pace input like typing.
 
-    def command(self, command, timeout=15.0):
+    def command(self, command, timeout=60.0):
         self.receive()
         self.send(command.encode("ascii") + b"\r")
         deadline = time.monotonic() + timeout

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -57,7 +57,7 @@ class WRClient:
         elif cpu_type is None and self.memory is None:
             cpu_type = "urv"
         self.cpu_type = cpu_type
-        self.size = min(self.memory.size if self.memory else 128*1024, 128*1024)
+        self.size     = min(self.memory.size if self.memory else 128*1024, 128*1024)
 
     def reg(self, name):
         return self.regs[self.info + "_" + name]
@@ -86,7 +86,8 @@ class WRClient:
             previous = self.read_cpu(CPU_HALT)
             self.write_cpu(CPU_HALT, 1)
             try:
-                self.wait(lambda: self.read_cpu(CPU_HALTED) & 1, "uRV did not halt; CPU reset was not asserted.")
+                self.wait(lambda: self.read_cpu(CPU_HALTED) & 1,
+                    "uRV did not halt; CPU reset was not asserted.")
             except Exception:
                 self.write_cpu(CPU_HALT, previous)
                 raise
@@ -126,7 +127,7 @@ class WRClient:
             raise ValueError("Firmware CPU profile does not match the loaded hardware.")
         if not data or len(data) > self.size:
             raise ValueError("Firmware must fit in the reserved WR CPU memory.")
-        data = data.ljust(self.size, b"\x00")
+        data  = data.ljust(self.size, b"\x00")
         order = "little" if self.memory else "big"
         self.stop()
         # Use the shared SoC memory path, including any HyperRAM cache.
@@ -148,11 +149,11 @@ class WRClient:
         if self.info:
             status = self.reg("status").read()
             result.update(
-                memory_ready = bool(status & 1),
-                link_up      = bool(status & 4),
-                time_valid   = bool(status & 8),
-                reset_reason = "host CPU reset" if self.reg("reset_reason").read() else "system reset",
-                reset_count  = self.reg("reset_count").read(),
+                memory_ready         = bool(status & 1),
+                link_up              = bool(status & 4),
+                time_valid           = bool(status & 8),
+                reset_reason         = "host CPU reset" if self.reg("reset_reason").read() else "system reset",
+                reset_count          = self.reg("reset_count").read(),
                 build_firmware_sha256 = f"{self.reg('firmware_hash').read():064x}",
             )
         for name, reg in self.regs.items():
@@ -166,7 +167,7 @@ class WRConsole:
     def __init__(self, bus, prefix=None, timeout=5.0):
         self.bus     = bus
         self.timeout = timeout
-        regs = vars(bus.regs)
+        regs       = vars(bus.regs)
         candidates = [name[:-5] for name in regs if name.endswith("xover_rxtx")]
         if prefix is None:
             if len(candidates) != 1:
@@ -176,8 +177,8 @@ class WRConsole:
         self.empty = regs[prefix + "_rxempty"]
         self.full  = regs[prefix + "_txfull"]
         parent = prefix.rsplit("_xover", 1)[0]
-        self.control = regs.get(parent + "_control")
-        self.level   = regs.get(parent + "_rxlevel")
+        self.control  = regs.get(parent + "_control")
+        self.level    = regs.get(parent + "_rxlevel")
         self.overflow = regs.get(parent + "_rxoverflow")
 
     @contextlib.contextmanager
@@ -193,11 +194,14 @@ class WRConsole:
 
     def receive(self, limit=128):
         if self.overflow and self.overflow.read():
-            raise RuntimeError("WR console RX overflow; output was lost. Reload the FPGA or increase crossover_rx_depth.")
+            raise RuntimeError(
+                "WR console RX overflow; output was lost. "
+                "Reload the FPGA or increase crossover_rx_depth.")
         if self.level:
             count = min(limit, self.level.read())
             if count:
-                return bytes(word & 0xff for word in self.bus.read(self.data.addr, length=count, burst="fixed"))
+                return bytes(word & 0xff for word in self.bus.read(
+                    self.data.addr, length=count, burst="fixed"))
             return b""
         data = bytearray()
         for _ in range(limit):
@@ -220,7 +224,7 @@ class WRConsole:
         self.receive()
         self.send(command.encode("ascii") + b"\r")
         deadline = time.monotonic() + timeout
-        output = bytearray()
+        output   = bytearray()
         while time.monotonic() < deadline:
             output.extend(self.receive())
             if b"wrc#" in output:
@@ -252,13 +256,18 @@ class WRConsole:
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="localhost")
-    parser.add_argument("--port", type=int, default=1234)
+    # Remote connection.
+    parser.add_argument("--host",    default="localhost")
+    parser.add_argument("--port",    default=1234, type=int)
     parser.add_argument("--csr-csv", default="csr.csv")
-    parser.add_argument("--cpu-type", choices=tuple(CPU_TYPES.values()))
-    parser.add_argument("--wr-region", default="wr_wb_slave")
+
+    # WR integration.
+    parser.add_argument("--cpu-type",      choices=tuple(CPU_TYPES.values()))
+    parser.add_argument("--wr-region",     default="wr_wb_slave")
     parser.add_argument("--memory-region", default="wr_cpu_mem")
     parser.add_argument("--uart-prefix")
+
+    # Commands.
     commands = parser.add_subparsers(dest="command", required=True)
     for command in ("status", "diagnose", "restart"):
         commands.add_parser(command)
@@ -268,7 +277,13 @@ def main():
     load.add_argument("file", type=Path)
     load.add_argument("--firmware-cpu", choices=tuple(CPU_TYPES.values()), required=True)
     args = parser.parse_args()
-    bus = RemoteClient(host=args.host, port=args.port, csr_csv=args.csr_csv, timeout=5, raise_on_timeout=True)
+    bus = RemoteClient(
+        host             = args.host,
+        port             = args.port,
+        csr_csv          = args.csr_csv,
+        timeout          = 5,
+        raise_on_timeout = True,
+    )
     bus.open()
     try:
         if args.command == "console":
@@ -278,7 +293,11 @@ def main():
                 else:
                     console.interactive()
         else:
-            wr = WRClient(bus, cpu_type=args.cpu_type, wr_region=args.wr_region, memory_region=args.memory_region)
+            wr = WRClient(bus,
+                cpu_type      = args.cpu_type,
+                wr_region     = args.wr_region,
+                memory_region = args.memory_region,
+            )
             if args.command == "restart":
                 wr.restart()
             elif args.command == "load-firmware":
@@ -287,7 +306,10 @@ def main():
                 result = wr.status()
                 if args.command == "diagnose":
                     with WRConsole(bus, prefix=args.uart_prefix).selected() as console:
-                        result["console"] = {command: console.command(command) for command in ("ver", "uptime", "time")}
+                        result["console"] = {
+                            command: console.command(command)
+                            for command in ("ver", "uptime", "time")
+                        }
                 print(json.dumps(result, indent=2))
     finally:
         bus.close()

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -1,0 +1,287 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Manage White Rabbit through a LiteX RemoteClient connection."""
+
+import sys
+import json
+import time
+import select
+import termios
+import argparse
+import contextlib
+from pathlib import Path
+
+from litex import RemoteClient
+
+# Constants ----------------------------------------------------------------------------------------
+
+WR_INFO_MAGIC = 0x57524331
+CPU_CSR       = 0x20b00
+CPU_RESET     = 0x00
+CPU_ADDRESS   = 0x04
+CPU_DATA      = 0x08
+CPU_HALTED    = 0x80
+CPU_HALT      = 0x84
+CPU_TYPES     = {0: "urv", 1: "vexriscv"}
+
+# Management ---------------------------------------------------------------------------------------
+
+class WRClient:
+    def __init__(self, bus, cpu_type=None, wr_region="wr_wb_slave", memory_region="wr_cpu_mem",
+        timeout=5.0):
+        self.bus     = bus
+        self.timeout = timeout
+        self.region  = getattr(bus.mems, wr_region)
+        self.memory  = getattr(bus.mems, memory_region, None)
+        self.regs    = vars(bus.regs)
+        info = [name[:-6] for name in self.regs if name.endswith("wr_info_magic")]
+        if len(info) > 1:
+            raise ValueError("Multiple WR information banks found; use a CSR map for one core.")
+        self.info = info[0] if info else None
+        if self.info:
+            if self.reg("magic").read() != WR_INFO_MAGIC:
+                raise RuntimeError("WR information signature mismatch; check the bitstream and csr.csv.")
+            detected = CPU_TYPES.get(self.reg("cpu_type").read())
+            if detected is None:
+                raise RuntimeError("Unsupported WR CPU identifier.")
+            external = self.reg("memory_mode").read()
+            if bool(external) != (self.memory is not None):
+                raise RuntimeError("WR memory map disagrees with hardware; check --memory-region and csr.csv.")
+            if cpu_type and cpu_type != detected:
+                raise ValueError("Requested CPU type disagrees with hardware.")
+            cpu_type = detected
+        elif cpu_type is None and self.memory is None:
+            cpu_type = "urv"
+        self.cpu_type = cpu_type
+        self.size = min(self.memory.size if self.memory else 128*1024, 128*1024)
+
+    def reg(self, name):
+        return self.regs[self.info + "_" + name]
+
+    def read_cpu(self, offset):
+        return self.bus.read(self.region.base + CPU_CSR + offset)
+
+    def write_cpu(self, offset, value):
+        self.bus.write(self.region.base + CPU_CSR + offset, value)
+
+    def wait(self, predicate, message):
+        deadline = time.monotonic() + self.timeout
+        while not predicate():
+            if time.monotonic() >= deadline:
+                raise TimeoutError(message)
+            time.sleep(0.01)
+
+    def stop(self):
+        if self.cpu_type not in CPU_TYPES.values():
+            raise ValueError("This older image needs --cpu-type urv or --cpu-type vexriscv.")
+        if self.read_cpu(CPU_RESET) & 1:
+            return
+        if self.cpu_type == "urv":
+            # Drain the pipeline before reset. Direct early resets on the
+            # upstream private-memory uRV wrapper can otherwise hang.
+            previous = self.read_cpu(CPU_HALT)
+            self.write_cpu(CPU_HALT, 1)
+            try:
+                self.wait(lambda: self.read_cpu(CPU_HALTED) & 1, "uRV did not halt; CPU reset was not asserted.")
+            except Exception:
+                self.write_cpu(CPU_HALT, previous)
+                raise
+        self.write_cpu(CPU_RESET, 1)
+        if not self.read_cpu(CPU_RESET) & 1:
+            raise RuntimeError("CPU reset assertion did not read back.")
+        if self.cpu_type == "urv":
+            self.write_cpu(CPU_HALT, 0)
+        time.sleep(0.05)
+
+    def start(self):
+        if self.info and not self.reg("status").read() & 1:
+            raise RuntimeError("WR memory is not ready; CPU remains in reset.")
+        self.write_cpu(CPU_RESET, 0)
+        if self.read_cpu(CPU_RESET) & 1:
+            raise RuntimeError("CPU reset release did not read back.")
+
+    def restart(self):
+        self.stop()
+        self.start()
+
+    def read_word(self, offset):
+        if self.memory:
+            return self.bus.read(self.memory.base + offset)
+        self.write_cpu(CPU_ADDRESS, offset // 4)
+        return self.read_cpu(CPU_DATA)
+
+    def write_word(self, offset, value):
+        if self.memory:
+            self.bus.write(self.memory.base + offset, value)
+        else:
+            self.write_cpu(CPU_ADDRESS, offset // 4)
+            self.write_cpu(CPU_DATA, value)
+
+    def load_firmware(self, data, firmware_cpu):
+        if firmware_cpu != self.cpu_type:
+            raise ValueError("Firmware CPU profile does not match the loaded hardware.")
+        if not data or len(data) > self.size:
+            raise ValueError("Firmware must fit in the reserved WR CPU memory.")
+        data = data.ljust(self.size, b"\x00")
+        order = "little" if self.memory else "big"
+        self.stop()
+        # Use the shared SoC memory path, including any HyperRAM cache.
+        for offset in range(0, len(data), 4):
+            self.write_word(offset, int.from_bytes(data[offset:offset+4], order))
+        for offset in range(0, len(data), 4):
+            expected = int.from_bytes(data[offset:offset+4], order)
+            if self.read_word(offset) != expected:
+                raise RuntimeError(f"Firmware verification failed at 0x{offset:08x}; CPU remains in reset.")
+        self.start()
+
+    def status(self):
+        result = dict(
+            cpu_type        = self.cpu_type or "unknown (use --cpu-type)",
+            memory          = "soc" if self.memory else "private",
+            memory_size     = self.size,
+            reset_requested = bool(self.read_cpu(CPU_RESET) & 1),
+        )
+        if self.info:
+            status = self.reg("status").read()
+            result.update(
+                memory_ready = bool(status & 1),
+                link_up      = bool(status & 4),
+                time_valid   = bool(status & 8),
+                reset_reason = "host CPU reset" if self.reg("reset_reason").read() else "system reset",
+                reset_count  = self.reg("reset_count").read(),
+                build_firmware_sha256 = f"{self.reg('firmware_hash').read():064x}",
+            )
+        for name, reg in self.regs.items():
+            if ("wr_cpu_boot_" in name or "wr_cpu_bridge_" in name) and reg.mode == "ro":
+                result[name] = reg.read()
+        return result
+
+# Console ------------------------------------------------------------------------------------------
+
+class WRConsole:
+    def __init__(self, bus, prefix=None, timeout=5.0):
+        self.timeout = timeout
+        regs = vars(bus.regs)
+        candidates = [name[:-5] for name in regs if name.endswith("xover_rxtx")]
+        if prefix is None:
+            if len(candidates) != 1:
+                raise ValueError("Select the WR crossover UART with --uart-prefix.")
+            prefix = candidates[0]
+        self.data  = regs[prefix + "_rxtx"]
+        self.empty = regs[prefix + "_rxempty"]
+        self.full  = regs[prefix + "_txfull"]
+        parent = prefix.rsplit("_xover", 1)[0]
+        self.control = regs.get(parent + "_control")
+
+    @contextlib.contextmanager
+    def selected(self):
+        previous = self.control.read() if self.control else None
+        if self.control:
+            self.control.write(1) # Crossover, manual mode.
+        try:
+            yield self
+        finally:
+            if self.control:
+                self.control.write(previous)
+
+    def receive(self, limit=128):
+        data = bytearray()
+        for _ in range(limit):
+            if self.empty.read():
+                break
+            data.append(self.data.read() & 0xff)
+        return bytes(data)
+
+    def send(self, data):
+        for byte in data:
+            deadline = time.monotonic() + self.timeout
+            while self.full.read():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("WR console TX FIFO is full.")
+                time.sleep(0.001)
+            self.data.write(byte)
+            time.sleep(0.03) # WRPC polls its UART; pace input like typing.
+
+    def command(self, command, timeout=15.0):
+        self.receive()
+        self.send(command.encode("ascii") + b"\r")
+        deadline = time.monotonic() + timeout
+        output = bytearray()
+        while time.monotonic() < deadline:
+            output.extend(self.receive())
+            if b"wrc#" in output:
+                return output.decode("utf-8", errors="replace")
+            time.sleep(0.01)
+        raise TimeoutError("WR console prompt timed out: " + repr(bytes(output[-500:])))
+
+    def interactive(self):
+        import tty
+        old = termios.tcgetattr(sys.stdin) if sys.stdin.isatty() else None
+        try:
+            if old:
+                tty.setcbreak(sys.stdin.fileno())
+            while True:
+                data = self.receive()
+                if data:
+                    sys.stdout.buffer.write(data)
+                    sys.stdout.buffer.flush()
+                if select.select([sys.stdin], [], [], 0.01)[0]:
+                    data = sys.stdin.buffer.read(1)
+                    if not data or data == b"\x1d": # Ctrl-].
+                        break
+                    self.send(b"\r" if data == b"\n" else data)
+        finally:
+            if old:
+                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old)
+
+# Command Line -------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=1234)
+    parser.add_argument("--csr-csv", default="csr.csv")
+    parser.add_argument("--cpu-type", choices=tuple(CPU_TYPES.values()))
+    parser.add_argument("--wr-region", default="wr_wb_slave")
+    parser.add_argument("--memory-region", default="wr_cpu_mem")
+    parser.add_argument("--uart-prefix")
+    commands = parser.add_subparsers(dest="command", required=True)
+    for command in ("status", "diagnose", "restart"):
+        commands.add_parser(command)
+    console = commands.add_parser("console")
+    console.add_argument("--command", dest="console_command")
+    load = commands.add_parser("load-firmware")
+    load.add_argument("file", type=Path)
+    load.add_argument("--firmware-cpu", choices=tuple(CPU_TYPES.values()), required=True)
+    args = parser.parse_args()
+    bus = RemoteClient(host=args.host, port=args.port, csr_csv=args.csr_csv, timeout=5, raise_on_timeout=True)
+    bus.open()
+    try:
+        if args.command == "console":
+            with WRConsole(bus, prefix=args.uart_prefix).selected() as console:
+                if args.console_command:
+                    print(console.command(args.console_command), end="")
+                else:
+                    console.interactive()
+        else:
+            wr = WRClient(bus, cpu_type=args.cpu_type, wr_region=args.wr_region, memory_region=args.memory_region)
+            if args.command == "restart":
+                wr.restart()
+            elif args.command == "load-firmware":
+                wr.load_firmware(args.file.read_bytes(), args.firmware_cpu)
+            else:
+                result = wr.status()
+                if args.command == "diagnose":
+                    with WRConsole(bus, prefix=args.uart_prefix).selected() as console:
+                        result["console"] = {command: console.command(command) for command in ("ver", "uptime", "time")}
+                print(json.dumps(result, indent=2))
+    finally:
+        bus.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     python_requires               = "~=3.7",
     install_requires              = ["litex"],
     include_package_data          = True,
+    entry_points                  = {"console_scripts": ["litex_wr=litex_wr_nic.wr:main"]},
     keywords                      = "HDL ASIC FPGA hardware design",
     classifiers                   = [
         "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",

--- a/test/test_wr_core.py
+++ b/test/test_wr_core.py
@@ -96,7 +96,7 @@ def test_compatibility_adapter_registers_memory_and_csrs_once(platform):
     assert slaves["region"].origin == 0x20000000
     assert slaves["region"].size == 0x01000000
     banks = CSRBankArray(soc, lambda name, memory: 5)
-    assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge"]
+    assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge", "wr_info"]
     assert [csr.name for csr in banks.banks[0][1]] == [
         "status", "error_count", "last_error_address",
     ]

--- a/test/test_wr_management.py
+++ b/test/test_wr_management.py
@@ -1,0 +1,186 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from types import SimpleNamespace
+
+import pytest
+
+from migen import run_simulation
+from litex.soc.interconnect import wishbone
+
+from litex_wr_nic.wr import WRClient, WRConsole, CPU_CSR, CPU_RESET, CPU_HALT, CPU_HALTED
+from litex_wr_nic.gateware.wr_info import WRInfo, WR_INFO_MAGIC
+
+
+class Register:
+    mode = "ro"
+
+    def __init__(self, value=0):
+        self.value = value
+
+    def read(self):
+        return self.value
+
+    def write(self, value):
+        self.value = value
+
+
+class Bus:
+    def __init__(self, external=False, info=False, cpu="urv"):
+        self.mems = SimpleNamespace(wr_wb_slave=SimpleNamespace(base=0x20000000))
+        if external:
+            self.mems.wr_cpu_mem = SimpleNamespace(base=0x50000000, size=16)
+        self.regs = SimpleNamespace()
+        if info:
+            for name, value in dict(magic=WR_INFO_MAGIC, cpu_type=int(cpu == "vexriscv"),
+                memory_mode=int(external), status=1, memory_size=128*1024,
+                firmware_hash=0x1234, reset_reason=0, reset_count=0).items():
+                setattr(self.regs, "wr_info_" + name, Register(value))
+        self.words = {}
+        self.operations = []
+        self.corrupt = False
+        self.halts = True
+        self.address = 0
+
+    def read(self, address):
+        self.operations.append(("read", address))
+        offset = address - self.mems.wr_wb_slave.base - CPU_CSR
+        if offset == CPU_HALTED:
+            return int(self.halts)
+        if offset == 8:
+            return self.words.get(self.address, 0) ^ int(self.corrupt)
+        value = self.words.get(address, 0)
+        if self.corrupt and address >= 0x50000000:
+            value ^= 1
+        return value
+
+    def write(self, address, value):
+        self.operations.append(("write", address, value))
+        offset = address - self.mems.wr_wb_slave.base - CPU_CSR
+        if offset == 4:
+            self.address = value
+        elif offset == 8:
+            self.words[self.address] = value
+        else:
+            self.words[address] = value
+
+
+@pytest.fixture(autouse=True)
+def no_delays(monkeypatch):
+    monkeypatch.setattr("litex_wr_nic.wr.time.sleep", lambda seconds: None)
+
+
+@pytest.mark.parametrize("external,cpu", [(False, "urv"), (True, "urv"), (True, "vexriscv")])
+def test_firmware_load_verifies_and_uses_correct_byte_order(external, cpu):
+    bus = Bus(external=external, info=True, cpu=cpu)
+    wr = WRClient(bus)
+    wr.size = 16
+    data = b"\x01\x23\x45\x67\x89"
+    wr.load_firmware(data, cpu)
+    assert wr.read_cpu(CPU_RESET) == 0
+    first = bus.words[0x50000000 if external else 0]
+    assert first == (0x67452301 if external else 0x01234567)
+    writes = [op for op in bus.operations if op[0] == "write"]
+    base = bus.mems.wr_wb_slave.base + CPU_CSR
+    if cpu == "urv":
+        assert writes[:3] == [("write", base + CPU_HALT, 1), ("write", base, 1), ("write", base + CPU_HALT, 0)]
+    else:
+        assert all(op[1] != base + CPU_HALT for op in writes)
+    assert writes[-1] == ("write", base, 0)
+
+
+def test_bad_image_is_rejected_before_stopping_cpu():
+    bus = Bus(external=True, info=True, cpu="vexriscv")
+    wr = WRClient(bus)
+    for data, cpu in [(b"bad", "urv"), (b"", "vexriscv"), (bytes(17), "vexriscv")]:
+        with pytest.raises(ValueError):
+            wr.load_firmware(data, cpu)
+    assert not any(op[0] == "write" for op in bus.operations)
+
+
+def test_corrupt_readback_leaves_cpu_in_reset():
+    bus = Bus(external=True, info=True, cpu="vexriscv")
+    bus.corrupt = True
+    wr = WRClient(bus)
+    with pytest.raises(RuntimeError, match="verification failed"):
+        wr.load_firmware(b"abcd", "vexriscv")
+    assert wr.read_cpu(CPU_RESET) == 1
+
+
+def test_failed_halt_restores_debug_request_without_reset():
+    bus = Bus()
+    bus.halts = False
+    wr = WRClient(bus, timeout=0)
+    with pytest.raises(TimeoutError, match="did not halt"):
+        wr.restart()
+    assert wr.read_cpu(CPU_HALT) == 0
+    assert wr.read_cpu(CPU_RESET) == 0
+
+
+def test_old_external_image_requires_cpu_selection():
+    bus = Bus(external=True)
+    wr = WRClient(bus)
+    with pytest.raises(ValueError, match="older image needs"):
+        wr.restart()
+    assert not any(op[0] == "write" for op in bus.operations)
+
+
+def test_live_identity_rejects_stale_map_and_cpu_mismatch():
+    bus = Bus(external=True, info=True, cpu="vexriscv")
+    assert WRClient(bus).status()["cpu_type"] == "vexriscv"
+    with pytest.raises(ValueError, match="disagrees"):
+        WRClient(bus, cpu_type="urv")
+    bus.regs.wr_info_magic.value = 0
+    with pytest.raises(RuntimeError, match="signature"):
+        WRClient(bus)
+
+
+def test_console_restores_uart_selection_on_error():
+    bus = SimpleNamespace(regs=SimpleNamespace(
+        uart_xover_rxtx=Register(), uart_xover_rxempty=Register(1),
+        uart_xover_txfull=Register(1), uart_control=Register(2)))
+    console = WRConsole(bus, timeout=0)
+    with pytest.raises(TimeoutError):
+        with console.selected():
+            assert bus.regs.uart_control.value == 1
+            console.send(b"x")
+    assert bus.regs.uart_control.value == 2
+
+
+def test_live_reset_diagnostics_cross_clock_domains():
+    host = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+    dut = WRInfo(host, "urv", False, 1, 0, 1)
+
+    def write_reset(value):
+        yield host.adr.eq((0x20000000 + CPU_CSR) >> 2)
+        yield host.dat_w.eq(value)
+        yield host.sel.eq(15)
+        yield host.we.eq(1)
+        yield host.cyc.eq(1)
+        yield host.stb.eq(1)
+        yield host.ack.eq(1)
+        yield
+        yield host.cyc.eq(0)
+        yield host.stb.eq(0)
+        yield host.ack.eq(0)
+        yield
+
+    def wr():
+        yield from write_reset(1)
+        yield from write_reset(1) # Repeated assertion must not count twice.
+        yield from write_reset(0)
+        for _ in range(10):
+            yield
+        yield from write_reset(1)
+
+    def sys():
+        for _ in range(200):
+            yield
+        assert (yield dut.status.status) == 0b1011
+        assert (yield dut.reset_reason.status) == 1
+        assert (yield dut.reset_count.status) == 2
+
+    run_simulation(dut, {"wr_sys": wr(), "sys": sys()}, clocks={"wr_sys": 16, "sys": 10})

--- a/test/test_wr_management.py
+++ b/test/test_wr_management.py
@@ -9,11 +9,13 @@ from types import SimpleNamespace
 import pytest
 
 from migen import run_simulation
-from litex.soc.interconnect import wishbone
+
+from litex.soc.interconnect import csr_bus, wishbone
 
 from litex_wr_nic.wr import WRClient, WRConsole, CPU_CSR, CPU_RESET, CPU_HALT, CPU_HALTED
 from litex_wr_nic.gateware.wr_info import WRInfo, WR_INFO_MAGIC
 
+# Host Models --------------------------------------------------------------------------------------
 
 class Register:
     mode = "ro"
@@ -35,15 +37,22 @@ class Bus:
             self.mems.wr_cpu_mem = SimpleNamespace(base=0x50000000, size=16)
         self.regs = SimpleNamespace()
         if info:
-            for name, value in dict(magic=WR_INFO_MAGIC, cpu_type=int(cpu == "vexriscv"),
-                memory_mode=int(external), status=1, memory_size=128*1024,
-                firmware_hash=0x1234, reset_reason=0, reset_count=0).items():
+            for name, value in dict(
+                magic         = WR_INFO_MAGIC,
+                cpu_type      = int(cpu == "vexriscv"),
+                memory_mode   = int(external),
+                status        = 1,
+                memory_size   = 128*1024,
+                firmware_hash = 0x1234,
+                reset_reason  = 0,
+                reset_count   = 0,
+            ).items():
                 setattr(self.regs, "wr_info_" + name, Register(value))
-        self.words = {}
+        self.words      = {}
         self.operations = []
-        self.corrupt = False
-        self.halts = True
-        self.address = 0
+        self.corrupt    = False
+        self.halts      = True
+        self.address    = 0
 
     def read(self, address):
         self.operations.append(("read", address))
@@ -67,6 +76,7 @@ class Bus:
         else:
             self.words[address] = value
 
+# Management Tests ---------------------------------------------------------------------------------
 
 @pytest.fixture(autouse=True)
 def no_delays(monkeypatch):
@@ -86,7 +96,11 @@ def test_firmware_load_verifies_and_uses_correct_byte_order(external, cpu):
     writes = [op for op in bus.operations if op[0] == "write"]
     base = bus.mems.wr_wb_slave.base + CPU_CSR
     if cpu == "urv":
-        assert writes[:3] == [("write", base + CPU_HALT, 1), ("write", base, 1), ("write", base + CPU_HALT, 0)]
+        assert writes[:3] == [
+            ("write", base + CPU_HALT, 1),
+            ("write", base, 1),
+            ("write", base + CPU_HALT, 0),
+        ]
     else:
         assert all(op[1] != base + CPU_HALT for op in writes)
     assert writes[-1] == ("write", base, 0)
@@ -140,8 +154,11 @@ def test_live_identity_rejects_stale_map_and_cpu_mismatch():
 
 def test_console_restores_uart_selection_on_error():
     bus = SimpleNamespace(regs=SimpleNamespace(
-        uart_xover_rxtx=Register(), uart_xover_rxempty=Register(1),
-        uart_xover_txfull=Register(1), uart_control=Register(2)))
+        uart_xover_rxtx    = Register(),
+        uart_xover_rxempty = Register(1),
+        uart_xover_txfull  = Register(1),
+        uart_control      = Register(2),
+    ))
     console = WRConsole(bus, timeout=0)
     with pytest.raises(TimeoutError):
         with console.selected():
@@ -153,6 +170,8 @@ def test_console_restores_uart_selection_on_error():
 def test_live_reset_diagnostics_cross_clock_domains():
     host = wishbone.Interface(data_width=32, address_width=32, addressing="word")
     dut = WRInfo(host, "urv", False, 1, 0, 1)
+    # Include the field packing used by the real SoC CSR bank.
+    dut.csr_bank = csr_bus.CSRBank(dut.get_csrs(), address=0)
 
     def write_reset(value):
         yield host.adr.eq((0x20000000 + CPU_CSR) >> 2)

--- a/test/test_wr_management.py
+++ b/test/test_wr_management.py
@@ -184,3 +184,58 @@ def test_live_reset_diagnostics_cross_clock_domains():
         assert (yield dut.reset_count.status) == 2
 
     run_simulation(dut, {"wr_sys": wr(), "sys": sys()}, clocks={"wr_sys": 16, "sys": 10})
+
+
+def test_console_reads_only_buffered_bytes_in_a_fixed_burst():
+    calls = []
+    data = Register()
+    data.addr = 0x100
+    bus = SimpleNamespace(regs=SimpleNamespace(
+        uart_xover_rxtx=data, uart_xover_rxempty=Register(), uart_xover_txfull=Register(),
+        uart_rxlevel=Register(3), uart_rxoverflow=Register()),
+        read=lambda address, length, burst: calls.append((address, length, burst)) or [65, 66, 67])
+    assert WRConsole(bus).receive() == b"ABC"
+    assert calls == [(0x100, 3, "fixed")]
+    bus.regs.uart_rxoverflow.value = 1
+    with pytest.raises(RuntimeError, match="overflow"):
+        WRConsole(bus).receive()
+
+
+def test_console_fifo_level_and_overflow(monkeypatch):
+    from litex.gen import LiteXModule
+    from litex.soc.interconnect import stream
+    from litex_wr_nic.gateware.uart import UARTShared, UARTPads
+
+    class PHY(LiteXModule):
+        def __init__(self, *args, **kwargs):
+            self.source = stream.Endpoint([("data", 8)])
+            self.sink   = stream.Endpoint([("data", 8)])
+
+    monkeypatch.setattr("litex_wr_nic.gateware.uart.UARTPHY", PHY)
+    dut = UARTShared(UARTPads(), 125e6, crossover_rx_depth=8)
+
+    def check():
+        for value in range(9):
+            yield dut.xover_phy.source.valid.eq(1)
+            yield dut.xover_phy.source.data.eq(value)
+            yield
+        yield dut.xover_phy.source.valid.eq(0)
+        for _ in range(3):
+            yield
+        assert (yield dut.rxlevel.status) == 9
+        assert (yield dut.rxoverflow.status) == 0
+        # A PHY cannot apply backpressure to the remote transmitter.
+        yield dut.xover_phy.source.valid.eq(1)
+        yield
+        yield dut.xover_phy.source.valid.eq(0)
+        yield
+        assert (yield dut.rxoverflow.status) == 1
+        for value in range(9):
+            assert (yield dut.xover._rxtx.rd_data) == value
+            yield dut.xover._rxtx.rd_stb.eq(1)
+            yield
+            yield dut.xover._rxtx.rd_stb.eq(0)
+            yield
+        assert (yield dut.rxlevel.status) == 0
+
+    run_simulation(dut, check())


### PR DESCRIPTION
Adds `litex_wr` / `python3 -m litex_wr_nic.wr` for status, the WR CSR console, restart, verified firmware loading and console diagnostics over any LiteX RemoteClient transport. Live registers report the CPU/memory configuration, readiness, build-time firmware fingerprint and host reset diagnostics.

Firmware loading validates the declared CPU profile and memory size before stopping the CPU, verifies the complete reserved memory, and leaves reset asserted on verification failure. uRV restart drains the pipeline using the debug halt sequence tested during #67/#68 qualification. Console access restores the previous UART selection on exit. UARTShared now buffers 4096 bytes and exports FIFO occupancy for fixed-address burst reads, plus overflow detection; this fixes truncation of long replies over JTAGBone.

Depends on #72. Defaults and usage are documented in `doc/wr_management.md`. Older external-memory images need an explicit CPU type because they lack live identification.

Validation: all 52 tests pass, including the actual uRV XSim regression. New tests cover byte order, profile/size rejection, failed verification and halt behavior, live identity, UART restoration and coherent reset diagnostics across clock domains. Coverage includes FIFO occupancy and host burst reads. Vivado 2024.1 implementation meets timing (WNS +0.002 ns, WHS +0.028 ns). On SPEC-A7 at `8dc238b`, two FPGA reloads passed full `ver`/`help`/`uptime`/`time` CSR-console commands, complete CPU startup capture after restart, live CPU identification and reset-counter checks; memory-error counts remained zero.

The halt-before-reset workaround also passes on private uRV hardware. The upstream direct-reset failure is reproducible on the unmodified baseline; its root cause is not established. Slow firmware transports need the bounded upload/readback fixes in #74 (SoC memory) and #80 (private memory). The firmware fingerprint identifies the build input, not a subsequently uploaded image. Physical WR lock/PPS qualification requires a connected WR peer.

LiteX style review (2026-09-08): Added named, documented management status fields and UART CSR descriptions; aligned host-tool argument tables and test fixtures. All 21 focused management/core tests pass, including status packing through a real CSR bank. The complete stack passes 87 tests. Six target elaborations preserve the existing CSR/memory/configuration maps, excluding generated build identifiers; management and MMCM status field widths/offsets are unchanged. This cleanup was checked in software/simulation and elaboration; the hardware/timing evidence above comes from the previously qualified bitstreams.
