### PR TITLE
wr: expose application time, event timestamps and scheduled triggers

### DIFF
--- a/doc/wr_application_time.md
+++ b/doc/wr_application_time.md
@@ -1,0 +1,76 @@
+# Application time, events and triggers
+
+`WhiteRabbitCore.time` exposes a common record in the native WR reference
+clock domain (`wr`, 62.5 MHz): `seconds` (40-bit TAI seconds), `cycles` (28-bit
+ticks, 16 ns each), `time_valid`, `link_up` and `state`. It uses the WR core's
+timecode directly; it does not introduce another free-running counter. The
+existing `TimeGenerator` remains available for applications that interpolate
+time in another clock domain.
+
+By default, time is usable only when the core marks it valid and synchronized
+link status is high. State 0 means invalid; state 1 means valid with link.
+`allow_time_holdover=True` permits state 2 while the core still marks time
+valid after link loss. This opt-in policy does not guarantee oscillator
+holdover accuracy. These states do not independently certify servo lock.
+
+## Coherent host snapshots
+
+```sh
+python3 -m litex_wr_nic.wr --csr-csv test/csr.csv read-time
+```
+
+The `wr_time_capture` write requests a snapshot in `wr`. `wr_time_busy` is
+set until the complete record reaches `sys`; `wr_time_done` then becomes 1.
+All fields remain stable until the next completed capture. Repeated capture
+writes while busy are ignored. This prevents torn seconds/cycles reads at a
+second boundary. Reset of the time domain invalidates the snapshot. A stopped
+reference clock causes the host command to time out instead of claiming a
+fresh timestamp.
+
+## Timestamping events
+
+```python
+from litex_wr_nic.gateware.wr_time import WREventTimestamp
+
+self.events = WREventTimestamp(self.wr_core.time, depth=16)
+self.comb += [
+    self.events.event.eq(event_pulse_wr),
+    self.events.tag.eq(event_tag_wr),
+    self.events.source.connect(application_timestamp_sink),
+]
+```
+
+`event` and `tag` must be synchronous to `wr`. The output is a `sys` stream
+containing the time record and an 8-bit tag, with `first=last=1` per event.
+Invalid time is delivered with `time_valid=0`. A full FIFO drops the event
+and increments `dropped` in `wr`; the corresponding CSR is transferred
+coherently to `sys`. The output supports backpressure. `cd_out` and tag width
+are configurable. An asynchronous input requires a synchronizer or capture
+circuit; its latency and uncertainty are part of the timestamp error budget.
+
+## Scheduling a trigger
+
+```python
+from litex_wr_nic.gateware.wr_time import WRTimeTrigger
+
+self.trigger = WRTimeTrigger(self.wr_core.time)
+# Feed trigger.sink with a future {seconds, cycles} in the wr domain.
+# If commands originate in sys, use a stream.ClockDomainCrossing first.
+self.comb += scheduled_commands_wr.connect(self.trigger.sink)
+```
+
+One command can be pending. `pulse` is asserted for the matching native WR
+tick. A past target, invalid cycle count or forward step past the target
+increments `missed`; invalid time or a backward step cancels the pending
+command and increments `cancelled`. No late pulse is emitted. Commands are
+accepted only when `sink.ready` is high. The counters and pulse are in `wr`.
+
+Realtime outputs require an active reference clock. Link-state propagation
+takes synchronizer cycles; a stopped clock can also stretch a tick. Board
+output logic must apply its clock-health and output-enable policy. Pin-level
+delays, pulse shaping and sub-tick interpolation belong to that logic; this
+interface does not claim calibrated PPS/trigger accuracy.
+
+Simulations cover second-boundary snapshots, reset invalidation, link/holdover
+policy, event FIFO backpressure/overflow and trigger cancellation. Qualification
+of physical timing and servo recovery requires a WR reference peer.

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -37,6 +37,7 @@ from litex_wr_nic.gateware.wrf_stream2wb     import Stream2Wishbone
 from litex_wr_nic.gateware.wrf_wb2stream     import Wishbone2Stream
 from litex_wr_nic.gateware.wb_clock_crossing import WishboneClockCrossing
 from litex_wr_nic.gateware.wr_info           import WRInfo
+from litex_wr_nic.gateware.wr_time           import WRApplicationTime
 
 # White Rabbit Core -------------------------------------------------------------------------------
 
@@ -89,7 +90,8 @@ class WhiteRabbitCore(LiteXModule):
         # Wishbone Slave.
         wb_slave_size = 0x0100_0000,
 
-        dac_bits      = 16
+        allow_time_holdover = False,
+        dac_bits            = 16
     ):
 
         self.platform = platform
@@ -121,6 +123,15 @@ class WhiteRabbitCore(LiteXModule):
         self.tm_time_valid   = Signal()
         self.tm_seconds      = Signal(40)
         self.tm_cycles       = Signal(28)
+
+        self.wr_time = WRApplicationTime(
+            seconds        = self.tm_seconds,
+            cycles         = self.tm_cycles,
+            valid          = self.tm_time_valid,
+            link_up        = self.tm_link_up,
+            allow_holdover = allow_time_holdover,
+        )
+        self.time = self.wr_time.time
 
         # Optional WR CPU Memory Master.
         # ------------------------------
@@ -459,7 +470,7 @@ def add_white_rabbit(soc, cpu_firmware, cpu_memory_region=None,
     # CSR traversal so legacy register names keep a single owner.
     soc.autocsr_exclude = set(getattr(soc, "autocsr_exclude", ())) | {"wr_core"}
     for name in (
-        "cd_wr", "cd_wr_sys", "wr_cpu", "wr_cpu_bridge", "wr_cpu_memory_cdc", "wr_info",
+        "cd_wr", "cd_wr_sys", "wr_cpu", "wr_cpu_bridge", "wr_cpu_memory_cdc", "wr_info", "wr_time",
         "wrf_stream2wb", "wrf_wb2stream", "wb_slave_sys", "wb_slave_wr",
         "led_pps", "led_link", "led_act", "dac_refclk_load", "dac_refclk_data",
         "dac_dmtd_load", "dac_dmtd_data", "pps_in", "pps_out_valid", "pps_out",

--- a/litex_wr_nic/gateware/wr_time.py
+++ b/litex_wr_nic/gateware/wr_time.py
@@ -1,0 +1,204 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.cdc import MultiReg, BusSynchronizer
+
+from litex.gen import *
+from litex.soc.interconnect import stream
+from litex.soc.interconnect.csr import CSR, CSRStatus
+
+# Application Time ---------------------------------------------------------------------------------
+
+WR_TIME_INVALID  = 0
+WR_TIME_VALID    = 1
+WR_TIME_HOLDOVER = 2
+WR_TIME_LAYOUT  = [("seconds", 40), ("cycles", 28), ("time_valid", 1), ("link_up", 1), ("state", 2)]
+WR_TICKS_PER_SECOND = 62_500_000
+
+
+class WRApplicationTime(LiteXModule):
+    """Expose native WR time, with an explicit policy for loss of link.
+
+    Timecode and validity are synchronous to cd_time (normally the 62.5 MHz
+    PHY reference clock). Link status is synchronized from the control domain.
+    VALID means the core marks time valid and the link is up; it is not an
+    independent measurement of PTP servo lock or timing accuracy.
+    """
+    def __init__(self, seconds, cycles, valid, link_up, cd_time="wr", allow_holdover=False,
+        with_csr=True):
+        self.time = Record(WR_TIME_LAYOUT)
+
+        # # #
+
+        link = Signal()
+        self.specials += MultiReg(link_up, link, cd_time)
+        self.comb += [
+            self.time.seconds.eq(seconds),
+            self.time.cycles.eq(cycles),
+            self.time.link_up.eq(link),
+            self.time.time_valid.eq(valid & (link | int(allow_holdover))),
+            self.time.state.eq(WR_TIME_INVALID),
+            If(valid,
+                If(link,
+                    self.time.state.eq(WR_TIME_VALID),
+                ).Elif(allow_holdover,
+                    self.time.state.eq(WR_TIME_HOLDOVER),
+                ),
+            ),
+        ]
+        if with_csr:
+            self.add_csr(cd_time)
+
+    def add_csr(self, cd_time):
+        self._capture = CSR() # Write to request a coherent WR time snapshot.
+        self._busy    = CSRStatus()
+        self._done    = CSRStatus()
+        self._seconds = CSRStatus(40)
+        self._cycles  = CSRStatus(28)
+        self._time_valid   = CSRStatus()
+        self._link_up = CSRStatus()
+        self._state   = CSRStatus(2)
+
+        request = Signal()
+        pending = Signal()
+        captured = Record(WR_TIME_LAYOUT)
+        reset_sys = Signal()
+        self.specials += MultiReg(ResetSignal(cd_time), reset_sys)
+        self.request_cdc = stream.ClockDomainCrossing([("data", 1)],
+            cd_from="sys", cd_to=cd_time, depth=4, with_common_rst=True)
+        self.reply_cdc = stream.ClockDomainCrossing(WR_TIME_LAYOUT,
+            cd_from=cd_time, cd_to="sys", depth=4, with_common_rst=True)
+        self.comb += [
+            self.request_cdc.sink.valid.eq(request),
+            self.request_cdc.source.ready.eq(~pending),
+            self.reply_cdc.sink.valid.eq(pending),
+            self.reply_cdc.source.ready.eq(1),
+        ]
+        for name, _ in WR_TIME_LAYOUT:
+            self.comb += getattr(self.reply_cdc.sink, name).eq(getattr(captured, name))
+        sync_time = getattr(self.sync, cd_time)
+        sync_time += [
+            If(self.request_cdc.source.valid & self.request_cdc.source.ready,
+                captured.raw_bits().eq(self.time.raw_bits()),
+                pending.eq(1),
+            ).Elif(self.reply_cdc.sink.valid & self.reply_cdc.sink.ready,
+                pending.eq(0),
+            ),
+        ]
+        self.sync += [
+            If(request & self.request_cdc.sink.ready, request.eq(0)),
+            If(self._capture.wr_stb & ~self._busy.status,
+                request.eq(1),
+                self._busy.status.eq(1),
+                self._done.status.eq(0),
+            ),
+            If(self.reply_cdc.source.valid,
+                self._busy.status.eq(0),
+                self._done.status.eq(1),
+                *[getattr(self, "_" + name).status.eq(getattr(self.reply_cdc.source, name))
+                    for name, _ in WR_TIME_LAYOUT],
+            ),
+            If(reset_sys,
+                request.eq(0),
+                self._busy.status.eq(0),
+                self._done.status.eq(0),
+                self._time_valid.status.eq(0),
+                self._state.status.eq(WR_TIME_INVALID),
+            ),
+        ]
+
+# Event Timestamping -------------------------------------------------------------------------------
+
+class WREventTimestamp(LiteXModule):
+    """Timestamp event pulses in cd_time and queue records for an application.
+
+    The pulse and tag must already be synchronous to cd_time. Crossing an
+    asynchronous event into that domain adds synchronizer latency/uncertainty.
+    Invalid timestamps are delivered with valid=0, not silently discarded.
+    """
+    def __init__(self, time, tag_width=8, depth=16, cd_time="wr", cd_out="sys"):
+        self.event = Signal()
+        self.tag   = Signal(tag_width)
+        self.dropped = Signal(32)
+        self.source = stream.Endpoint(WR_TIME_LAYOUT + [("tag", tag_width)])
+
+        # # #
+
+        layout = WR_TIME_LAYOUT + [("tag", tag_width)]
+        if cd_time == cd_out:
+            self.queue = ClockDomainsRenamer(cd_time)(stream.SyncFIFO(layout, depth, buffered=True))
+        else:
+            self.queue = stream.ClockDomainCrossing(layout,
+                cd_from=cd_time, cd_to=cd_out, depth=depth, with_common_rst=True)
+        self.comb += [
+            self.queue.sink.valid.eq(self.event),
+            self.queue.sink.first.eq(1),
+            self.queue.sink.last.eq(1),
+            self.queue.sink.tag.eq(self.tag),
+            self.queue.source.connect(self.source),
+            *[getattr(self.queue.sink, name).eq(getattr(time, name)) for name, _ in WR_TIME_LAYOUT],
+        ]
+        sync_time = getattr(self.sync, cd_time)
+        sync_time += If(self.event & ~self.queue.sink.ready, self.dropped.eq(self.dropped + 1))
+        self._dropped = CSRStatus(32)
+        self.dropped_cdc = BusSynchronizer(32, cd_time, "sys")
+        self.comb += [
+            self.dropped_cdc.i.eq(self.dropped),
+            self._dropped.status.eq(self.dropped_cdc.o),
+        ]
+
+# Scheduled Trigger -------------------------------------------------------------------------------
+
+class WRTimeTrigger(LiteXModule):
+    """One scheduled trigger in the time domain, with explicit cancellation.
+
+    sink, pulse, pending, missed and cancelled use cd_time. A command must
+    specify a future native WR timestamp. Past times, forward steps over the
+    target and loss of validity never generate a late trigger.
+    """
+    def __init__(self, time, cd_time="wr", ticks_per_second=WR_TICKS_PER_SECOND):
+        self.sink      = stream.Endpoint([("seconds", 40), ("cycles", 28)])
+        self.pulse     = Signal()
+        self.pending   = Signal()
+        self.missed    = Signal(32)
+        self.cancelled = Signal(32)
+
+        # # #
+
+        target   = Signal(68)
+        previous = Signal(68)
+        now = Cat(time.cycles, time.seconds)
+        requested = Cat(self.sink.cycles, self.sink.seconds)
+        self.comb += [
+            self.sink.ready.eq(~self.pending),
+            self.pulse.eq(self.pending & time.time_valid & (now == target)),
+        ]
+        sync_time = getattr(self.sync, cd_time)
+        sync_time += [
+            previous.eq(now),
+            If(self.sink.valid & self.sink.ready,
+                If(~time.time_valid,
+                    self.cancelled.eq(self.cancelled + 1),
+                ).Elif((requested <= now) | (self.sink.cycles >= ticks_per_second),
+                    self.missed.eq(self.missed + 1),
+                ).Else(
+                    target.eq(requested),
+                    self.pending.eq(1),
+                ),
+            ),
+            If(self.pending,
+                If(~time.time_valid | (now < previous),
+                    self.pending.eq(0),
+                    self.cancelled.eq(self.cancelled + 1),
+                ).Elif(now > target,
+                    self.pending.eq(0),
+                    self.missed.eq(self.missed + 1),
+                ).Elif(self.pulse,
+                    self.pending.eq(0),
+                ),
+            ),
+        ]

--- a/litex_wr_nic/gateware/wr_time.py
+++ b/litex_wr_nic/gateware/wr_time.py
@@ -8,6 +8,7 @@ from migen import *
 from migen.genlib.cdc import MultiReg, BusSynchronizer
 
 from litex.gen import *
+
 from litex.soc.interconnect import stream
 from litex.soc.interconnect.csr import CSR, CSRStatus
 
@@ -16,7 +17,15 @@ from litex.soc.interconnect.csr import CSR, CSRStatus
 WR_TIME_INVALID  = 0
 WR_TIME_VALID    = 1
 WR_TIME_HOLDOVER = 2
-WR_TIME_LAYOUT  = [("seconds", 40), ("cycles", 28), ("time_valid", 1), ("link_up", 1), ("state", 2)]
+
+WR_TIME_LAYOUT = [
+    ("seconds",    40),
+    ("cycles",     28),
+    ("time_valid",  1),
+    ("link_up",     1),
+    ("state",       2),
+]
+
 WR_TICKS_PER_SECOND = 62_500_000
 
 
@@ -54,18 +63,20 @@ class WRApplicationTime(LiteXModule):
             self.add_csr(cd_time)
 
     def add_csr(self, cd_time):
-        self._capture = CSR() # Write to request a coherent WR time snapshot.
-        self._busy    = CSRStatus()
-        self._done    = CSRStatus()
-        self._seconds = CSRStatus(40)
-        self._cycles  = CSRStatus(28)
-        self._time_valid   = CSRStatus()
-        self._link_up = CSRStatus()
-        self._state   = CSRStatus(2)
+        self._capture    = CSR() # Write to request a coherent WR time snapshot.
+        self._busy       = CSRStatus(description="A snapshot request is pending.")
+        self._done       = CSRStatus(description="The snapshot is ready; cleared on recapture or reset.")
+        self._seconds    = CSRStatus(40, description="Captured WR TAI seconds.")
+        self._cycles     = CSRStatus(28, description="Captured 16 ns cycles within the second.")
+        self._time_valid = CSRStatus(description="Captured time validity after applying link-loss policy.")
+        self._link_up    = CSRStatus(description="Captured WR link status.")
+        self._state      = CSRStatus(2, description="Captured state: 0 = invalid, 1 = valid, 2 = holdover.")
 
-        request = Signal()
-        pending = Signal()
-        captured = Record(WR_TIME_LAYOUT)
+        # # #
+
+        request   = Signal()
+        pending   = Signal()
+        captured  = Record(WR_TIME_LAYOUT)
         reset_sys = Signal()
         self.specials += MultiReg(ResetSignal(cd_time), reset_sys)
         self.request_cdc = stream.ClockDomainCrossing([("data", 1)],
@@ -121,8 +132,8 @@ class WREventTimestamp(LiteXModule):
     Invalid timestamps are delivered with valid=0, not silently discarded.
     """
     def __init__(self, time, tag_width=8, depth=16, cd_time="wr", cd_out="sys"):
-        self.event = Signal()
-        self.tag   = Signal(tag_width)
+        self.event   = Signal()
+        self.tag     = Signal(tag_width)
         self.dropped = Signal(32)
         self.source = stream.Endpoint(WR_TIME_LAYOUT + [("tag", tag_width)])
 
@@ -144,7 +155,8 @@ class WREventTimestamp(LiteXModule):
         ]
         sync_time = getattr(self.sync, cd_time)
         sync_time += If(self.event & ~self.queue.sink.ready, self.dropped.eq(self.dropped + 1))
-        self._dropped = CSRStatus(32)
+        self._dropped = CSRStatus(32,
+            description="Events dropped while the timestamp queue was full, wrapping at 32 bits.")
         self.dropped_cdc = BusSynchronizer(32, cd_time, "sys")
         self.comb += [
             self.dropped_cdc.i.eq(self.dropped),
@@ -169,9 +181,9 @@ class WRTimeTrigger(LiteXModule):
 
         # # #
 
-        target   = Signal(68)
-        previous = Signal(68)
-        now = Cat(time.cycles, time.seconds)
+        target    = Signal(68)
+        previous  = Signal(68)
+        now       = Cat(time.cycles, time.seconds)
         requested = Cat(self.sink.cycles, self.sink.seconds)
         self.comb += [
             self.sink.ready.eq(~self.pending),

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -207,8 +207,10 @@ class WRClient:
         self.regs[prefix + "capture"].write(1)
         self.wait(lambda: self.regs[prefix + "done"].read(),
             "WR time snapshot timed out; check the PHY reference clock.")
-        return {name: self.regs[prefix + name].read()
-            for name in ("seconds", "cycles", "time_valid", "link_up", "state")}
+        return {
+            name: self.regs[prefix + name].read()
+            for name in ("seconds", "cycles", "time_valid", "link_up", "state")
+        }
 
 # Console ------------------------------------------------------------------------------------------
 

--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -199,6 +199,17 @@ class WRClient:
                 result[name] = reg.read()
         return result
 
+    def read_time(self):
+        banks = [name[:-8] for name in self.regs if name.endswith("wr_time_capture")]
+        if len(banks) != 1:
+            raise ValueError("A unique WR time snapshot bank is required.")
+        prefix = banks[0] + "_"
+        self.regs[prefix + "capture"].write(1)
+        self.wait(lambda: self.regs[prefix + "done"].read(),
+            "WR time snapshot timed out; check the PHY reference clock.")
+        return {name: self.regs[prefix + name].read()
+            for name in ("seconds", "cycles", "time_valid", "link_up", "state")}
+
 # Console ------------------------------------------------------------------------------------------
 
 class WRConsole:
@@ -307,7 +318,7 @@ def main():
 
     # Commands.
     commands = parser.add_subparsers(dest="command", required=True)
-    for command in ("status", "diagnose", "restart"):
+    for command in ("status", "diagnose", "restart", "read-time"):
         commands.add_parser(command)
     console = commands.add_parser("console")
     console.add_argument("--command", dest="console_command")
@@ -336,7 +347,9 @@ def main():
                 wr_region     = args.wr_region,
                 memory_region = args.memory_region,
             )
-            if args.command == "restart":
+            if args.command == "read-time":
+                print(json.dumps(wr.read_time(), indent=2))
+            elif args.command == "restart":
                 wr.restart()
             elif args.command == "load-firmware":
                 wr.load_firmware(args.file.read_bytes(), args.firmware_cpu)

--- a/test/test_wr_core.py
+++ b/test/test_wr_core.py
@@ -96,7 +96,7 @@ def test_compatibility_adapter_registers_memory_and_csrs_once(platform):
     assert slaves["region"].origin == 0x20000000
     assert slaves["region"].size == 0x01000000
     banks = CSRBankArray(soc, lambda name, memory: 5)
-    assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge", "wr_info"]
+    assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge", "wr_info", "wr_time"]
     assert [csr.name for csr in banks.banks[0][1]] == [
         "status", "error_count", "last_error_address",
     ]

--- a/test/test_wr_management.py
+++ b/test/test_wr_management.py
@@ -317,3 +317,16 @@ def test_upload_fences_writes_and_detects_memory_aliasing():
     with pytest.raises(RuntimeError, match="verification failed"):
         WRClient(bus).load_firmware(image, "vexriscv")
     assert WRClient(bus).read_cpu(CPU_RESET) == 1
+
+
+def test_time_snapshot_command_and_stopped_clock_timeout():
+    bus = Bus(info=True)
+    fields = dict(capture=0, done=1, seconds=123, cycles=456, time_valid=1, link_up=1, state=1)
+    for name, value in fields.items():
+        setattr(bus.regs, "wr_time_" + name, Register(value))
+    wr = WRClient(bus, timeout=0)
+    assert wr.read_time() == dict(seconds=123, cycles=456, time_valid=1, link_up=1, state=1)
+    assert bus.regs.wr_time_capture.read() == 1
+    bus.regs.wr_time_done.value = 0
+    with pytest.raises(TimeoutError, match="reference clock"):
+        wr.read_time()

--- a/test/test_wr_time.py
+++ b/test/test_wr_time.py
@@ -1,0 +1,196 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.fhdl.structure import _Assign
+
+from litex.gen import LiteXModule
+
+from litex_wr_nic.gateware.wr_time import (
+    WRApplicationTime, WREventTimestamp, WRTimeTrigger, WR_TIME_LAYOUT,
+    WR_TIME_INVALID, WR_TIME_VALID, WR_TIME_HOLDOVER,
+)
+
+
+def simulate(dut, generators):
+    clocks = {"sys": 10, "wr": 16}
+    for name in clocks:
+        if not hasattr(dut, "cd_" + name):
+            setattr(dut, "cd_" + name, ClockDomain(name))
+    fragment = dut.get_fragment()
+    for statement in fragment.comb:
+        if isinstance(statement, _Assign) and isinstance(statement.r, ClockSignal):
+            if statement.r.cd in clocks:
+                for domain in fragment.clock_domains:
+                    if statement.l is domain.clk:
+                        clocks[domain.name] = clocks[statement.r.cd]
+    run_simulation(fragment, generators, clocks=clocks)
+
+
+def test_link_loss_policy_is_explicit():
+    for holdover in (False, True):
+        valid = Signal(reset=1)
+        link = Signal(reset=1)
+        dut = WRApplicationTime(1, 2, valid, link, allow_holdover=holdover, with_csr=False)
+
+        def check():
+            for _ in range(5):
+                yield
+            assert (yield dut.time.state) == WR_TIME_VALID
+            yield link.eq(0)
+            for _ in range(5):
+                yield
+            assert (yield dut.time.time_valid) == int(holdover)
+            assert (yield dut.time.state) == (WR_TIME_HOLDOVER if holdover else WR_TIME_INVALID)
+            yield valid.eq(0)
+            yield
+            assert (yield dut.time.time_valid) == 0
+            assert (yield dut.time.state) == WR_TIME_INVALID
+
+        simulate(dut, {"wr": check()})
+
+
+def test_snapshot_is_coherent_at_seconds_rollover_and_stable_until_recapture():
+    dut = LiteXModule()
+    dut.cd_sys = ClockDomain("sys")
+    dut.cd_wr = ClockDomain("wr")
+    seconds = Signal(40, reset=9)
+    cycles = Signal(28, reset=62_499_995)
+    dut.time = WRApplicationTime(seconds, cycles, 1, 1)
+    dut.sync.wr += If(cycles == 62_499_999,
+        cycles.eq(0), seconds.eq(seconds + 1),
+    ).Else(cycles.eq(cycles + 1))
+    observed = []
+
+    @passive
+    def reference():
+        while True:
+            observed.append(((yield seconds), (yield cycles)))
+            yield
+
+    def host():
+        yield dut.time._capture.wr_stb.eq(1)
+        yield
+        yield dut.time._capture.wr_stb.eq(0)
+        for _ in range(200):
+            if (yield dut.time._done.status):
+                break
+            yield
+        else:
+            raise AssertionError("Snapshot did not complete")
+        result = ((yield dut.time._seconds.status), (yield dut.time._cycles.status))
+        assert result in observed
+        assert (yield dut.time._busy.status) == 0
+        for _ in range(30):
+            yield
+            assert ((yield dut.time._seconds.status), (yield dut.time._cycles.status)) == result
+        # Reset the time domain while sys continues: clear the stale validity.
+        yield dut.cd_wr.rst.eq(1)
+        for _ in range(10):
+            yield
+        assert (yield dut.time._done.status) == 0
+        assert (yield dut.time._time_valid.status) == 0
+
+    simulate(dut, {"sys": host(), "wr": reference()})
+
+
+def test_event_queue_preserves_flags_and_reports_loss_under_backpressure():
+    time = Record(WR_TIME_LAYOUT, name="time")
+    dut = WREventTimestamp(time, depth=4)
+    received = []
+
+    def events():
+        for _ in range(8):
+            yield
+        yield time.seconds.eq(12)
+        yield time.time_valid.eq(1)
+        yield time.state.eq(WR_TIME_VALID)
+        # Keep the consumer stopped long enough to fill the async FIFO.
+        for number in range(12):
+            yield dut.event.eq(1)
+            yield dut.tag.eq(number)
+            yield time.cycles.eq(number)
+            yield
+        yield dut.event.eq(0)
+        for _ in range(100):
+            yield
+        assert (yield dut.dropped) == 8
+        # Invalid time is retained as an explicit flag on the event.
+        yield time.time_valid.eq(0)
+        yield time.state.eq(WR_TIME_INVALID)
+        yield time.cycles.eq(99)
+        yield dut.tag.eq(99)
+        yield dut.event.eq(1)
+        yield
+        yield dut.event.eq(0)
+        for _ in range(100):
+            yield
+
+    def consumer():
+        for _ in range(40):
+            yield
+        yield dut.source.ready.eq(1)
+        for _ in range(350):
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                received.append(((yield dut.source.tag), (yield dut.source.cycles), (yield dut.source.time_valid)))
+                assert (yield dut.source.first) and (yield dut.source.last)
+            yield
+
+    simulate(dut, {"wr": events(), "sys": consumer()})
+    assert received == [(n, n, 1) for n in range(4)] + [(99, 99, 0)]
+
+
+def test_trigger_fires_once_and_cancels_invalid_past_or_skipped_times():
+    time = Record(WR_TIME_LAYOUT, name="time")
+    dut = WRTimeTrigger(time)
+
+    def schedule(second, cycle):
+        yield dut.sink.seconds.eq(second)
+        yield dut.sink.cycles.eq(cycle)
+        yield dut.sink.valid.eq(1)
+        yield
+        yield dut.sink.valid.eq(0)
+        yield
+
+    def check():
+        yield time.time_valid.eq(1)
+        yield time.seconds.eq(3)
+        yield time.cycles.eq(62_499_998)
+        yield from schedule(4, 1)
+        assert (yield dut.pending)
+        yield time.seconds.eq(4)
+        yield time.cycles.eq(0)
+        yield
+        assert not (yield dut.pulse)
+        yield time.cycles.eq(1)
+        yield
+        assert (yield dut.pulse)
+        yield time.cycles.eq(2)
+        yield
+        assert not (yield dut.pulse)
+        assert not (yield dut.pending)
+        yield from schedule(3, 1)
+        assert (yield dut.missed) == 1
+        yield from schedule(4, 10)
+        yield time.cycles.eq(11)
+        for _ in range(2):
+            yield
+        assert (yield dut.missed) == 2
+        assert not (yield dut.pulse)
+        yield from schedule(4, 20)
+        yield time.time_valid.eq(0)
+        for _ in range(2):
+            yield
+        assert (yield dut.cancelled) == 1
+        yield time.time_valid.eq(1)
+        yield from schedule(4, 30)
+        yield time.seconds.eq(2) # A backwards time step cancels the old request.
+        for _ in range(2):
+            yield
+        assert (yield dut.cancelled) == 2
+        assert not (yield dut.pending)
+
+    simulate(dut, {"wr": check()})

--- a/test/test_wr_time.py
+++ b/test/test_wr_time.py
@@ -14,6 +14,7 @@ from litex_wr_nic.gateware.wr_time import (
     WR_TIME_INVALID, WR_TIME_VALID, WR_TIME_HOLDOVER,
 )
 
+# Simulation Helpers -------------------------------------------------------------------------------
 
 def simulate(dut, generators):
     clocks = {"sys": 10, "wr": 16}
@@ -29,11 +30,12 @@ def simulate(dut, generators):
                         clocks[domain.name] = clocks[statement.r.cd]
     run_simulation(fragment, generators, clocks=clocks)
 
+# Application Time Tests ---------------------------------------------------------------------------
 
 def test_link_loss_policy_is_explicit():
     for holdover in (False, True):
         valid = Signal(reset=1)
-        link = Signal(reset=1)
+        link  = Signal(reset=1)
         dut = WRApplicationTime(1, 2, valid, link, allow_holdover=holdover, with_csr=False)
 
         def check():
@@ -56,13 +58,16 @@ def test_link_loss_policy_is_explicit():
 def test_snapshot_is_coherent_at_seconds_rollover_and_stable_until_recapture():
     dut = LiteXModule()
     dut.cd_sys = ClockDomain("sys")
-    dut.cd_wr = ClockDomain("wr")
+    dut.cd_wr  = ClockDomain("wr")
     seconds = Signal(40, reset=9)
-    cycles = Signal(28, reset=62_499_995)
+    cycles  = Signal(28, reset=62_499_995)
     dut.time = WRApplicationTime(seconds, cycles, 1, 1)
     dut.sync.wr += If(cycles == 62_499_999,
-        cycles.eq(0), seconds.eq(seconds + 1),
-    ).Else(cycles.eq(cycles + 1))
+        cycles.eq(0),
+        seconds.eq(seconds + 1),
+    ).Else(
+        cycles.eq(cycles + 1),
+    )
     observed = []
 
     @passive
@@ -135,7 +140,11 @@ def test_event_queue_preserves_flags_and_reports_loss_under_backpressure():
         yield dut.source.ready.eq(1)
         for _ in range(350):
             if (yield dut.source.valid) and (yield dut.source.ready):
-                received.append(((yield dut.source.tag), (yield dut.source.cycles), (yield dut.source.time_valid)))
+                received.append((
+                    (yield dut.source.tag),
+                    (yield dut.source.cycles),
+                    (yield dut.source.time_valid),
+                ))
                 assert (yield dut.source.first) and (yield dut.source.last)
             yield
 


### PR DESCRIPTION
Adds a common application time record based on the native WR timecode, coherent host snapshots (`litex_wr read-time`), event timestamp queues with backpressure/drop reporting, and one-shot scheduled triggers.

The default policy invalidates application time after synchronized link loss. Holdover is explicit and remains conditional on WR time validity. Triggers reject past targets and invalid cycle values, cancel on invalid time or backward steps, and report forward steps that skip a target without emitting a late pulse. Snapshot fields remain coherent across seconds rollover and stable until recapture.

Depends on #74. Integration examples and clock-domain/output constraints are documented in `doc/wr_application_time.md`. Timestamp granularity is the native 16 ns tick; these interfaces do not independently certify servo lock or calibrated pin timing.

Validation: all 66 tests pass in the subsequent fabric/clock suites (65 before the inherited upload-fence regression), including the actual uRV XSim regression. Added simulations cover rollover snapshots, reset invalidation, link/holdover policy, event overflow and trigger cancellation. SPEC-A7 VexRiscv/integrated elaboration passes. Two stacked uRV/private FPGA reloads passed coherent hardware snapshots, with cycles in range and time invalid as expected without a WR link; console and restart remained functional. Physical timing/servo qualification requires a WR reference peer; none is attached.

LiteX style review (2026-09-08): Aligned time records, CSR declarations and simulations; documented snapshot and event registers. All 15 focused time/core tests pass. The complete stack passes 87 tests. Six target elaborations preserve the existing CSR/memory/configuration maps, excluding generated build identifiers; management and MMCM status field widths/offsets are unchanged. This cleanup was checked in software/simulation and elaboration; the hardware/timing evidence above comes from the previously qualified bitstreams.
