### PR TITLE
wr: separate CPU memory from firmware boot policy

### DIFF
--- a/doc/wr_boot_policy.md
+++ b/doc/wr_boot_policy.md
@@ -1,0 +1,88 @@
+# Choosing WR memory and boot source
+
+On SPEC-A7, `--wr-cpu-memory` selects storage and `--wr-cpu-boot` selects how
+firmware reaches it. Defaults remain uRV, private memory and embedded firmware.
+
+| Memory | Embedded | SPI | Host |
+| --- | --- | --- | --- |
+| Private uRV RAM | Default | Use SoC memory | Use SoC memory |
+| Integrated SoC RAM | Default | Supported | Supported |
+| HyperRAM | No FPGA initialization | Default | Supported |
+| Reserved DDR/other SoC region | Controller dependent; use SPI/host | Generic helper | Generic helper |
+
+For example, build an image that waits for a host-supplied VexRiscv firmware:
+
+```sh
+python3 spec_a7_wr_nic.py --build --wr-cpu-type vexriscv \
+    --wr-cpu-memory integrated --wr-cpu-boot host --skip-firmware-build
+```
+
+After loading that bitstream and starting `litex_server`, upload firmware:
+
+```sh
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv load-firmware \
+    litex_wr_nic/firmware/spec_a7_wrc_vexriscv.boot
+```
+
+Use `--wr-cpu-memory hyperram --wr-cpu-boot host` for the same flow through
+the HyperRAM controller and shared cache. Host boot holds the CPU until the
+memory controller is ready and the host has written and verified all 128 KiB.
+Failed validation leaves the CPU held. A host reboot or disconnect does not
+release a waiting CPU. A normal CPU restart keeps the verified memory image.
+
+`--wr-cpu-memory integrated --wr-cpu-boot spi` reads the same SPI boot slot as
+HyperRAM boot. The default `auto` boot source preserves the previous selection
+for each memory mode. Private uRV RAM is physically inside the WR wrapper;
+select SoC-backed memory for interchangeable loaders.
+
+## Reusing a memory region
+
+`add_wr_cpu_memory` prepares a SoC memory window and boot controller. Pass its
+return value as keyword arguments to `add_white_rabbit`/`add_wr_core`:
+
+```python
+from litex.soc.integration.soc import SoCRegion
+from litex_wr_nic.gateware.wr_memory import add_wr_cpu_memory
+
+# This aligned 128 KiB window must be inside an existing DDR bus slave.
+# Reserve it from the main CPU's allocator/linker and every DMA user.
+wr_memory = add_wr_cpu_memory(self,
+    cpu_type     = "vexriscv",
+    memory       = "region",
+    region       = SoCRegion(origin=wr_reserved_origin, size=128*1024),
+    memory_ready = ddr_initialized,
+    boot         = "host",
+)
+self.add_wr_core(cpu_type="vexriscv", cpu_firmware="unused.bram",
+    sfp_pads=sfp_pads, sfp_i2c_pads=sfp_i2c_pads, **wr_memory)
+```
+
+The helper checks the backing region and exports a `wr_cpu_mem` subregion for
+host discovery. It does not allocate or enforce the software reservation.
+For `memory="integrated"` it creates the RAM; embedded boot additionally
+requires `firmware="path/to/profile.bin"`. SPI boot requires `sys_clk_freq`
+and the core's flash pads/loader connection. The caller owns controller and
+cache initialization. Both CPU and host must use the same cache path; bypass
+writes are not coherent with cached CPU reads. The current VexRiscv adapter's
+instruction cache is reset with its CPU during reload.
+
+## Boot package metadata
+
+The firmware builder now emits version 2 `.boot` files. The 32-byte
+little-endian header contains magic, version, payload length, payload CRC32,
+CPU ID (uRV=0, VexRiscv=1), WRPC ABI ID (1), load address (0) and entry point
+(0). A loader rejects a CPU/ABI/address mismatch before issuing memory writes.
+Length and CRC checks still gate CPU release. Images contain a zero-filled
+128 KiB memory window.
+
+The host tool reads the profile from this header. Raw binaries and legacy
+version 1 packages still require `--firmware-cpu`. FPGA loaders accept legacy
+version 1 by default for existing flash contents; these images have no CPU
+metadata. Integrations can set `allow_legacy_boot=False` to require version 2.
+The standalone packager accepts `--cpu-type urv|vexriscv`; omitting it preserves
+the legacy format for older bitstreams.
+
+Validation covers both CPU profiles, metadata rejection before writes,
+memory-controller readiness, host verification and the supported SPEC-A7
+elaborations. DDR behavior needs qualification with the selected controller
+and application; SPEC-A7 provides HyperRAM rather than DDR.

--- a/litex_wr_nic/firmware/build.py
+++ b/litex_wr_nic/firmware/build.py
@@ -159,7 +159,7 @@ def copy_firmware(cpu_type):
         print(f"Error: Firmware file {FIRMWARE_BIN_SRC} does not exist.")
         exit(1)
     shutil.copy(FIRMWARE_BIN_SRC, firmware_bin_dest)
-    write_boot_image(firmware_bin_dest, firmware_boot_dest)
+    write_boot_image(firmware_bin_dest, firmware_boot_dest, cpu_type=cpu_type)
 
 def build_sdbfs():
     """Build the SDB filesystem."""

--- a/litex_wr_nic/gateware/wr_cpu.py
+++ b/litex_wr_nic/gateware/wr_cpu.py
@@ -19,6 +19,9 @@ from litex_wr_nic.wr_boot import (
     WR_BOOT_MAGIC,
     WR_BOOT_MAX_PAYLOAD,
     WR_BOOT_VERSION,
+    WR_BOOT_PROFILE_VERSION,
+    WR_BOOT_CPU_IDS,
+    WR_BOOT_ABI,
 )
 
 # Constants ----------------------------------------------------------------------------------------
@@ -356,6 +359,9 @@ class WRCPUFlashBoot(LiteXModule, AutoCSR):
     ERROR_CRC        = 4
     ERROR_WISHBONE   = 5
     ERROR_WB_TIMEOUT = 6
+    ERROR_PROFILE    = 7
+    ERROR_ABI        = 8
+    ERROR_ADDRESS    = 9
 
     def __init__(self, sys_clk_freq,
         flash_offset     = WR_BOOT_FLASH_OFFSET,
@@ -363,6 +369,9 @@ class WRCPUFlashBoot(LiteXModule, AutoCSR):
         spi_clk_freq     = 15e6,
         memory_wait      = 200e-6,
         wishbone_timeout = 1024,
+        cpu_type         = "urv",
+        memory_ready     = 1,
+        allow_legacy     = True,
     ):
         self.bus = wishbone.Interface(data_width=32, address_width=32, addressing="byte")
 
@@ -429,7 +438,9 @@ class WRCPUFlashBoot(LiteXModule, AutoCSR):
 
         spi_fsm.act("WAIT_MEMORY",
             self.cs_n.eq(1),
-            If(wait_count == wait_cycles - 1,
+            If(memory_ready == 0,
+                NextValue(wait_count, 0),
+            ).Elif(wait_count == wait_cycles - 1,
                 NextValue(spi_bits, 7),
                 NextValue(spi_div, half_period - 1),
                 NextState("WARMUP_LOW"),
@@ -539,8 +550,8 @@ class WRCPUFlashBoot(LiteXModule, AutoCSR):
         )
 
         # Boot image parser and Wishbone writer.
-        header       = Array(Signal(8, name=f"header_{n}") for n in range(16))
-        header_index = Signal(4)
+        header       = Array(Signal(8, name=f"header_{n}") for n in range(32))
+        header_index = Signal(5)
         header_magic = Cat(*header[0:4])
         header_ver   = Cat(*header[4:8])
         header_len   = Cat(*header[8:12])
@@ -571,18 +582,49 @@ class WRCPUFlashBoot(LiteXModule, AutoCSR):
         boot_fsm.act("CHECK_HEADER",
             If(header_magic != int.from_bytes(WR_BOOT_MAGIC, "little"),
                 *fail(self.ERROR_MAGIC),
-            ).Elif(header_ver != WR_BOOT_VERSION,
+            ).Elif((header_ver != WR_BOOT_PROFILE_VERSION) &
+                ((header_ver != WR_BOOT_VERSION) | int(not allow_legacy)),
                 *fail(self.ERROR_VERSION),
             ).Elif((header_len == 0) | (header_len[:2] != 0) | (header_len > max_payload),
                 *fail(self.ERROR_LENGTH),
             ).Else(
-                NextValue(payload_len, header_len),
-                NextValue(remaining, header_len),
-                NextValue(expected_crc, header_crc),
-                NextValue(crc, 0xffff_ffff),
-                NextValue(progress, 0),
-                NextState("PAYLOAD"),
+                If(header_ver == WR_BOOT_PROFILE_VERSION,
+                    NextValue(header_index, 16),
+                    NextState("PROFILE"),
+                ).Else(
+                    NextState("START_PAYLOAD"),
+                ),
             )
+        )
+        boot_fsm.act("PROFILE",
+            byte_accept.eq(1),
+            If(byte_valid,
+                NextValue(header[header_index], byte_data),
+                If(header_index == 31,
+                    NextState("CHECK_PROFILE"),
+                ).Else(
+                    NextValue(header_index, header_index + 1),
+                ),
+            ),
+        )
+        boot_fsm.act("CHECK_PROFILE",
+            If(Cat(*header[16:20]) != WR_BOOT_CPU_IDS[cpu_type],
+                *fail(self.ERROR_PROFILE),
+            ).Elif(Cat(*header[20:24]) != WR_BOOT_ABI,
+                *fail(self.ERROR_ABI),
+            ).Elif((Cat(*header[24:28]) != 0) | (Cat(*header[28:32]) != 0),
+                *fail(self.ERROR_ADDRESS),
+            ).Else(
+                NextState("START_PAYLOAD"),
+            ),
+        )
+        boot_fsm.act("START_PAYLOAD",
+            NextValue(payload_len, header_len),
+            NextValue(remaining, header_len),
+            NextValue(expected_crc, header_crc),
+            NextValue(crc, 0xffff_ffff),
+            NextValue(progress, 0),
+            NextState("PAYLOAD"),
         )
         boot_fsm.act("PAYLOAD",
             byte_accept.eq(1),

--- a/litex_wr_nic/gateware/wr_memory.py
+++ b/litex_wr_nic/gateware/wr_memory.py
@@ -1,0 +1,115 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen import *
+from litex.soc.integration.common import get_mem_data
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.interconnect.csr import CSRStorage, CSRStatus
+
+from litex_wr_nic.gateware.wr_cpu import (
+    WRCPUFlashBoot, WR_CPU_MEMORY_ORIGIN, WR_CPU_MEMORY_SIZE,
+    validate_wr_cpu_config, wr_cpu_word_bus,
+)
+
+# WR CPU Boot Policy -------------------------------------------------------------------------------
+
+class WRCPUHostBoot(LiteXModule):
+    """Hold the CPU until the host has loaded and verified its memory."""
+    def __init__(self, memory_ready=1):
+        self.ready         = Signal()
+        self._host_ready   = CSRStorage()
+        self._memory_ready = CSRStatus()
+
+        # # #
+
+        self.comb += [
+            self.ready.eq(self._host_ready.storage & memory_ready),
+            self._memory_ready.status.eq(memory_ready),
+        ]
+
+
+def resolve_wr_boot(memory, boot="auto"):
+    if boot == "auto":
+        boot = "embedded" if memory in ("private", "integrated") else "spi"
+    if boot not in ("embedded", "spi", "host"):
+        raise ValueError(f"Unsupported WR CPU boot source: {boot}")
+    if memory == "private" and boot != "embedded":
+        raise ValueError("Private uRV memory requires embedded boot; use SoC memory for SPI/host boot.")
+    if memory not in ("private", "integrated") and boot == "embedded":
+        raise ValueError("Embedded boot requires private or integrated memory with FPGA initialization.")
+    return boot
+
+
+def add_wr_cpu_memory(soc, cpu_type="urv", memory="integrated", boot="auto",
+    firmware=None, region=None, memory_ready=1, sys_clk_freq=None, allow_legacy_boot=True):
+    """Prepare CPU memory/boot independently of the board's memory controller.
+
+    ``memory='region'`` uses a reserved region already backed by the SoC bus,
+    including HyperRAM or DDR. The caller owns its controller, cache, physical
+    readiness signal and reservation against other software/DMA users.
+    Returned keyword arguments can be passed directly to add_white_rabbit.
+    """
+    if memory not in ("private", "integrated", "region"):
+        raise ValueError(f"Unsupported WR memory integration: {memory}")
+    validate_wr_cpu_config(cpu_type, memory=memory)
+    boot = resolve_wr_boot(memory, boot)
+    if boot == "spi" and sys_clk_freq is None:
+        raise ValueError("SPI boot requires the system clock frequency.")
+    loader = None
+    ready = memory_ready
+    if memory == "private":
+        if region is not None:
+            raise ValueError("Private memory cannot use a SoC memory region.")
+        return dict(cpu_memory_region=None, cpu_memory_ready=1, cpu_boot_loader=None)
+    if region is None:
+        if memory == "region":
+            raise ValueError("A reserved, bus-backed SoC region is required.")
+        region = SoCRegion(origin=WR_CPU_MEMORY_ORIGIN, size=WR_CPU_MEMORY_SIZE, mode="rwx")
+    if region.size != WR_CPU_MEMORY_SIZE or region.origin % WR_CPU_MEMORY_SIZE:
+        raise ValueError("WR memory requires a 128 KiB region aligned to 128 KiB.")
+    if "w" not in region.mode or "r" not in region.mode:
+        raise ValueError("WR CPU memory must be readable and writable.")
+    if memory == "region":
+        regions = soc.bus.regions
+        if not any(region.origin >= parent.origin and
+            region.origin + region.size <= parent.origin + parent.size and
+            not parent.linker for parent in regions.values()):
+            raise ValueError("The reserved WR memory region must be backed by an existing SoC region.")
+        existing = regions.get("wr_cpu_mem")
+        if existing is not None:
+            if existing.origin != region.origin or existing.size != region.size:
+                raise ValueError("wr_cpu_mem already refers to a different memory region.")
+        else:
+            # A named subregion provides host discovery without adding a second
+            # slave decoder over the DDR controller. Software must reserve it.
+            soc.bus.add_region("wr_cpu_mem", SoCRegion(
+                origin = region.origin,
+                size   = region.size,
+                mode   = region.mode,
+                cached = region.cached,
+                linker = True,
+            ))
+    if memory == "integrated":
+        contents = []
+        if boot == "embedded":
+            if firmware is None:
+                raise ValueError("Embedded WR boot requires a firmware binary.")
+            contents = get_mem_data(firmware, data_width=32, endianness="little", mem_size=region.size)
+        soc.add_ram("wr_cpu_mem", region.origin, region.size, contents=contents)
+    if boot == "spi":
+        soc.wr_cpu_boot = loader = WRCPUFlashBoot(sys_clk_freq,
+            cpu_type     = cpu_type,
+            memory_ready = memory_ready,
+            allow_legacy = allow_legacy_boot,
+        )
+        soc.bus.add_master(name="wr_cpu_boot", master=wr_cpu_word_bus(soc, loader.bus), region=region)
+        ready = loader.ready
+    elif boot == "host":
+        soc.wr_cpu_boot = host = WRCPUHostBoot(memory_ready)
+        ready = host.ready
+    return dict(cpu_memory_region=region, cpu_memory_ready=ready, cpu_boot_loader=loader)

--- a/litex_wr_nic/gateware/wr_memory.py
+++ b/litex_wr_nic/gateware/wr_memory.py
@@ -7,9 +7,10 @@
 from migen import *
 
 from litex.gen import *
-from litex.soc.integration.common import get_mem_data
-from litex.soc.integration.soc import SoCRegion
+
 from litex.soc.interconnect.csr import CSRStorage, CSRStatus
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.integration.common import get_mem_data
 
 from litex_wr_nic.gateware.wr_cpu import (
     WRCPUFlashBoot, WR_CPU_MEMORY_ORIGIN, WR_CPU_MEMORY_SIZE,
@@ -22,8 +23,10 @@ class WRCPUHostBoot(LiteXModule):
     """Hold the CPU until the host has loaded and verified its memory."""
     def __init__(self, memory_ready=1):
         self.ready         = Signal()
-        self._host_ready   = CSRStorage()
-        self._memory_ready = CSRStatus()
+        self._host_ready = CSRStorage(
+            description="Release the WR CPU after the host has loaded and verified its firmware.")
+        self._memory_ready = CSRStatus(
+            description="The SoC memory controller is ready for WR CPU accesses.")
 
         # # #
 
@@ -61,7 +64,7 @@ def add_wr_cpu_memory(soc, cpu_type="urv", memory="integrated", boot="auto",
     if boot == "spi" and sys_clk_freq is None:
         raise ValueError("SPI boot requires the system clock frequency.")
     loader = None
-    ready = memory_ready
+    ready  = memory_ready
     if memory == "private":
         if region is not None:
             raise ValueError("Private memory cannot use a SoC memory region.")
@@ -76,9 +79,12 @@ def add_wr_cpu_memory(soc, cpu_type="urv", memory="integrated", boot="auto",
         raise ValueError("WR CPU memory must be readable and writable.")
     if memory == "region":
         regions = soc.bus.regions
-        if not any(region.origin >= parent.origin and
+        if not any(
+            region.origin >= parent.origin and
             region.origin + region.size <= parent.origin + parent.size and
-            not parent.linker for parent in regions.values()):
+            not parent.linker
+            for parent in regions.values()
+        ):
             raise ValueError("The reserved WR memory region must be backed by an existing SoC region.")
         existing = regions.get("wr_cpu_mem")
         if existing is not None:
@@ -99,7 +105,11 @@ def add_wr_cpu_memory(soc, cpu_type="urv", memory="integrated", boot="auto",
         if boot == "embedded":
             if firmware is None:
                 raise ValueError("Embedded WR boot requires a firmware binary.")
-            contents = get_mem_data(firmware, data_width=32, endianness="little", mem_size=region.size)
+            contents = get_mem_data(firmware,
+                data_width = 32,
+                endianness = "little",
+                mem_size   = region.size,
+            )
         soc.add_ram("wr_cpu_mem", region.origin, region.size, contents=contents)
     if boot == "spi":
         soc.wr_cpu_boot = loader = WRCPUFlashBoot(sys_clk_freq,

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 from litex import RemoteClient
 
+from litex_wr_nic.wr_boot import WR_BOOT_MAGIC, inspect_boot_image
+
 # Constants ----------------------------------------------------------------------------------------
 
 WR_INFO_MAGIC = 0x57524331
@@ -56,6 +58,10 @@ class WRClient:
             cpu_type = detected
         elif cpu_type is None and self.memory is None:
             cpu_type = "urv"
+        self.host_ready = next((reg for name, reg in self.regs.items()
+            if name.endswith("wr_cpu_boot_host_ready")), None)
+        self.memory_ready = next((reg for name, reg in self.regs.items()
+            if name.endswith("wr_cpu_boot_memory_ready")), None)
         self.cpu_type = cpu_type
         self.size     = min(self.memory.size if self.memory else 128*1024, 128*1024)
 
@@ -80,7 +86,7 @@ class WRClient:
             raise ValueError("This older image needs --cpu-type urv or --cpu-type vexriscv.")
         if self.read_cpu(CPU_RESET) & 1:
             return
-        if self.cpu_type == "urv":
+        if self.cpu_type == "urv" and not (self.host_ready and not self.host_ready.read()):
             # Drain the pipeline before reset. Direct early resets on the
             # upstream private-memory uRV wrapper can otherwise hang.
             previous = self.read_cpu(CPU_HALT)
@@ -99,6 +105,12 @@ class WRClient:
         time.sleep(0.05)
 
     def start(self):
+        if self.host_ready:
+            if not self.memory_ready.read():
+                raise RuntimeError("The memory controller is not ready; CPU remains in reset.")
+            self.host_ready.write(1)
+            if self.info:
+                self.wait(lambda: self.reg("status").read() & 1, "Host boot readiness did not reach the CPU.")
         if self.info and not self.reg("status").read() & 1:
             raise RuntimeError("WR memory is not ready; CPU remains in reset.")
         self.write_cpu(CPU_RESET, 0)
@@ -122,21 +134,40 @@ class WRClient:
             self.write_cpu(CPU_ADDRESS, offset // 4)
             self.write_cpu(CPU_DATA, value)
 
-    def load_firmware(self, data, firmware_cpu):
+    def load_firmware(self, data, firmware_cpu=None):
+        if data.startswith(WR_BOOT_MAGIC):
+            image = inspect_boot_image(data, max_payload=self.size, cpu_type=self.cpu_type)
+            if firmware_cpu and image["cpu_type"] and firmware_cpu != image["cpu_type"]:
+                raise ValueError("Declared firmware CPU disagrees with boot image metadata.")
+            firmware_cpu = image["cpu_type"] or firmware_cpu
+            data = image["payload"]
+        if firmware_cpu is None:
+            raise ValueError("Raw and legacy images require --firmware-cpu.")
         if firmware_cpu != self.cpu_type:
             raise ValueError("Firmware CPU profile does not match the loaded hardware.")
         if not data or len(data) > self.size:
             raise ValueError("Firmware must fit in the reserved WR CPU memory.")
+        if self.memory_ready and not self.memory_ready.read():
+            raise RuntimeError("The memory controller is not ready for firmware upload.")
         data  = data.ljust(self.size, b"\x00")
         order = "little" if self.memory else "big"
         self.stop()
         # Use the shared SoC memory path, including any HyperRAM cache.
-        for offset in range(0, len(data), 4):
-            self.write_word(offset, int.from_bytes(data[offset:offset+4], order))
-        for offset in range(0, len(data), 4):
-            expected = int.from_bytes(data[offset:offset+4], order)
-            if self.read_word(offset) != expected:
-                raise RuntimeError(f"Firmware verification failed at 0x{offset:08x}; CPU remains in reset.")
+        words = [int.from_bytes(data[offset:offset+4], order) for offset in range(0, len(data), 4)]
+        if self.memory:
+            for index in range(0, len(words), 64):
+                self.bus.write(self.memory.base + 4*index, words[index:index+64])
+            for index in range(0, len(words), 64):
+                expected = words[index:index+64]
+                actual = self.bus.read(self.memory.base + 4*index, length=len(expected))
+                if actual != expected:
+                    raise RuntimeError(f"Firmware verification failed near 0x{4*index:08x}; CPU remains in reset.")
+        else:
+            for index, word in enumerate(words):
+                self.write_word(4*index, word)
+            for index, word in enumerate(words):
+                if self.read_word(4*index) != word:
+                    raise RuntimeError(f"Firmware verification failed at 0x{4*index:08x}; CPU remains in reset.")
         self.start()
 
     def status(self):
@@ -275,7 +306,7 @@ def main():
     console.add_argument("--command", dest="console_command")
     load = commands.add_parser("load-firmware")
     load.add_argument("file", type=Path)
-    load.add_argument("--firmware-cpu", choices=tuple(CPU_TYPES.values()), required=True)
+    load.add_argument("--firmware-cpu", choices=tuple(CPU_TYPES.values()), help="Required for raw/legacy images.")
     args = parser.parse_args()
     bus = RemoteClient(
         host             = args.host,

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -164,15 +164,17 @@ class WRClient:
                 self.bus.read(self.memory.base + 4*(index + len(chunk) - 1))
             for index in range(0, len(words), 64):
                 expected = words[index:index+64]
-                actual = self.bus.read(self.memory.base + 4*index, length=len(expected))
+                actual   = self.bus.read(self.memory.base + 4*index, length=len(expected))
                 if actual != expected:
-                    raise RuntimeError(f"Firmware verification failed near 0x{4*index:08x}; CPU remains in reset.")
+                    raise RuntimeError(
+                        f"Firmware verification failed near 0x{4*index:08x}; CPU remains in reset.")
         else:
             for index, word in enumerate(words):
                 self.write_word(4*index, word)
             for index, word in enumerate(words):
                 if self.read_word(4*index) != word:
-                    raise RuntimeError(f"Firmware verification failed at 0x{4*index:08x}; CPU remains in reset.")
+                    raise RuntimeError(
+                        f"Firmware verification failed at 0x{4*index:08x}; CPU remains in reset.")
         self.start()
 
     def status(self):

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -155,8 +155,13 @@ class WRClient:
         # Use the shared SoC memory path, including any HyperRAM cache.
         words = [int.from_bytes(data[offset:offset+4], order) for offset in range(0, len(data), 4)]
         if self.memory:
-            for index in range(0, len(words), 64):
-                self.bus.write(self.memory.base + 4*index, words[index:index+64])
+            for index in range(0, len(words), 16):
+                chunk = words[index:index+16]
+                self.bus.write(self.memory.base + 4*index, chunk)
+                # RemoteClient writes have no response. Fence each batch so a
+                # slow transport cannot accumulate the entire image ahead of
+                # the first read and exceed its response timeout.
+                self.bus.read(self.memory.base + 4*(index + len(chunk) - 1))
             for index in range(0, len(words), 64):
                 expected = words[index:index+64]
                 actual = self.bus.read(self.memory.base + 4*index, length=len(expected))

--- a/litex_wr_nic/wr_boot.py
+++ b/litex_wr_nic/wr_boot.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 WR_BOOT_MAGIC        = b"WRCB"
 WR_BOOT_VERSION      = 1
+WR_BOOT_PROFILE_VERSION = 2
+WR_BOOT_PROFILE_HEADER  = struct.Struct("<4sIIIIIII")
+WR_BOOT_CPU_IDS         = {"urv": 0, "vexriscv": 1}
+WR_BOOT_ABI             = 1 # WRPC RV32, little-endian, reset vector zero.
 WR_BOOT_HEADER       = struct.Struct("<4sIII")
 WR_BOOT_MAX_PAYLOAD  = 128 * 1024
 WR_BOOT_FLASH_OFFSET = 0x002f_0000
@@ -24,7 +28,7 @@ SPEC_A7_FLASH_SIZE   = 16 * 1024 * 1024
 
 # Boot Image Helpers -------------------------------------------------------------------------------
 
-def build_boot_image(payload, max_payload=WR_BOOT_MAX_PAYLOAD, pad_to_max=False):
+def build_boot_image(payload, max_payload=WR_BOOT_MAX_PAYLOAD, pad_to_max=False, cpu_type=None):
     payload = bytes(payload)
     if not payload:
         raise ValueError("WR CPU boot payload must not be empty")
@@ -35,38 +39,61 @@ def build_boot_image(payload, max_payload=WR_BOOT_MAX_PAYLOAD, pad_to_max=False)
     if pad_to_max:
         padded += bytes(max_payload - len(padded))
     crc = zlib.crc32(padded) & 0xffff_ffff
+    if cpu_type is not None:
+        if cpu_type not in WR_BOOT_CPU_IDS:
+            raise ValueError(f"Unsupported WR boot CPU profile: {cpu_type}")
+        return WR_BOOT_PROFILE_HEADER.pack(WR_BOOT_MAGIC, WR_BOOT_PROFILE_VERSION,
+            len(padded), crc, WR_BOOT_CPU_IDS[cpu_type], WR_BOOT_ABI, 0, 0) + padded
     return WR_BOOT_HEADER.pack(WR_BOOT_MAGIC, WR_BOOT_VERSION, len(padded), crc) + padded
 
 
-def parse_boot_image(image, max_payload=WR_BOOT_MAX_PAYLOAD):
+def inspect_boot_image(image, max_payload=WR_BOOT_MAX_PAYLOAD, cpu_type=None):
     image = bytes(image)
     if len(image) < WR_BOOT_HEADER.size:
         raise ValueError("WR CPU boot image is shorter than its header")
     magic, version, length, expected_crc = WR_BOOT_HEADER.unpack_from(image)
     if magic != WR_BOOT_MAGIC:
         raise ValueError("invalid WR CPU boot-image magic")
-    if version != WR_BOOT_VERSION:
+    header_size = WR_BOOT_HEADER.size
+    profile = None
+    if version == WR_BOOT_PROFILE_VERSION:
+        header_size = WR_BOOT_PROFILE_HEADER.size
+        if len(image) < header_size:
+            raise ValueError("WR CPU boot image is shorter than its profile header")
+        _, _, _, _, cpu_id, abi, load_address, entry = WR_BOOT_PROFILE_HEADER.unpack_from(image)
+        profile = next((name for name, value in WR_BOOT_CPU_IDS.items() if value == cpu_id), None)
+        if profile is None or (cpu_type is not None and profile != cpu_type):
+            raise ValueError("WR boot CPU profile mismatch")
+        if abi != WR_BOOT_ABI:
+            raise ValueError("Unsupported WR boot ABI")
+        if load_address or entry:
+            raise ValueError("WR firmware requires load address and entry point zero")
+    elif version != WR_BOOT_VERSION:
         raise ValueError(f"unsupported WR CPU boot-image version {version}")
     if length == 0 or length % 4:
         raise ValueError("WR CPU boot-image payload length must be non-zero and 4-byte aligned")
     if length > max_payload:
         raise ValueError("WR CPU boot-image payload exceeds the CPU memory window")
-    if len(image) != WR_BOOT_HEADER.size + length:
+    if len(image) != header_size + length:
         raise ValueError("WR CPU boot-image length does not match its header")
-    payload    = image[WR_BOOT_HEADER.size:]
+    payload    = image[header_size:]
     actual_crc = zlib.crc32(payload) & 0xffff_ffff
     if actual_crc != expected_crc:
         raise ValueError(
             f"WR CPU boot-image CRC mismatch: expected 0x{expected_crc:08x}, got 0x{actual_crc:08x}")
-    return payload
+    return {"version": version, "cpu_type": profile, "payload": payload}
 
 
-def write_boot_image(input_path, output_path):
+def parse_boot_image(image, max_payload=WR_BOOT_MAX_PAYLOAD, cpu_type=None):
+    return inspect_boot_image(image, max_payload, cpu_type)["payload"]
+
+
+def write_boot_image(input_path, output_path, cpu_type=None):
     payload = Path(input_path).read_bytes()
     # Match the deterministic zero-filled tail of the private and integrated
     # RAM images. This also initializes the complete HyperRAM CPU window before
     # reset is released.
-    image = build_boot_image(payload, pad_to_max=True)
+    image = build_boot_image(payload, pad_to_max=True, cpu_type=cpu_type)
     Path(output_path).write_bytes(image)
     return len(image)
 
@@ -98,8 +125,9 @@ def main():
     parser = argparse.ArgumentParser(description="Package a WR CPU binary for FPGA flash boot.")
     parser.add_argument("input", help="Raw WR CPU firmware binary.")
     parser.add_argument("output", help="Packaged boot image.")
+    parser.add_argument("--cpu-type", choices=tuple(WR_BOOT_CPU_IDS), help="Include CPU/ABI metadata (v2 format).")
     args = parser.parse_args()
-    size = write_boot_image(args.input, args.output)
+    size = write_boot_image(args.input, args.output, cpu_type=args.cpu_type)
     print(f"Wrote {size} bytes to {args.output}.")
 
 

--- a/litex_wr_nic/wr_boot.py
+++ b/litex_wr_nic/wr_boot.py
@@ -13,18 +13,18 @@ from pathlib import Path
 
 # Constants ----------------------------------------------------------------------------------------
 
-WR_BOOT_MAGIC        = b"WRCB"
-WR_BOOT_VERSION      = 1
+WR_BOOT_MAGIC           = b"WRCB"
+WR_BOOT_VERSION         = 1
 WR_BOOT_PROFILE_VERSION = 2
 WR_BOOT_PROFILE_HEADER  = struct.Struct("<4sIIIIIII")
 WR_BOOT_CPU_IDS         = {"urv": 0, "vexriscv": 1}
 WR_BOOT_ABI             = 1 # WRPC RV32, little-endian, reset vector zero.
-WR_BOOT_HEADER       = struct.Struct("<4sIII")
-WR_BOOT_MAX_PAYLOAD  = 128 * 1024
-WR_BOOT_FLASH_OFFSET = 0x002f_0000
-WR_SDB_FLASH_OFFSET  = 0x002e_0000
-WR_SDB_MAX_SIZE      = 64 * 1024
-SPEC_A7_FLASH_SIZE   = 16 * 1024 * 1024
+WR_BOOT_HEADER          = struct.Struct("<4sIII")
+WR_BOOT_MAX_PAYLOAD     = 128 * 1024
+WR_BOOT_FLASH_OFFSET    = 0x002f_0000
+WR_SDB_FLASH_OFFSET     = 0x002e_0000
+WR_SDB_MAX_SIZE         = 64 * 1024
+SPEC_A7_FLASH_SIZE      = 16 * 1024 * 1024
 
 # Boot Image Helpers -------------------------------------------------------------------------------
 
@@ -55,7 +55,7 @@ def inspect_boot_image(image, max_payload=WR_BOOT_MAX_PAYLOAD, cpu_type=None):
     if magic != WR_BOOT_MAGIC:
         raise ValueError("invalid WR CPU boot-image magic")
     header_size = WR_BOOT_HEADER.size
-    profile = None
+    profile     = None
     if version == WR_BOOT_PROFILE_VERSION:
         header_size = WR_BOOT_PROFILE_HEADER.size
         if len(image) < header_size:

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -51,6 +51,7 @@ from litex_wr_nic.gateware.delay.core        import MacroDelay, CoarseDelay, Fin
 from litex_wr_nic.gateware.pps               import PPSGenerator
 from litex_wr_nic.gateware.clk10m            import Clk10MGenerator
 from litex_wr_nic.gateware.nic.phy           import LiteEthPHYWRGMII
+from litex_wr_nic.gateware.wr_memory         import add_wr_cpu_memory, resolve_wr_boot
 from litex_wr_nic.gateware.wr_cpu            import (
     WRCPUFlashBoot,
     WR_CPU_MEMORY_ORIGIN,
@@ -128,6 +129,7 @@ class BaseSoC(LiteXWRNICSoC):
         wr_cpu_type               = "urv",
         wr_cpu_variant            = None,
         wr_cpu_memory             = "private",
+        wr_cpu_boot               = "auto",
 
         # Sync-In Parameters.
         # -------------------
@@ -199,21 +201,9 @@ class BaseSoC(LiteXWRNICSoC):
             white_rabbit_cpu_binary = os.path.join("litex_wr_nic", "firmware",
                 wr_cpu_firmware_filename(wr_cpu_type, "bin"))
 
+        wr_cpu_boot = resolve_wr_boot(wr_cpu_memory, wr_cpu_boot)
         wr_cpu_region = None
-        wr_cpu_ready  = 1
-        wr_cpu_loader = None
-        if wr_cpu_memory == "integrated":
-            if not os.path.isfile(white_rabbit_cpu_binary):
-                raise FileNotFoundError(
-                    f"WR CPU binary not found: {white_rabbit_cpu_binary}; build the firmware first.")
-            contents = get_mem_data(white_rabbit_cpu_binary,
-                data_width = 32,
-                endianness = "little",
-                mem_size   = WR_CPU_MEMORY_SIZE,
-            )
-            self.add_ram("wr_cpu_mem", WR_CPU_MEMORY_ORIGIN, WR_CPU_MEMORY_SIZE, contents=contents)
-            wr_cpu_region = SoCRegion(origin=WR_CPU_MEMORY_ORIGIN, size=WR_CPU_MEMORY_SIZE, mode="rwx")
-        elif wr_cpu_memory == "hyperram":
+        if wr_cpu_memory == "hyperram":
             wr_cpu_region = SoCRegion(origin=WR_CPU_MEMORY_ORIGIN, size=WR_CPU_MEMORY_SIZE, mode="rwx")
             wr_cpu_bus    = wishbone.Interface(data_width=32, address_width=32, addressing="word")
             self.bus.add_slave(name="wr_cpu_mem", slave=wr_cpu_bus, region=wr_cpu_region)
@@ -233,13 +223,18 @@ class BaseSoC(LiteXWRNICSoC):
                 clk_ratio    = "4:1",
             )
             self.comb += self.wr_cpu_cache.slave.connect(self.hyperram.bus)
-            self.wr_cpu_boot = wr_cpu_loader = WRCPUFlashBoot(sys_clk_freq=sys_clk_freq)
-            self.bus.add_master(name="wr_cpu_boot",
-                master = wr_cpu_word_bus(self, wr_cpu_loader.bus),
-                region = wr_cpu_region,
-            )
-            wr_cpu_ready = wr_cpu_loader.ready
             self.add_config("WR_CPU_CACHE_SIZE", 8*KILOBYTE)
+        wr_memory = add_wr_cpu_memory(self,
+            cpu_type     = wr_cpu_type,
+            memory       = "region" if wr_cpu_memory == "hyperram" else wr_cpu_memory,
+            boot         = wr_cpu_boot,
+            firmware     = white_rabbit_cpu_binary,
+            region       = wr_cpu_region,
+            sys_clk_freq = sys_clk_freq,
+        )
+        wr_cpu_region = wr_memory["cpu_memory_region"]
+        wr_cpu_ready  = wr_memory["cpu_memory_ready"]
+        wr_cpu_loader = wr_memory["cpu_boot_loader"]
 
         # UART -------------------------------------------------------------------------------------
 
@@ -688,6 +683,8 @@ def main():
     parser.add_argument("--wr-cpu-memory", default="private",
         choices=["private", "integrated", "hyperram"],
         help="WR CPU memory implementation (default: private).")
+    parser.add_argument("--wr-cpu-boot", default="auto", choices=["auto", "embedded", "spi", "host"],
+        help="WR firmware source (auto: embedded for BRAM, SPI for HyperRAM).")
     parser.add_argument("--wr-cpu-type", default="urv",
         choices=WR_CPU_TYPES,
         help="WR CPU implementation (default: embedded uRV).")
@@ -724,6 +721,7 @@ def main():
         wr_cpu_type    = args.wr_cpu_type,
         wr_cpu_variant = args.wr_cpu_variant,
         wr_cpu_memory  = args.wr_cpu_memory,
+        wr_cpu_boot    = args.wr_cpu_boot,
     )
     if args.with_wishbone_fabric_interface_probe:
         soc.add_wishbone_fabric_interface_probe()
@@ -767,12 +765,12 @@ def main():
         bitstream = builder.get_bitstream_filename(mode="flash")
         sdb_image = "litex_wr_nic/firmware/sdb-wrpc.bin"
         boot_image = os.path.join("litex_wr_nic", "firmware",
-            wr_cpu_firmware_filename(args.wr_cpu_type, "boot")) if args.wr_cpu_memory == "hyperram" else None
+            wr_cpu_firmware_filename(args.wr_cpu_type, "boot")) if resolve_wr_boot(args.wr_cpu_memory, args.wr_cpu_boot) == "spi" else None
         validate_flash_layout(bitstream, sdb_image, boot_image)
         prog = soc.platform.create_programmer()
         prog.flash(0x0000_0000, bitstream)
         prog.flash(WR_SDB_FLASH_OFFSET, sdb_image)
-        if args.wr_cpu_memory == "hyperram":
+        if resolve_wr_boot(args.wr_cpu_memory, args.wr_cpu_boot) == "spi":
             prog.flash(WR_BOOT_FLASH_OFFSET, boot_image)
 
 if __name__ == "__main__":

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -32,7 +32,6 @@ from litex.soc.cores.clock          import S7PLL, S7MMCM
 from litex.soc.cores.led            import LedChaser
 from litex.soc.cores.spi.spi_master import SPIMaster
 from litex.soc.cores.hyperbus       import HyperRAM
-from litex.soc.integration.common   import get_mem_data
 from litex.soc.integration.soc      import SoCRegion
 
 from litepcie.phy.s7pciephy import S7PCIEPHY
@@ -53,13 +52,11 @@ from litex_wr_nic.gateware.clk10m            import Clk10MGenerator
 from litex_wr_nic.gateware.nic.phy           import LiteEthPHYWRGMII
 from litex_wr_nic.gateware.wr_memory         import add_wr_cpu_memory, resolve_wr_boot
 from litex_wr_nic.gateware.wr_cpu            import (
-    WRCPUFlashBoot,
     WR_CPU_MEMORY_ORIGIN,
     WR_CPU_MEMORY_SIZE,
     WR_CPU_TYPES,
     validate_wr_cpu_config,
     wr_cpu_firmware_filename,
-    wr_cpu_word_bus,
 )
 from litex_wr_nic.wr_boot import WR_BOOT_FLASH_OFFSET, WR_SDB_FLASH_OFFSET, validate_flash_layout
 
@@ -201,7 +198,7 @@ class BaseSoC(LiteXWRNICSoC):
             white_rabbit_cpu_binary = os.path.join("litex_wr_nic", "firmware",
                 wr_cpu_firmware_filename(wr_cpu_type, "bin"))
 
-        wr_cpu_boot = resolve_wr_boot(wr_cpu_memory, wr_cpu_boot)
+        wr_cpu_boot   = resolve_wr_boot(wr_cpu_memory, wr_cpu_boot)
         wr_cpu_region = None
         if wr_cpu_memory == "hyperram":
             wr_cpu_region = SoCRegion(origin=WR_CPU_MEMORY_ORIGIN, size=WR_CPU_MEMORY_SIZE, mode="rwx")
@@ -764,8 +761,10 @@ def main():
     if args.flash:
         bitstream = builder.get_bitstream_filename(mode="flash")
         sdb_image = "litex_wr_nic/firmware/sdb-wrpc.bin"
-        boot_image = os.path.join("litex_wr_nic", "firmware",
-            wr_cpu_firmware_filename(args.wr_cpu_type, "boot")) if resolve_wr_boot(args.wr_cpu_memory, args.wr_cpu_boot) == "spi" else None
+        boot_image = (
+            os.path.join("litex_wr_nic", "firmware", wr_cpu_firmware_filename(args.wr_cpu_type, "boot"))
+            if resolve_wr_boot(args.wr_cpu_memory, args.wr_cpu_boot) == "spi" else None
+        )
         validate_flash_layout(bitstream, sdb_image, boot_image)
         prog = soc.platform.create_programmer()
         prog.flash(0x0000_0000, bitstream)

--- a/test/test_wr_boot.py
+++ b/test/test_wr_boot.py
@@ -64,3 +64,19 @@ def test_flash_layout_rejects_bitstream_overlap(tmp_path):
     sdb.write_bytes(bytes(64 * 1024))
     with pytest.raises(ValueError, match="overlaps"):
         validate_flash_layout(bitstream, sdb)
+
+
+def test_profile_metadata_and_validation():
+    from litex_wr_nic.wr_boot import inspect_boot_image
+    for cpu in ("urv", "vexriscv"):
+        image = build_boot_image(b"test", cpu_type=cpu)
+        assert len(image) == 36
+        assert inspect_boot_image(image, cpu_type=cpu) == dict(version=2, cpu_type=cpu, payload=b"test")
+        other = "urv" if cpu == "vexriscv" else "vexriscv"
+        with pytest.raises(ValueError, match="profile mismatch"):
+            parse_boot_image(image, cpu_type=other)
+    for offset, match in ((16, "profile"), (20, "ABI"), (24, "address"), (28, "address")):
+        damaged = bytearray(image)
+        damaged[offset] ^= 0x80
+        with pytest.raises(ValueError, match=match):
+            parse_boot_image(damaged)

--- a/test/test_wr_cpu_flash_boot.py
+++ b/test/test_wr_cpu_flash_boot.py
@@ -11,12 +11,13 @@ from litex_wr_nic.wr_boot import build_boot_image
 
 # Flash Boot Simulation ----------------------------------------------------------------------------
 
-def simulate_boot(image, startup_clocks=0, memory_latency=0):
+def simulate_boot(image, startup_clocks=0, memory_latency=0, **kwargs):
     dut = WRCPUFlashBoot(
         sys_clk_freq     = 100,
         spi_clk_freq     = 25,
         memory_wait      = 0,
         wishbone_timeout = 32,
+        **kwargs,
     )
     writes = []
     result = {}
@@ -158,3 +159,28 @@ def test_flash_boot_timeout_keeps_cpu_in_reset():
     result, writes = simulate_boot(build_boot_image(bytes(range(16))), memory_latency=100)
     assert result == {"ready": 0, "error": WRCPUFlashBoot.ERROR_WB_TIMEOUT}
     assert writes == []
+
+
+def test_profiled_flash_boot_checks_cpu_abi_before_writing():
+    payload = bytes(range(16))
+    for cpu in ("urv", "vexriscv"):
+        image = build_boot_image(payload, cpu_type=cpu)
+        result, writes = simulate_boot(image, cpu_type=cpu)
+        assert result == {"ready": 1, "error": 0}
+        assert len(writes) == 4
+        other = "urv" if cpu == "vexriscv" else "vexriscv"
+        result, writes = simulate_boot(image, cpu_type=other)
+        assert result["error"] == WRCPUFlashBoot.ERROR_PROFILE
+        assert not writes and not result["ready"]
+    for offset, error in ((20, WRCPUFlashBoot.ERROR_ABI), (24, WRCPUFlashBoot.ERROR_ADDRESS), (28, WRCPUFlashBoot.ERROR_ADDRESS)):
+        image = bytearray(build_boot_image(payload, cpu_type="urv"))
+        image[offset] ^= 2
+        result, writes = simulate_boot(image)
+        assert result["error"] == error
+        assert not writes and not result["ready"]
+
+
+def test_strict_flash_boot_rejects_legacy_image():
+    result, writes = simulate_boot(build_boot_image(bytes(range(16))), allow_legacy=False)
+    assert result["error"] == WRCPUFlashBoot.ERROR_VERSION
+    assert not writes and not result["ready"]

--- a/test/test_wr_cpu_flash_boot.py
+++ b/test/test_wr_cpu_flash_boot.py
@@ -172,7 +172,11 @@ def test_profiled_flash_boot_checks_cpu_abi_before_writing():
         result, writes = simulate_boot(image, cpu_type=other)
         assert result["error"] == WRCPUFlashBoot.ERROR_PROFILE
         assert not writes and not result["ready"]
-    for offset, error in ((20, WRCPUFlashBoot.ERROR_ABI), (24, WRCPUFlashBoot.ERROR_ADDRESS), (28, WRCPUFlashBoot.ERROR_ADDRESS)):
+    for offset, error in (
+        (20, WRCPUFlashBoot.ERROR_ABI),
+        (24, WRCPUFlashBoot.ERROR_ADDRESS),
+        (28, WRCPUFlashBoot.ERROR_ADDRESS),
+    ):
         image = bytearray(build_boot_image(payload, cpu_type="urv"))
         image[offset] ^= 2
         result, writes = simulate_boot(image)

--- a/test/test_wr_management.py
+++ b/test/test_wr_management.py
@@ -287,3 +287,33 @@ def test_host_boot_rejects_upload_before_ddr_initialization():
     with pytest.raises(RuntimeError, match="memory controller"):
         WRClient(bus).load_firmware(b"test", "vexriscv")
     assert not any(op[0] == "write" for op in bus.operations)
+
+
+def test_upload_fences_writes_and_detects_memory_aliasing():
+    class QueuedBus(Bus):
+        def __init__(self, alias=False):
+            super().__init__(external=True, info=True, cpu="vexriscv")
+            self.mems.wr_cpu_mem.size = 512
+            self.queued = 0
+            self.alias = alias
+
+        def write(self, address, value):
+            if address >= 0x50000000 and not isinstance(value, list):
+                self.queued += 1
+                assert self.queued <= 16, "Host queued writes without waiting for the transport"
+                if self.alias:
+                    address = 0x50000000 + (address - 0x50000000) % 64
+            super().write(address, value)
+
+        def read(self, address, length=None):
+            self.queued = 0
+            if self.alias and length is None and address >= 0x50000000:
+                address = 0x50000000 + (address - 0x50000000) % 64
+            return super().read(address, length)
+
+    image = bytes(range(256)) + bytes(256)
+    WRClient(QueuedBus()).load_firmware(image, "vexriscv")
+    bus = QueuedBus(alias=True)
+    with pytest.raises(RuntimeError, match="verification failed"):
+        WRClient(bus).load_firmware(image, "vexriscv")
+    assert WRClient(bus).read_cpu(CPU_RESET) == 1

--- a/test/test_wr_management.py
+++ b/test/test_wr_management.py
@@ -54,7 +54,9 @@ class Bus:
         self.halts      = True
         self.address    = 0
 
-    def read(self, address):
+    def read(self, address, length=None):
+        if length is not None:
+            return [self.read(address + 4*index) for index in range(length)]
         self.operations.append(("read", address))
         offset = address - self.mems.wr_wb_slave.base - CPU_CSR
         if offset == CPU_HALTED:
@@ -67,6 +69,10 @@ class Bus:
         return value
 
     def write(self, address, value):
+        if isinstance(value, list):
+            for index, word in enumerate(value):
+                self.write(address + 4*index, word)
+            return
         self.operations.append(("write", address, value))
         offset = address - self.mems.wr_wb_slave.base - CPU_CSR
         if offset == 4:
@@ -258,3 +264,26 @@ def test_console_fifo_level_and_overflow(monkeypatch):
         assert (yield dut.rxlevel.status) == 0
 
     run_simulation(dut, check())
+
+
+def test_profiled_image_and_host_boot_of_a_stopped_urv():
+    from litex_wr_nic.wr_boot import build_boot_image
+    bus = Bus(external=True, info=True, cpu="urv")
+    bus.halts = False # The CPU is held by host boot and cannot enter debug.
+    bus.regs.wr_cpu_boot_host_ready = Register(0)
+    bus.regs.wr_cpu_boot_memory_ready = Register(1)
+    wr = WRClient(bus)
+    wr.load_firmware(build_boot_image(b"test", cpu_type="urv"))
+    assert bus.regs.wr_cpu_boot_host_ready.read() == 1
+    assert wr.read_cpu(CPU_RESET) == 0
+    assert not any(op[0] == "read" and op[1] == bus.mems.wr_wb_slave.base + CPU_CSR + CPU_HALTED
+        for op in bus.operations)
+
+
+def test_host_boot_rejects_upload_before_ddr_initialization():
+    bus = Bus(external=True, info=True, cpu="vexriscv")
+    bus.regs.wr_cpu_boot_host_ready = Register(0)
+    bus.regs.wr_cpu_boot_memory_ready = Register(0)
+    with pytest.raises(RuntimeError, match="memory controller"):
+        WRClient(bus).load_firmware(b"test", "vexriscv")
+    assert not any(op[0] == "write" for op in bus.operations)

--- a/test/test_wr_memory.py
+++ b/test/test_wr_memory.py
@@ -9,15 +9,17 @@ from types import SimpleNamespace
 import pytest
 
 from migen import Signal, run_simulation
+
 from litex.gen import LiteXModule
 from litex.soc.integration.soc import SoCRegion
 
 from litex_wr_nic.gateware.wr_memory import WRCPUHostBoot, add_wr_cpu_memory, resolve_wr_boot
 
+# Memory and Boot Policy Tests ---------------------------------------------------------------------
 
 def test_host_boot_waits_for_host_and_memory_controller():
     ready = Signal()
-    dut = WRCPUHostBoot(ready)
+    dut   = WRCPUHostBoot(ready)
 
     def check():
         assert (yield dut.ready) == 0
@@ -38,8 +40,8 @@ def test_memory_and_boot_are_independent(tmp_path):
     binary = tmp_path / "firmware.bin"
     binary.write_bytes(bytes.fromhex("12345678"))
     for boot in ("embedded", "host", "spi"):
-        soc = LiteXModule()
-        rams = []
+        soc     = LiteXModule()
+        rams    = []
         masters = []
         soc.add_ram = lambda *args, **kwargs: rams.append((args, kwargs))
         soc.bus = SimpleNamespace(add_master=lambda **kwargs: masters.append(kwargs))
@@ -52,8 +54,8 @@ def test_memory_and_boot_are_independent(tmp_path):
 
 
 def test_reserved_ddr_region_and_invalid_configuration():
-    soc = LiteXModule()
-    region = SoCRegion(origin=0x51000000, size=128*1024)
+    soc     = LiteXModule()
+    region  = SoCRegion(origin=0x51000000, size=128*1024)
     regions = {"main_ram": SoCRegion(origin=0x50000000, size=32*1024*1024)}
     soc.bus = SimpleNamespace(regions=regions,
         add_region=lambda name, region: regions.update({name: region}))

--- a/test/test_wr_memory.py
+++ b/test/test_wr_memory.py
@@ -1,0 +1,71 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from types import SimpleNamespace
+
+import pytest
+
+from migen import Signal, run_simulation
+from litex.gen import LiteXModule
+from litex.soc.integration.soc import SoCRegion
+
+from litex_wr_nic.gateware.wr_memory import WRCPUHostBoot, add_wr_cpu_memory, resolve_wr_boot
+
+
+def test_host_boot_waits_for_host_and_memory_controller():
+    ready = Signal()
+    dut = WRCPUHostBoot(ready)
+
+    def check():
+        assert (yield dut.ready) == 0
+        yield dut._host_ready.storage.eq(1)
+        yield
+        assert (yield dut.ready) == 0
+        yield ready.eq(1)
+        yield
+        assert (yield dut.ready) == 1
+        yield ready.eq(0)
+        yield
+        assert (yield dut.ready) == 0
+
+    run_simulation(dut, check())
+
+
+def test_memory_and_boot_are_independent(tmp_path):
+    binary = tmp_path / "firmware.bin"
+    binary.write_bytes(bytes.fromhex("12345678"))
+    for boot in ("embedded", "host", "spi"):
+        soc = LiteXModule()
+        rams = []
+        masters = []
+        soc.add_ram = lambda *args, **kwargs: rams.append((args, kwargs))
+        soc.bus = SimpleNamespace(add_master=lambda **kwargs: masters.append(kwargs))
+        result = add_wr_cpu_memory(soc, cpu_type="vexriscv", memory="integrated", boot=boot,
+            firmware=str(binary), sys_clk_freq=125e6)
+        assert rams[0][0] == ("wr_cpu_mem", 0x40000000, 128*1024)
+        assert rams[0][1]["contents"] == ([0x78563412] if boot == "embedded" else [])
+        assert bool(masters) == (boot == "spi")
+        assert (result["cpu_boot_loader"] is not None) == (boot == "spi")
+
+
+def test_reserved_ddr_region_and_invalid_configuration():
+    soc = LiteXModule()
+    region = SoCRegion(origin=0x51000000, size=128*1024)
+    regions = {"main_ram": SoCRegion(origin=0x50000000, size=32*1024*1024)}
+    soc.bus = SimpleNamespace(regions=regions,
+        add_region=lambda name, region: regions.update({name: region}))
+    result = add_wr_cpu_memory(soc, memory="region", boot="host", region=region)
+    assert result["cpu_memory_region"] is region
+    assert regions["wr_cpu_mem"].origin == region.origin
+    assert regions["wr_cpu_mem"].linker
+    assert resolve_wr_boot("hyperram") == "spi"
+    assert resolve_wr_boot("private") == "embedded"
+    for memory, boot in (("private", "host"), ("private", "spi"), ("region", "embedded")):
+        with pytest.raises(ValueError):
+            add_wr_cpu_memory(LiteXModule(), memory=memory, boot=boot, region=region)
+    with pytest.raises(ValueError, match="128 KiB"):
+        add_wr_cpu_memory(LiteXModule(), memory="region", boot="host",
+            region=SoCRegion(origin=0x50000000, size=64*1024))


### PR DESCRIPTION
Adds independent embedded/SPI/host boot selection for SoC-backed WR CPU memory. SPEC-A7 can now host-load integrated RAM or HyperRAM, and SPI-load either. Defaults remain uRV/private/embedded and SPI boot for HyperRAM. The generic helper supports a reserved, bus-backed SoC region (including DDR), checks its bounds and exports it for host discovery.

Host boot waits for controller readiness and a verified upload before releasing the CPU. Firmware uploads use bursts through the shared memory/cache path. Version 2 boot packages add CPU, ABI, load-address and entry-point metadata; the FPGA loader rejects mismatches before writing memory. Legacy version 1 remains accepted by default for existing flash images and can be disabled by an integration.

Depends on #73. Usage and constraints are in `doc/wr_boot_policy.md`; private uRV RAM retains embedded boot, and DDR reservation/controller qualification belongs to the integration.

Validation: all 61 tests pass (60 before the upload fence fix, plus its focused regression), including actual uRV execution with XSim; the affected management/memory tests also pass after burst-upload optimization. New simulations check both CPU profiles, ABI/address/profile rejection before writes, strict legacy rejection, host/controller readiness, verified upload and region validation. SPEC-A7 elaborates for default uRV/private, VexRiscv/integrated/host, VexRiscv/integrated/SPI and uRV/HyperRAM/host. SPEC-A7 host boot passed two FPGA reloads: the VexRiscv CPU stayed held before upload, a full 128 KiB typed image was uploaded and verified over JTAGBone in about 113 seconds, then ver/help/time/uptime and restart passed with zero CPU memory errors. Read barriers between upload bursts prevent unacknowledged writes from overrunning slow transports; full readback detects address aliasing. The original routed host-boot report has a false inter-mode PIPE setup failure (-0.101 ns). Applying the verified dedicated PIPE mux clock constraint from #78 to the same routed design gives WNS +0.096 ns and WHS +0.055 ns. Full HyperRAM readback exposed a board sampling/cache-timing problem, fixed in #79. With that follow-up, the final HyperRAM image meets setup/hold timing and passed two FPGA reloads with full 128 KiB upload/readback (~114 seconds each), VexRiscv execution, full console access and restart; CPU memory errors stayed zero. Use the complete stack including #79 for SPEC-A7 HyperRAM host boot. Physical WR link/servo/PPS qualification still requires a WR reference peer.

LiteX style review (2026-09-08): Aligned boot metadata and memory helpers, documented readiness registers, and removed imports made unused by the memory helper. All 29 focused boot/memory/core tests pass. The complete stack passes 87 tests. Six target elaborations preserve the existing CSR/memory/configuration maps, excluding generated build identifiers; management and MMCM status field widths/offsets are unchanged. This cleanup was checked in software/simulation and elaboration; the hardware/timing evidence above comes from the previously qualified bitstreams.
