### PR TITLE
wr: preserve application fabric flow control and packet errors

### DIFF
--- a/doc/wr_application_fabric.md
+++ b/doc/wr_application_fabric.md
@@ -1,0 +1,58 @@
+# WR application fabric
+
+`WhiteRabbitCore.sink` and `.source` are byte-wide LiteX stream endpoints in
+`sys`, with `first`, `last` and `error`. Data transfers on `valid & ready`.
+The producer must hold all fields while stalled. An error is reported on the
+last byte; a consumer must discard the complete packet when that flag is set.
+Applications that cannot undo partial packet processing should buffer a whole
+packet before committing it.
+
+The adapters connect these streams to the WR fabric in `wr_sys`. WR fabric is
+pipelined Wishbone: `STB & ~STALL` accepts a request, while `ACK`, `ERR` or `RTY`
+completes a previously accepted request. The transmit adapter keeps `CYC`
+asserted until every response has returned. It supports consecutive accepted
+words and up to 16 outstanding requests by default. An error or retry aborts
+the Wishbone cycle and drains the rest of the application packet. The slave
+must discard aborted requests when `CYC` falls; responses must be low before
+the next packet begins. There is no automatic retry or response timeout.
+
+The receive adapter stalls before accepting data it cannot buffer. It queues
+an explicit end-of-frame token, including when `CYC` falls with a full FIFO.
+One word of lookahead preserves trailing error status and single-byte final
+words. OOB metadata is consumed without being exposed as packet payload.
+Both byte-select encodings for a single byte are supported. Empty frames
+produce no application packet.
+
+The FIFO, partial-word converter and protocol state machines share a reset
+derived from both clock domains, with asynchronous assertion and locally
+synchronized release. Resetting either side discards buffered packets; users
+must also reset their downstream packet assembly on a WR reset.
+
+## Diagnostics
+
+Each adapter exposes coherent, read-only 32-bit counters in `sys`:
+
+| CSR suffix | Meaning |
+| --- | --- |
+| `packets` | Completed or aborted fabric cycles |
+| `errors` | Packets with an input error, malformed receive request, or bus error/retry |
+| `stalls` | Fabric clock cycles with a request waiting on `STALL` |
+| `overflow` | Receive requests changed or withdrawn while stalled |
+
+Counters wrap and reset with the adapter. Receive overflow marks the affected
+packet as erroneous; a master that respects `STALL` does not overflow the
+adapter. The transmit overflow counter remains zero because its stream input
+supports backpressure. These counters cover the adapters, not losses inside
+the WR endpoint or a downstream application.
+
+The NIC PHY preserves the error flag into LiteEth. A LiteScope capture of
+the WR bus and protocol state machines must use `wr_sys`; the application
+stream uses `sys` and requires a separate capture or an explicit CDC probe.
+
+## Validation
+
+`pytest -q test/test_wr_fabric.py` exercises asynchronous loopback with random
+backpressure, odd/even lengths, delayed pipelined responses, trailing status,
+bus errors/retries, a reset during a partial packet, and a master violating
+`STALL`. Physical packet throughput and WR link behavior require a connected
+WR peer and are separate from CPU/console smoke tests.

--- a/litex_wr_nic/gateware/nic/phy.py
+++ b/litex_wr_nic/gateware/nic/phy.py
@@ -31,10 +31,11 @@ class LiteEthPHYWRGMII(LiteXModule):
             self.cd_eth_rx.clk.eq(ClockSignal("sys")),
             self.cd_eth_rx.rst.eq(ResetSignal("sys")),
             self.cd_eth_tx.clk.eq(ClockSignal("sys")),
-            self.cd_eth_tx.clk.eq(ClockSignal("sys")),
+            self.cd_eth_tx.rst.eq(ResetSignal("sys")),
         ]
 
         self.comb += [
-            sink.connect(wrf_stream2wb.sink,     omit={"last_be", "error"}),
-            wrf_wb2stream.source.connect(source, omit={"last_be", "error"}),
+            sink.connect(wrf_stream2wb.sink,     omit={"last_be"}),
+            wrf_wb2stream.source.connect(source, omit={"last_be"}),
+            source.last_be.eq(source.last),
         ]

--- a/litex_wr_nic/gateware/soc.py
+++ b/litex_wr_nic/gateware/soc.py
@@ -268,16 +268,14 @@ class LiteXWRNICSoC(SoCMini):
     def add_wishbone_fabric_interface_probe(self):
        analyzer_signals = [
            self.wrf_stream2wb.bus,
-           self.wrf_stream2wb.sink,
            self.wrf_stream2wb.fsm,
 
            self.wrf_wb2stream.bus,
-           self.wrf_wb2stream.source,
-           self.wrf_wb2stream.fsm,
+           self.wrf_wb2stream.input_fsm,
        ]
        self.analyzer = LiteScopeAnalyzer(analyzer_signals,
            depth        = 256,
-           clock_domain = "wr",
+           clock_domain = "wr_sys",
            samplerate   = int(62.5e6),
            register     = True,
            csr_csv      = "test/analyzer.csv"

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -394,7 +394,7 @@ class WhiteRabbitCore(LiteXModule):
             o_wrf_src_sel         = wrf_wb2stream.bus.sel,
 
             i_wrf_src_ack         = wrf_wb2stream.bus.ack,
-            i_wrf_src_stall       = 0, # Not Used.
+            i_wrf_src_stall       = wrf_wb2stream.bus.stall,
             i_wrf_src_err         = wrf_wb2stream.bus.err,
             i_wrf_src_rty         = 0, # Not Used.
 
@@ -407,9 +407,9 @@ class WhiteRabbitCore(LiteXModule):
             i_wrf_snk_sel         = wrf_stream2wb.bus.sel,
 
             o_wrf_snk_ack         = wrf_stream2wb.bus.ack,
-            o_wrf_snk_stall       = Open(), # Not Used.
+            o_wrf_snk_stall       = wrf_stream2wb.bus.stall,
             o_wrf_snk_err         = wrf_stream2wb.bus.err,
-            o_wrf_snk_rty         = Open(), # Not Used.
+            o_wrf_snk_rty         = wrf_stream2wb.bus.rty,
 
             # Time.
             o_tm_link_up_o        = self.tm_link_up,

--- a/litex_wr_nic/gateware/wrf.py
+++ b/litex_wr_nic/gateware/wrf.py
@@ -1,0 +1,62 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.cdc import BusSynchronizer
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.gen import *
+from litex.soc.interconnect import stream, wishbone
+from litex.soc.interconnect.csr import CSRStatus
+
+# WR Fabric Interfaces -----------------------------------------------------------------------------
+
+class WRFInterface(wishbone.Interface):
+    def __init__(self):
+        super().__init__(data_width=16, address_width=2, addressing="byte")
+        # Unlike classic Wishbone, WR fabric separates request acceptance
+        # (STB and not STALL) from response completion (ACK/ERR/RTY).
+        for name in ("stall", "rty"):
+            setattr(self, name, Signal(name=name))
+            self.layout.append((name, 1, DIR_S_TO_M))
+
+
+class WRFClockCrossing(LiteXModule, DUID):
+    """FIFO and protocol logic share synchronized resets at both ends."""
+    def __init__(self, layout, cd_from, cd_to, depth=16):
+        DUID.__init__(self)
+        self.cd_input  = ClockDomain(f"wrf_in{self.duid}")
+        self.cd_output = ClockDomain(f"wrf_out{self.duid}")
+        self.input_cd  = self.cd_input.name
+        self.output_cd = self.cd_output.name
+        reset = ResetSignal(cd_from) | ResetSignal(cd_to)
+        self.comb += [
+            self.cd_input.clk.eq(ClockSignal(cd_from)),
+            self.cd_output.clk.eq(ClockSignal(cd_to)),
+        ]
+        self.specials += [
+            AsyncResetSynchronizer(self.cd_input, reset),
+            AsyncResetSynchronizer(self.cd_output, reset),
+        ]
+        if cd_from == cd_to:
+            self.fifo = ClockDomainsRenamer(self.input_cd)(stream.SyncFIFO(layout, depth, buffered=True))
+        else:
+            self.fifo = ClockDomainsRenamer({"write": self.input_cd, "read": self.output_cd})(
+                stream.AsyncFIFO(layout, depth))
+        self.sink   = self.fifo.sink
+        self.source = self.fifo.source
+
+
+class WRFCounters(LiteXModule):
+    def __init__(self, cd):
+        for name in ("packets", "errors", "stalls", "overflow"):
+            counter = Signal(32, name=name)
+            status = CSRStatus(32, name=name)
+            cdc = BusSynchronizer(32, cd, "sys")
+            setattr(self, name, counter)
+            setattr(self, "_" + name, status)
+            setattr(self, name + "_cdc", cdc)
+            self.comb += [cdc.i.eq(counter), status.status.eq(cdc.o)]

--- a/litex_wr_nic/gateware/wrf.py
+++ b/litex_wr_nic/gateware/wrf.py
@@ -9,6 +9,7 @@ from migen.genlib.cdc import BusSynchronizer
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.gen import *
+
 from litex.soc.interconnect import stream, wishbone
 from litex.soc.interconnect.csr import CSRStatus
 
@@ -32,6 +33,9 @@ class WRFClockCrossing(LiteXModule, DUID):
         self.cd_output = ClockDomain(f"wrf_out{self.duid}")
         self.input_cd  = self.cd_input.name
         self.output_cd = self.cd_output.name
+
+        # # #
+
         reset = ResetSignal(cd_from) | ResetSignal(cd_to)
         self.comb += [
             self.cd_input.clk.eq(ClockSignal(cd_from)),
@@ -52,11 +56,19 @@ class WRFClockCrossing(LiteXModule, DUID):
 
 class WRFCounters(LiteXModule):
     def __init__(self, cd):
-        for name in ("packets", "errors", "stalls", "overflow"):
+        for name, description in {
+            "packets"  : "Completed WR fabric packets.",
+            "errors"   : "WR fabric packets with errors.",
+            "stalls"   : "Cycles with a stalled WR fabric request.",
+            "overflow" : "WR fabric requests changed or withdrawn while stalled.",
+        }.items():
             counter = Signal(32, name=name)
-            status = CSRStatus(32, name=name)
-            cdc = BusSynchronizer(32, cd, "sys")
+            status  = CSRStatus(32, name=name, description=description + " Wraps at 32 bits.")
+            cdc     = BusSynchronizer(32, cd, "sys")
             setattr(self, name, counter)
             setattr(self, "_" + name, status)
             setattr(self, name + "_cdc", cdc)
-            self.comb += [cdc.i.eq(counter), status.status.eq(cdc.o)]
+            self.comb += [
+                cdc.i.eq(counter),
+                status.status.eq(cdc.o),
+            ]

--- a/litex_wr_nic/gateware/wrf_stream2wb.py
+++ b/litex_wr_nic/gateware/wrf_stream2wb.py
@@ -2,90 +2,134 @@
 # This file is part of LiteX-WR-NIC.
 #
 # Copyright (c) 2024 Warsaw University of Technology
-# Copyright (c) 2024 Enjoy-Digital <enjoy-digital.fr>
+# Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
 
 from litex.gen import *
-
 from litex.soc.interconnect import stream
 
-from litex.soc.interconnect import wishbone
+from litex_wr_nic.gateware.wrf import WRFInterface, WRFClockCrossing, WRFCounters
 
-# White Rabbit Fabric Stream 2 Wishbone ------------------------------------------------------------
-#
-# This module converts a 8-bit stream (sys_clk) into 16-bit Wishbone bus transactions (wr_clk):
-#                                                  │
-#                                   ◄──  sys_clk   │  wr_clk ──►
-#                                                  │
-#                        ┌─────────────────┐    ┌───────┐    ┌────────┐
-#                        │ 8-bit to 16-bit │    │       │    │        │
-#      8-bit Stream  ────►                 ┼────►  CDC  ┼────►  FSM   ┼───► 16-bit Wishbone
-#                        │    Converter    │    │       │    │        │
-#                        └─────────────────┘    └───────┘    └────────┘
+# White Rabbit Fabric Stream to Wishbone -----------------------------------------------------------
 
 class Stream2Wishbone(LiteXModule):
-    def __init__(self, cd_to="wr"):
-        self.sink = sink = stream.Endpoint([("data", 8)])
-        self.bus  = bus  = wishbone.Interface(data_width=16, address_width=2, addressing="byte")
+    """Transmit packets with independent pipelined request/response handling.
+
+    STALL governs request acceptance; ACK retires accepted requests. CYC stays
+    asserted through the final response. ERR/RTY abort the packet and drain its
+    remaining input. An input error produces a trailing WR error status word.
+    """
+    def __init__(self, cd_to="wr", depth=16, max_pending=16, match_class=0x02):
+        if max_pending < 1 or not 0 <= match_class <= 255:
+            raise ValueError("WR fabric needs a positive pending limit and an 8-bit class.")
+        self.sink = sink = stream.Endpoint([("data", 8), ("error", 1)])
+        self.bus  = bus  = WRFInterface()
 
         # # #
 
-        # 8-bit to 16-bit Converter.
-        self.converter = converter = stream.Converter(8, 16, reverse=True, report_valid_token_count=True)
-
-        # Clock Domain Crossing.
-        self.cdc = cdc = stream.ClockDomainCrossing(
-            layout  = [("data", 16), ("valid_token_count", 3)],
-            cd_from = "sys",
-            cd_to   = cd_to,
-            depth   = 16,
-            with_common_rst = True,
-        )
-
-        # Sink -> Converter -> CDC.
+        # Pack the error flag alongside each byte so it follows the exact same
+        # buffering and packet boundaries as the data, including odd packets.
+        self.cdc = cdc = WRFClockCrossing(
+            [("data", 18), ("valid_token_count", 2)], "sys", cd_to, depth)
+        self.converter = converter = ClockDomainsRenamer(cdc.input_cd)(
+            stream.Converter(9, 18, reverse=True, report_valid_token_count=True))
         self.comb += [
-            sink.connect(converter.sink),
+            sink.connect(converter.sink, omit={"data", "error"}),
+            converter.sink.data.eq(Cat(sink.data, sink.error)),
             converter.source.connect(cdc.sink),
         ]
-
-        # FSM.
-        self.fsm = fsm = ClockDomainsRenamer(cd_to)(FSM(reset_state="IDLE"))
+        self.stats = stats = WRFCounters(cdc.output_cd)
+        self.fsm = fsm = ClockDomainsRenamer(cdc.output_cd)(FSM(reset_state="IDLE"))
+        pending = Signal(max=max_pending + 1)
+        accepted = Signal()
+        response = Signal()
+        failed = Signal()
+        room = Signal()
+        frame_bad = Signal()
+        data_word = Cat(cdc.source.data[:8], cdc.source.data[9:17])
+        word_error = cdc.source.data[17] | ((cdc.source.valid_token_count == 2) & cdc.source.data[8])
+        self.comb += [
+            accepted.eq(bus.cyc & bus.stb & ~bus.stall),
+            response.eq(bus.cyc & (bus.ack | bus.err | bus.rty) & ((pending != 0) | accepted)),
+            failed.eq(response & (bus.err | bus.rty)),
+            room.eq(pending < max_pending),
+            bus.we.eq(1),
+        ]
+        sync_output = getattr(self.sync, cdc.output_cd)
+        sync_output += [
+            If(accepted & ~response, pending.eq(pending + 1)),
+            If(response & ~accepted, pending.eq(pending - 1)),
+            If(~bus.cyc, pending.eq(0)),
+            If(bus.cyc & bus.stb & bus.stall, stats.stalls.eq(stats.stalls + 1)),
+        ]
         fsm.act("IDLE",
-            If(cdc.source.valid,
-                NextState("STATUS")
-            )
+            NextValue(frame_bad, 0),
+            If(cdc.source.valid, NextState("STATUS")),
         )
         fsm.act("STATUS",
             bus.cyc.eq(1),
-            bus.stb.eq(1),
-            bus.we.eq(1),
-            bus.adr.eq(0b10), # Status Word.
-            bus.sel.eq(0b11),
-            bus.dat_w.eq(0x0200),
-            If(bus.ack,
-                NextState("DATA")
-            )
+            bus.stb.eq(room),
+            bus.adr.eq(2),
+            bus.sel.eq(3),
+            bus.dat_w.eq(match_class << 8),
+            If(accepted, NextState("DATA")),
+            If(failed,
+                NextValue(frame_bad, 1),
+                NextState("DROP"),
+            ),
         )
         fsm.act("DATA",
             bus.cyc.eq(1),
-            bus.stb.eq(cdc.source.valid),
-            bus.we.eq(1),
-            bus.adr.eq(0b00), # Regular Data.
-            Case(cdc.source.valid_token_count, {
-                1         : bus.sel.eq(0b10),
-                2         : bus.sel.eq(0b11),
-                "default" : bus.sel.eq(0b11),
-            }),
-            bus.dat_w.eq(cdc.source.data),
-            If(bus.ack,
-                cdc.source.ready.eq(1),
+            bus.stb.eq(cdc.source.valid & room),
+            bus.adr.eq(0),
+            bus.sel.eq(Mux(cdc.source.valid_token_count == 1, 2, 3)),
+            bus.dat_w.eq(data_word),
+            cdc.source.ready.eq(accepted),
+            If(accepted,
+                NextValue(frame_bad, frame_bad | word_error),
                 If(cdc.source.last,
-                    NextState("END")
-                )
-            )
+                    If(frame_bad | word_error,
+                        NextState("ERROR_STATUS"),
+                    ).Else(
+                        NextState("WAIT"),
+                    ),
+                ),
+            ),
+            If(failed,
+                NextValue(frame_bad, 1),
+                If(accepted & cdc.source.last, NextState("END")).Else(NextState("DROP")),
+            ),
+        )
+        fsm.act("ERROR_STATUS",
+            bus.cyc.eq(1),
+            bus.stb.eq(room),
+            bus.adr.eq(2),
+            bus.sel.eq(3),
+            bus.dat_w.eq((match_class << 8) | 2),
+            If(accepted, NextState("WAIT")),
+            If(failed, NextState("END")),
+        )
+        fsm.act("WAIT",
+            bus.cyc.eq(1),
+            If(pending == 0, NextState("END")),
+            If(failed,
+                NextValue(frame_bad, 1),
+                NextState("END"),
+            ),
+        )
+        fsm.act("DROP",
+            # ERR/RTY terminate the Wishbone cycle. Discard the rest of this
+            # application packet before accepting a new frame.
+            cdc.source.ready.eq(1),
+            If(cdc.source.valid & cdc.source.last, NextState("END")),
         )
         fsm.act("END",
-            NextState("IDLE")
+            NextValue(stats.packets, stats.packets + 1),
+            If(frame_bad, NextValue(stats.errors, stats.errors + 1)),
+            NextState("RECOVER"),
+        )
+        fsm.act("RECOVER",
+            If(~(bus.ack | bus.err | bus.rty), NextState("IDLE")),
         )

--- a/litex_wr_nic/gateware/wrf_stream2wb.py
+++ b/litex_wr_nic/gateware/wrf_stream2wb.py
@@ -8,6 +8,7 @@
 from migen import *
 
 from litex.gen import *
+
 from litex.soc.interconnect import stream
 
 from litex_wr_nic.gateware.wrf import WRFInterface, WRFClockCrossing, WRFCounters
@@ -41,14 +42,14 @@ class Stream2Wishbone(LiteXModule):
             converter.source.connect(cdc.sink),
         ]
         self.stats = stats = WRFCounters(cdc.output_cd)
-        self.fsm = fsm = ClockDomainsRenamer(cdc.output_cd)(FSM(reset_state="IDLE"))
-        pending = Signal(max=max_pending + 1)
-        accepted = Signal()
-        response = Signal()
-        failed = Signal()
-        room = Signal()
-        frame_bad = Signal()
-        data_word = Cat(cdc.source.data[:8], cdc.source.data[9:17])
+        self.fsm   = fsm = ClockDomainsRenamer(cdc.output_cd)(FSM(reset_state="IDLE"))
+        pending    = Signal(max=max_pending + 1)
+        accepted   = Signal()
+        response   = Signal()
+        failed     = Signal()
+        room       = Signal()
+        frame_bad  = Signal()
+        data_word  = Cat(cdc.source.data[:8], cdc.source.data[9:17])
         word_error = cdc.source.data[17] | ((cdc.source.valid_token_count == 2) & cdc.source.data[8])
         self.comb += [
             accepted.eq(bus.cyc & bus.stb & ~bus.stall),
@@ -99,7 +100,11 @@ class Stream2Wishbone(LiteXModule):
             ),
             If(failed,
                 NextValue(frame_bad, 1),
-                If(accepted & cdc.source.last, NextState("END")).Else(NextState("DROP")),
+                If(accepted & cdc.source.last,
+                    NextState("END"),
+                ).Else(
+                    NextState("DROP"),
+                ),
             ),
         )
         fsm.act("ERROR_STATUS",

--- a/litex_wr_nic/gateware/wrf_wb2stream.py
+++ b/litex_wr_nic/gateware/wrf_wb2stream.py
@@ -8,6 +8,7 @@
 from migen import *
 
 from litex.gen import *
+
 from litex.soc.interconnect import stream
 
 from litex_wr_nic.gateware.wrf import WRFInterface, WRFClockCrossing, WRFCounters
@@ -22,7 +23,7 @@ class Wishbone2Stream(LiteXModule):
     so final status/error words and odd byte counts reach the correct packet.
     """
     def __init__(self, cd_from="wr", depth=16):
-        self.bus    = bus = WRFInterface()
+        self.bus    = bus    = WRFInterface()
         self.source = source = stream.Endpoint([("data", 8), ("error", 1)])
 
         # # #
@@ -31,12 +32,12 @@ class Wishbone2Stream(LiteXModule):
         self.cdc = cdc = WRFClockCrossing(layout, cd_from, "sys", depth)
         self.stats = stats = WRFCounters(cdc.input_cd)
         self.input_fsm = ingress = ClockDomainsRenamer(cdc.input_cd)(FSM(reset_state="IDLE"))
-        accepted = Signal()
-        frame_bad = Signal()
-        stalled = Signal()
+        accepted     = Signal()
+        frame_bad    = Signal()
+        stalled      = Signal()
         stalled_word = Signal(21)
         request_word = Cat(bus.dat_w, bus.adr, bus.sel, bus.we)
-        violation = Signal()
+        violation    = Signal()
         self.comb += [
             accepted.eq(bus.cyc & bus.stb & ~bus.stall),
             violation.eq(stalled & (~bus.cyc | ~bus.stb | (request_word != stalled_word))),
@@ -63,7 +64,9 @@ class Wishbone2Stream(LiteXModule):
             NextValue(stalled, bus.cyc & bus.stb & bus.stall),
             NextValue(stalled_word, request_word),
             If(violation | (accepted & (~bus.we | ((bus.adr == 2) & bus.dat_w[1]) |
-                ((bus.adr == 0) & (bus.sel == 0)))), NextValue(frame_bad, 1)),
+                ((bus.adr == 0) & (bus.sel == 0)))),
+                NextValue(frame_bad, 1),
+            ),
             If(~bus.cyc,
                 NextValue(stalled, 0),
                 NextState("END"),
@@ -82,15 +85,19 @@ class Wishbone2Stream(LiteXModule):
         )
 
         # Parse the buffered records in the application clock domain.
-        word = stream.Endpoint([("data", 16), ("sel", 2), ("error", 1)])
-        data = Signal(16)
-        sel = Signal(2)
+        word  = stream.Endpoint([("data", 16), ("sel", 2), ("error", 1)])
+        data  = Signal(16)
+        sel   = Signal(2)
         first = Signal()
         error = Signal()
         self.fsm = parser = ClockDomainsRenamer(cdc.output_cd)(FSM(reset_state="EMPTY"))
         is_data = (cdc.source.adr == 0) & ~cdc.source.end & (cdc.source.sel != 0)
         status_error = ((cdc.source.adr == 2) & cdc.source.data[1]) | cdc.source.error
-        self.comb += [word.data.eq(data), word.sel.eq(sel), word.first.eq(first)]
+        self.comb += [
+            word.data.eq(data),
+            word.sel.eq(sel),
+            word.first.eq(first),
+        ]
         parser.act("EMPTY",
             cdc.source.ready.eq(1),
             If(cdc.source.valid,
@@ -132,7 +139,10 @@ class Wishbone2Stream(LiteXModule):
 
         # Serialize high byte first; SEL=10 and SEL=01 contain one byte.
         self.converter = converter = ClockDomainsRenamer(cdc.output_cd)(FSM(reset_state="HIGH"))
-        self.comb += [source.valid.eq(word.valid), source.error.eq(word.error & source.last)]
+        self.comb += [
+            source.valid.eq(word.valid),
+            source.error.eq(word.error & source.last),
+        ]
         converter.act("HIGH",
             source.data.eq(Mux(word.sel == 1, word.data[:8], word.data[8:])),
             source.first.eq(word.first),

--- a/litex_wr_nic/gateware/wrf_wb2stream.py
+++ b/litex_wr_nic/gateware/wrf_wb2stream.py
@@ -2,103 +2,147 @@
 # This file is part of LiteX-WR-NIC.
 #
 # Copyright (c) 2024 Warsaw University of Technology
-# Copyright (c) 2024 Enjoy-Digital <enjoy-digital.fr>
+# Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
 
 from litex.gen import *
-
 from litex.soc.interconnect import stream
 
-from litex.soc.interconnect import wishbone
+from litex_wr_nic.gateware.wrf import WRFInterface, WRFClockCrossing, WRFCounters
 
-# White Rabbit Fabric Wishbone 2 Stream ------------------------------------------------------------
-#
-# This module converts 16-bit Wishbone bus transactions (wr_clk) to a 8-bit stream (sys_clk):
-#                                          │
-#                           ◄──    wr_clk  │ sys_clk ──►
-#                                          │
-#                         ┌────────┐    ┌───────┐  ┌─────────────────┐
-#                         │        │    │       │  │ 16-bit to 8-bit │
-#     16-bit Wishbone ────►  FSM   ┼────►  CDC  ┼──►                 ┼───► 8-bit Stream
-#                         │        │    │       │  │    Converter    │
-#                         └────────┘    └───────┘  └─────────────────┘
+# White Rabbit Fabric Wishbone to Stream -----------------------------------------------------------
 
 class Wishbone2Stream(LiteXModule):
-    def __init__(self, cd_from="wr"):
-        self.bus    = bus    = wishbone.Interface(data_width=16, address_width=2, addressing="byte")
-        self.source = source = stream.Endpoint([("data", 8)])
+    """Receive WR packets without acknowledging data that cannot be buffered.
+
+    An explicit end token preserves CYC termination while the FIFO is full.
+    One data word is retained until the following word or end token is known,
+    so final status/error words and odd byte counts reach the correct packet.
+    """
+    def __init__(self, cd_from="wr", depth=16):
+        self.bus    = bus = WRFInterface()
+        self.source = source = stream.Endpoint([("data", 8), ("error", 1)])
 
         # # #
 
-        # Signals.
-        valid = Signal()
-        last  = Signal()
-        sel   = Signal(2)
-        data  = Signal(16)
-
-        # Always accept incoming accesses.
-        self.comb += bus.ack.eq(1)
-
-        # Clock Domain Crossing.
-        self.cdc = cdc = stream.ClockDomainCrossing(
-            layout  = [("data", 16), ("sel", 2)],
-            cd_from = cd_from,
-            cd_to   = "sys",
-            depth   = 16,
-            with_common_rst = True,
-        )
-
-        # FSM.
-        self.fsm = fsm = ClockDomainsRenamer(cd_from)(FSM(reset_state="IDLE"))
-        fsm.act("IDLE",
-            If(bus.stb & bus.cyc,
-                # On Status Word, jump to DATA.
-                If(bus.adr == 0b10,
-                    NextState("DATA")
-                )
-            )
-        )
-        fsm.act("DATA",
-            # Copy Regular Data.
-            If(bus.stb & bus.cyc,
-                If(bus.adr == 0b00,
-                    valid.eq(1),
-                    sel.eq(bus.sel),
-                    data.eq(bus.dat_w),
-                )
-            ),
-            # Return to IDLE when Regular Data or Access is done.
-            If(~bus.cyc | (bus.stb & bus.cyc & (bus.adr != 0b00)),
-                last.eq(1),
-                NextState("IDLE")
-            )
-        )
-        self.comb += cdc.sink.last.eq(last)
-        _sync = getattr(self.sync, cd_from)
-        _sync += [
-            cdc.sink.valid.eq(valid),
-            cdc.sink.sel.eq(sel),
-            cdc.sink.data.eq(data),
-        ]
-
-        # 16-bit to 8-bit Converter.
-        self.converter = converter = stream.Converter(16, 8, reverse=True)
-
-        # CDC -> Converter -> Source.
+        layout = [("data", 16), ("adr", 2), ("sel", 2), ("end", 1), ("error", 1)]
+        self.cdc = cdc = WRFClockCrossing(layout, cd_from, "sys", depth)
+        self.stats = stats = WRFCounters(cdc.input_cd)
+        self.input_fsm = ingress = ClockDomainsRenamer(cdc.input_cd)(FSM(reset_state="IDLE"))
+        accepted = Signal()
+        frame_bad = Signal()
+        stalled = Signal()
+        stalled_word = Signal(21)
+        request_word = Cat(bus.dat_w, bus.adr, bus.sel, bus.we)
+        violation = Signal()
         self.comb += [
-            If(cdc.source.valid,
-                # Even number of bytes.
-                If(cdc.source.sel == 0b11,
-                    cdc.source.connect(converter.sink, omit={"sel"}),
-                    converter.source.connect(source),
-                # Odd number of bytes.
-                ).Elif(cdc.source.sel == 0b10,
-                    cdc.source.connect(source, omit={"sel", "data"}),
-                    source.data.eq(cdc.source.data[8:16])
-                ).Else(
-                    cdc.source.ready.eq(1), # Ready by default.
-                )
-            )
+            accepted.eq(bus.cyc & bus.stb & ~bus.stall),
+            violation.eq(stalled & (~bus.cyc | ~bus.stb | (request_word != stalled_word))),
+            cdc.sink.data.eq(bus.dat_w),
+            cdc.sink.adr.eq(bus.adr),
+            cdc.sink.sel.eq(bus.sel),
         ]
+        sync_input = getattr(self.sync, cdc.input_cd)
+        sync_input += [
+            bus.ack.eq(accepted & bus.we),
+            bus.err.eq(accepted & ~bus.we),
+            If(bus.cyc & bus.stb & bus.stall, stats.stalls.eq(stats.stalls + 1)),
+            If(violation, stats.overflow.eq(stats.overflow + 1)),
+        ]
+        ingress.act("IDLE",
+            bus.stall.eq(1),
+            NextValue(stalled, 0),
+            NextValue(frame_bad, 0),
+            If(bus.cyc, NextState("DATA")),
+        )
+        ingress.act("DATA",
+            bus.stall.eq(~cdc.sink.ready),
+            cdc.sink.valid.eq(bus.cyc & bus.stb & bus.we),
+            NextValue(stalled, bus.cyc & bus.stb & bus.stall),
+            NextValue(stalled_word, request_word),
+            If(violation | (accepted & (~bus.we | ((bus.adr == 2) & bus.dat_w[1]) |
+                ((bus.adr == 0) & (bus.sel == 0)))), NextValue(frame_bad, 1)),
+            If(~bus.cyc,
+                NextValue(stalled, 0),
+                NextState("END"),
+            ),
+        )
+        ingress.act("END",
+            bus.stall.eq(1),
+            cdc.sink.valid.eq(1),
+            cdc.sink.end.eq(1),
+            cdc.sink.error.eq(frame_bad),
+            If(cdc.sink.ready,
+                NextValue(stats.packets, stats.packets + 1),
+                If(frame_bad, NextValue(stats.errors, stats.errors + 1)),
+                NextState("IDLE"),
+            ),
+        )
+
+        # Parse the buffered records in the application clock domain.
+        word = stream.Endpoint([("data", 16), ("sel", 2), ("error", 1)])
+        data = Signal(16)
+        sel = Signal(2)
+        first = Signal()
+        error = Signal()
+        self.fsm = parser = ClockDomainsRenamer(cdc.output_cd)(FSM(reset_state="EMPTY"))
+        is_data = (cdc.source.adr == 0) & ~cdc.source.end & (cdc.source.sel != 0)
+        status_error = ((cdc.source.adr == 2) & cdc.source.data[1]) | cdc.source.error
+        self.comb += [word.data.eq(data), word.sel.eq(sel), word.first.eq(first)]
+        parser.act("EMPTY",
+            cdc.source.ready.eq(1),
+            If(cdc.source.valid,
+                If(cdc.source.end,
+                    NextValue(error, 0),
+                ).Elif(is_data,
+                    NextValue(data, cdc.source.data),
+                    NextValue(sel, cdc.source.sel),
+                    NextValue(first, 1),
+                    NextState("WORD"),
+                ).Else(
+                    NextValue(error, error | status_error | (cdc.source.adr == 0)),
+                ),
+            ),
+        )
+        parser.act("WORD",
+            If(cdc.source.valid,
+                If(is_data | cdc.source.end,
+                    word.valid.eq(1),
+                    word.last.eq(cdc.source.end),
+                    word.error.eq(error | cdc.source.error),
+                    cdc.source.ready.eq(word.ready),
+                    If(word.ready,
+                        If(cdc.source.end,
+                            NextValue(error, 0),
+                            NextState("EMPTY"),
+                        ).Else(
+                            NextValue(data, cdc.source.data),
+                            NextValue(sel, cdc.source.sel),
+                            NextValue(first, 0),
+                        ),
+                    ),
+                ).Else(
+                    cdc.source.ready.eq(1),
+                    NextValue(error, error | status_error | (cdc.source.adr == 0)),
+                ),
+            ),
+        )
+
+        # Serialize high byte first; SEL=10 and SEL=01 contain one byte.
+        self.converter = converter = ClockDomainsRenamer(cdc.output_cd)(FSM(reset_state="HIGH"))
+        self.comb += [source.valid.eq(word.valid), source.error.eq(word.error & source.last)]
+        converter.act("HIGH",
+            source.data.eq(Mux(word.sel == 1, word.data[:8], word.data[8:])),
+            source.first.eq(word.first),
+            source.last.eq(word.last & (word.sel != 3)),
+            word.ready.eq(source.ready & (word.sel != 3)),
+            If(source.valid & source.ready & (word.sel == 3), NextState("LOW")),
+        )
+        converter.act("LOW",
+            source.data.eq(word.data[:8]),
+            source.last.eq(word.last),
+            word.ready.eq(source.ready),
+            If(source.valid & source.ready, NextState("HIGH")),
+        )

--- a/test/test_wr_clock_domains.py
+++ b/test/test_wr_clock_domains.py
@@ -97,13 +97,17 @@ def test_wr_interfaces_without_phy_clock():
         # The WR core itself originates fabric traffic in its system domain.
         yield rx.bus.cyc.eq(1)
         yield rx.bus.stb.eq(1)
-        yield rx.bus.adr.eq(2)
-        yield
-        yield rx.bus.adr.eq(0)
+        yield rx.bus.we.eq(1)
         yield rx.bus.sel.eq(3)
-        for word in [0xabcd, 0xef01]:
+        for address, word in [(2, 0x0200), (0, 0xabcd), (0, 0xef01)]:
+            yield rx.bus.adr.eq(address)
             yield rx.bus.dat_w.eq(word)
-            yield
+            for _ in range(100):
+                yield
+                if not (yield rx.bus.stall):
+                    break
+            else:
+                raise AssertionError("Fabric receive bus stalled")
         yield rx.bus.cyc.eq(0)
         yield rx.bus.stb.eq(0)
         for _ in range(150):

--- a/test/test_wr_core.py
+++ b/test/test_wr_core.py
@@ -96,7 +96,7 @@ def test_compatibility_adapter_registers_memory_and_csrs_once(platform):
     assert slaves["region"].origin == 0x20000000
     assert slaves["region"].size == 0x01000000
     banks = CSRBankArray(soc, lambda name, memory: 5)
-    assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge", "wr_info", "wr_time"]
+    assert [name for name, *_ in banks.banks] == ["wr_cpu_bridge", "wr_info", "wr_time", "wrf_stream2wb", "wrf_wb2stream"]
     assert [csr.name for csr in banks.banks[0][1]] == [
         "status", "error_count", "last_error_address",
     ]

--- a/test/test_wr_fabric.py
+++ b/test/test_wr_fabric.py
@@ -1,0 +1,300 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import random
+
+from migen import *
+from migen.fhdl.structure import _Assign
+
+from litex.gen import LiteXModule
+
+from litex_wr_nic.gateware.wrf_stream2wb import Stream2Wishbone
+from litex_wr_nic.gateware.wrf_wb2stream import Wishbone2Stream
+
+
+def simulate(dut, generators):
+    dut.cd_sys = ClockDomain("sys")
+    dut.cd_wr = ClockDomain("wr")
+    fragment = dut.get_fragment()
+    clocks = {"sys": 8, "wr": 16}
+    for statement in fragment.comb:
+        if isinstance(statement, _Assign) and isinstance(statement.r, ClockSignal):
+            if statement.r.cd in clocks:
+                for domain in fragment.clock_domains:
+                    if statement.l is domain.clk:
+                        clocks[domain.name] = clocks[statement.r.cd]
+    run_simulation(fragment, generators, clocks=clocks)
+
+
+def send_packets(sink, packets, error_frames=()):
+    for _ in range(10):
+        yield
+    for frame, packet in enumerate(packets):
+        for index, byte in enumerate(packet):
+            yield sink.valid.eq(1)
+            yield sink.data.eq(byte)
+            yield sink.first.eq(index == 0)
+            yield sink.last.eq(index == len(packet) - 1)
+            yield sink.error.eq(frame in error_frames and index == 0)
+            for _ in range(5000):
+                yield
+                if (yield sink.ready):
+                    break
+            else:
+                raise AssertionError("TX stream did not accept data")
+        yield sink.valid.eq(0)
+        yield
+
+
+def test_packet_loopback_with_backpressure_odd_lengths_and_errors():
+    dut = LiteXModule()
+    dut.tx = Stream2Wishbone(depth=8)
+    dut.rx = Wishbone2Stream(depth=8)
+    dut.comb += dut.tx.bus.connect(dut.rx.bus)
+    packets = [bytes((index + length) % 256 for index in range(length))
+        for length in (1, 2, 3, 7, 16, 31, 128, 255)]
+    received = []
+    rng = random.Random(0x5742)
+
+    def consumer():
+        packet = bytearray()
+        for tick in range(15000):
+            ready = tick > 200 and rng.randrange(4) != 0
+            yield dut.rx.source.ready.eq(ready)
+            yield
+            if (yield dut.rx.source.valid) and (yield dut.rx.source.ready):
+                assert bool((yield dut.rx.source.first)) == (len(packet) == 0)
+                packet.append((yield dut.rx.source.data))
+                if (yield dut.rx.source.last):
+                    received.append((bytes(packet), (yield dut.rx.source.error)))
+                    packet.clear()
+                    if len(received) == len(packets):
+                        return
+        raise AssertionError(("Packet loopback did not complete", received, bytes(packet)))
+
+    simulate(dut, {"sys": [send_packets(dut.tx.sink, packets, error_frames=(1, 5)), consumer()]})
+    assert received == [(packet, int(index in (1, 5))) for index, packet in enumerate(packets)]
+
+
+def test_tx_retires_delayed_responses_and_keeps_request_stable_under_stall():
+    dut = Stream2Wishbone(depth=16, max_pending=8)
+    packets = [bytes(range(48)), b"abc"]
+    frames = []
+    accepted_ticks = []
+
+    def fabric():
+        responses = []
+        words = []
+        previous_cyc = 0
+        stalled_request = None
+        for tick in range(5000):
+            cyc = yield dut.bus.cyc
+            stb = yield dut.bus.stb
+            stall = yield dut.bus.stall
+            request = ((yield dut.bus.adr), (yield dut.bus.dat_w), (yield dut.bus.sel))
+            if stalled_request is not None and cyc:
+                assert stb and request == stalled_request
+            stalled_request = request if cyc and stb and stall else None
+            if cyc and stb and not stall:
+                words.append(request)
+                responses.append(tick + 4)
+                accepted_ticks.append(tick)
+            if previous_cyc and not cyc:
+                assert not responses, "CYC dropped with outstanding responses"
+                frames.append(words)
+                words = []
+                if len(frames) == 2:
+                    return
+            previous_cyc = cyc
+            # Responses describe earlier accepted words and can coincide with
+            # STALL on a new word. Do not equate ACK with acceptance.
+            ack = bool(responses and responses[0] <= tick + 1)
+            if ack:
+                responses.pop(0)
+            yield dut.bus.ack.eq(ack)
+            yield dut.bus.stall.eq(tick < 70 or tick % 7 in (2, 3))
+            yield
+        raise AssertionError("TX did not complete")
+
+    simulate(dut, {"sys": send_packets(dut.sink, packets), "wr": fabric()})
+    for packet, frame in zip(packets, frames):
+        assert frame[0] == (2, 0x0200, 3)
+        data = bytearray()
+        for address, value, sel in frame[1:]:
+            assert address == 0
+            data.append(value >> 8)
+            if sel == 3:
+                data.append(value & 255)
+        assert bytes(data) == packet
+    assert any(second - first == 1 for first, second in zip(accepted_ticks, accepted_ticks[1:]))
+
+
+def test_rx_retains_end_marker_while_full_and_marks_trailing_status_error():
+    dut = Wishbone2Stream(depth=4)
+    received = []
+
+    def master():
+        for _ in range(10):
+            yield
+        yield dut.bus.cyc.eq(1)
+        yield dut.bus.we.eq(1)
+        yield dut.bus.stb.eq(1)
+        for address, value, sel in [(2, 0x0200, 3), (0, 0x1234, 3), (0, 0x5600, 2),
+            (1, 0xaaaa, 3), (2, 0x0202, 3)]:
+            yield dut.bus.adr.eq(address)
+            yield dut.bus.dat_w.eq(value)
+            yield dut.bus.sel.eq(sel)
+            for _ in range(500):
+                yield
+                if not (yield dut.bus.stall):
+                    break
+            else:
+                raise AssertionError("RX remained stalled")
+        yield dut.bus.cyc.eq(0)
+        yield dut.bus.stb.eq(0)
+        for _ in range(300):
+            yield
+
+    def consumer():
+        for tick in range(600):
+            yield dut.source.ready.eq(tick > 150)
+            yield
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                received.append(((yield dut.source.data), (yield dut.source.first),
+                    (yield dut.source.last), (yield dut.source.error)))
+
+    simulate(dut, {"wr": master(), "sys": consumer()})
+    assert received == [(0x12, 1, 0, 0), (0x34, 0, 0, 0), (0x56, 0, 1, 1)]
+
+
+def test_tx_aborts_error_and_retry_then_starts_a_clean_packet():
+    for response in ("err", "rty"):
+        dut = Stream2Wishbone(depth=8)
+        packets = [bytes(range(32)), b"good"]
+        frames = []
+
+        def fabric():
+            failed = False
+            previous_cyc = 0
+            words = []
+            for _ in range(5000):
+                cyc = yield dut.bus.cyc
+                stb = yield dut.bus.stb
+                yield dut.bus.ack.eq(0)
+                yield getattr(dut.bus, response).eq(0)
+                if cyc and stb:
+                    words.append(((yield dut.bus.adr), (yield dut.bus.dat_w), (yield dut.bus.sel)))
+                    if not failed and len(words) == 3:
+                        yield getattr(dut.bus, response).eq(1)
+                        failed = True
+                    else:
+                        yield dut.bus.ack.eq(1)
+                if previous_cyc and not cyc:
+                    frames.append(words)
+                    words = []
+                    if len(frames) == 2:
+                        return
+                previous_cyc = cyc
+                yield
+            raise AssertionError("TX did not recover")
+
+        simulate(dut, {"sys": send_packets(dut.sink, packets), "wr": fabric()})
+        assert frames[-1] == [(2, 0x0200, 3), (0, 0x676f, 3), (0, 0x6f64, 3)]
+
+
+def test_reset_flushes_partial_packet_state_on_both_sides():
+    dut = LiteXModule()
+    dut.tx = Stream2Wishbone(depth=4)
+    dut.rx = Wishbone2Stream(depth=4)
+    dut.comb += dut.tx.bus.connect(dut.rx.bus)
+    after_reset = {"active": False}
+    received = []
+
+    def producer():
+        for _ in range(10):
+            yield
+        for index in range(12):
+            yield dut.tx.sink.valid.eq(1)
+            yield dut.tx.sink.first.eq(index == 0)
+            yield dut.tx.sink.last.eq(0)
+            yield dut.tx.sink.data.eq(0xff)
+            yield dut.tx.sink.error.eq(1)
+            while True:
+                yield
+                if (yield dut.tx.sink.ready):
+                    break
+        yield dut.tx.sink.valid.eq(0)
+        for _ in range(30):
+            yield
+        yield dut.cd_wr.rst.eq(1)
+        for _ in range(20):
+            yield
+        yield dut.cd_wr.rst.eq(0)
+        for _ in range(20):
+            yield
+        after_reset["active"] = True
+        yield from send_packets(dut.tx.sink, [b"new"])
+
+    def consumer():
+        yield dut.rx.source.ready.eq(1)
+        for _ in range(1500):
+            yield
+            if after_reset["active"] and (yield dut.rx.source.valid) and (yield dut.rx.source.ready):
+                received.append(((yield dut.rx.source.data), (yield dut.rx.source.first),
+                    (yield dut.rx.source.last), (yield dut.rx.source.error)))
+
+    simulate(dut, {"sys": [producer(), consumer()]})
+    assert received == [(ord("n"), 1, 0, 0), (ord("e"), 0, 0, 0), (ord("w"), 0, 1, 0)]
+
+
+def test_rx_reports_a_master_that_aborts_a_stalled_word():
+    dut = Wishbone2Stream(depth=4)
+    dropped = {"done": False, "accepted": []}
+    received = []
+
+    def master():
+        for _ in range(10):
+            yield
+        yield dut.bus.cyc.eq(1)
+        yield dut.bus.we.eq(1)
+        yield dut.bus.stb.eq(1)
+        yield dut.bus.adr.eq(2)
+        yield dut.bus.dat_w.eq(0x0200)
+        yield dut.bus.sel.eq(3)
+        while True:
+            yield
+            if not (yield dut.bus.stall):
+                break
+        yield dut.bus.adr.eq(0)
+        for index in range(64):
+            yield dut.bus.dat_w.eq(index)
+            yield
+            if (yield dut.bus.stall):
+                # Deliberately violate the protocol by abandoning this word.
+                for _ in range(3):
+                    yield
+                yield dut.bus.cyc.eq(0)
+                yield dut.bus.stb.eq(0)
+                dropped["done"] = True
+                break
+            dropped["accepted"].extend([0, index])
+        else:
+            raise AssertionError("RX FIFO never applied backpressure")
+        for _ in range(300):
+            yield
+        assert (yield dut.stats.overflow) == 1
+        assert (yield dut.stats.errors) == 1
+
+    def consumer():
+        for _ in range(1000):
+            yield dut.source.ready.eq(dropped["done"])
+            yield
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                received.append(((yield dut.source.data), (yield dut.source.last), (yield dut.source.error)))
+
+    simulate(dut, {"wr": master(), "sys": consumer()})
+    assert [data for data, _, _ in received] == dropped["accepted"]
+    assert received[-1][1:] == (1, 1)

--- a/test/test_wr_fabric.py
+++ b/test/test_wr_fabric.py
@@ -14,10 +14,11 @@ from litex.gen import LiteXModule
 from litex_wr_nic.gateware.wrf_stream2wb import Stream2Wishbone
 from litex_wr_nic.gateware.wrf_wb2stream import Wishbone2Stream
 
+# Simulation Helpers -------------------------------------------------------------------------------
 
 def simulate(dut, generators):
     dut.cd_sys = ClockDomain("sys")
-    dut.cd_wr = ClockDomain("wr")
+    dut.cd_wr  = ClockDomain("wr")
     fragment = dut.get_fragment()
     clocks = {"sys": 8, "wr": 16}
     for statement in fragment.comb:
@@ -48,6 +49,7 @@ def send_packets(sink, packets, error_frames=()):
         yield sink.valid.eq(0)
         yield
 
+# Fabric Tests -------------------------------------------------------------------------------------
 
 def test_packet_loopback_with_backpressure_odd_lengths_and_errors():
     dut = LiteXModule()
@@ -86,13 +88,13 @@ def test_tx_retires_delayed_responses_and_keeps_request_stable_under_stall():
     accepted_ticks = []
 
     def fabric():
-        responses = []
-        words = []
-        previous_cyc = 0
+        responses       = []
+        words           = []
+        previous_cyc    = 0
         stalled_request = None
         for tick in range(5000):
-            cyc = yield dut.bus.cyc
-            stb = yield dut.bus.stb
+            cyc   = yield dut.bus.cyc
+            stb   = yield dut.bus.stb
             stall = yield dut.bus.stall
             request = ((yield dut.bus.adr), (yield dut.bus.dat_w), (yield dut.bus.sel))
             if stalled_request is not None and cyc:
@@ -293,7 +295,11 @@ def test_rx_reports_a_master_that_aborts_a_stalled_word():
             yield dut.source.ready.eq(dropped["done"])
             yield
             if (yield dut.source.valid) and (yield dut.source.ready):
-                received.append(((yield dut.source.data), (yield dut.source.last), (yield dut.source.error)))
+                received.append((
+                    (yield dut.source.data),
+                    (yield dut.source.last),
+                    (yield dut.source.error),
+                ))
 
     simulate(dut, {"wr": master(), "sys": consumer()})
     assert [data for data, _, _ in received] == dropped["accepted"]


### PR DESCRIPTION
Preserves packet framing and errors under application backpressure and delayed WR fabric responses. RX stalls before accepting data it cannot buffer and retains end-of-frame/status records; TX separates pipelined request acceptance from completion, waits for all responses, and aborts/drains on ERR or RTY. Odd packet lengths, trailing error status and reset during a partial word are handled explicitly. NIC error propagation and the fabric LiteScope clock domain are corrected.

Adds coherent packet/error/stall/overflow counters and documents stream, reset and abort contracts in `doc/wr_application_fabric.md`. Depends on #75.

Validation: all 72 tests pass, including six new fabric simulations with asynchronous clocks, seeded backpressure, delayed pipelined responses, odd/even lengths, trailing status, error/retry recovery, one-sided reset, and a master withdrawing a stalled request. SPEC-A7 VexRiscv/integrated elaboration passes. The default-uRV build passed two FPGA reloads with full ver/help/time/uptime replies, continued execution, safe restart and coherent time snapshots; adapter error/overflow counters stayed zero. The original routed report has a false inter-mode PIPE setup failure (-0.161 ns). With the dedicated PIPE mux clocks declared exclusive as in #78, the same routed design meets timing (WNS +0.036 ns, WHS +0.057 ns). Physical traffic/throughput qualification requires a connected WR peer; none is currently attached.

LiteX style review (2026-09-08): Aligned fabric signals and simulations, expanded dense logic blocks, and documented counters. All 17 focused fabric/core tests pass. The complete stack passes 87 tests. Six target elaborations preserve the existing CSR/memory/configuration maps, excluding generated build identifiers; management and MMCM status field widths/offsets are unchanged. This cleanup was checked in software/simulation and elaboration; the hardware/timing evidence above comes from the previously qualified bitstreams.
