### PR TITLE
wr: add calibrated DAC and MMCM tuning backends

### DIFF
--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -373,6 +373,9 @@ class BaseSoC(LiteXWRNICSoC):
         if with_white_rabbit:
             # Host/WR register and fabric traffic crosses asynchronous FIFOs.
             platform.add_false_path_constraints(self.crg.cd_sys.clk, self.cd_wr_sys.clk)
+            # Tuning commands cross an asynchronous FIFO into PSCLK. The
+            # disciplined WR clock has no fixed phase relative to PSCLK.
+            platform.add_false_path_constraints(self.crg.cd_clk200.clk, self.cd_wr_sys.clk)
 
         platform.add_false_path_constraints(*asynchronous_clk_domains)
 

--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -50,7 +50,7 @@ from litex_wr_nic.gateware.delay.core        import MacroDelay, CoarseDelay, Fin
 from litex_wr_nic.gateware.pps               import PPSGenerator
 from litex_wr_nic.gateware.clk10m            import Clk10MGenerator
 from litex_wr_nic.gateware.nic.phy           import LiteEthPHYWRGMII
-from litex_wr_nic.gateware.ps_gen            import PSGen
+from litex_wr_nic.gateware.wr_clock          import WRMMCMBackend
 from litex_wr_nic.gateware.wr_cpu            import (
     WR_CPU_MEMORY_ORIGIN,
     WR_CPU_MEMORY_SIZE,
@@ -269,31 +269,29 @@ class BaseSoC(LiteXWRNICSoC):
 
             # RefClk MMCM Phase Shift.
             # ------------------------
-            self.refclk_mmcm_ps_gen = PSGen(
-                cd_psclk  = "clk200",
-                cd_sys    = "wr_sys",
-                ctrl_size = 16,
+            self.refclk_mmcm_ps_gen = WRMMCMBackend(
+                cd_psclk   = "clk200",
+                cd_command = "wr_sys",
+                width      = 16,
             )
             self.comb += [
-                self.refclk_mmcm_ps_gen.ctrl_data.eq(self.dac_refclk_data),
-                self.refclk_mmcm_ps_gen.ctrl_load.eq(self.dac_refclk_load),
-                self.crg.refclk_mmcm.psen.eq(self.refclk_mmcm_ps_gen.psen),
-                self.crg.refclk_mmcm.psincdec.eq(self.refclk_mmcm_ps_gen.psincdec),
+                self.wr_core.refclk_tuning.connect(self.refclk_mmcm_ps_gen.command),
+                self.crg.refclk_mmcm.psen.eq(     self.refclk_mmcm_ps_gen.psen),
+                self.crg.refclk_mmcm.psincdec.eq( self.refclk_mmcm_ps_gen.psincdec),
                 self.refclk_mmcm_ps_gen.psdone.eq(self.crg.refclk_mmcm.psdone),
             ]
 
             # DMTD MMCM Phase Shift.
             # ----------------------
-            self.dmtd_mmcm_ps_gen = PSGen(
-                cd_psclk  = "clk200",
-                cd_sys    = "wr_sys",
-                ctrl_size = 16,
+            self.dmtd_mmcm_ps_gen = WRMMCMBackend(
+                cd_psclk   = "clk200",
+                cd_command = "wr_sys",
+                width      = 16,
             )
             self.comb += [
-                self.dmtd_mmcm_ps_gen.ctrl_data.eq(self.dac_dmtd_data),
-                self.dmtd_mmcm_ps_gen.ctrl_load.eq(self.dac_dmtd_load),
-                self.crg.dmtd_mmcm.psen.eq(self.dmtd_mmcm_ps_gen.psen),
-                self.crg.dmtd_mmcm.psincdec.eq(self.dmtd_mmcm_ps_gen.psincdec),
+                self.wr_core.dmtd_tuning.connect(self.dmtd_mmcm_ps_gen.command),
+                self.crg.dmtd_mmcm.psen.eq(     self.dmtd_mmcm_ps_gen.psen),
+                self.crg.dmtd_mmcm.psincdec.eq( self.dmtd_mmcm_ps_gen.psincdec),
                 self.dmtd_mmcm_ps_gen.psdone.eq(self.crg.dmtd_mmcm.psdone),
             ]
 

--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -107,6 +107,11 @@ class _CRG(LiteXModule):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(LiteXWRNICSoC):
+    # Use the oscillator-control slots for this board's MMCM backends.
+    csr_map = {name: location for name, location in LiteXWRNICSoC.csr_map.items()
+        if name not in ("refclk_dac", "dmtd_dac")}
+    csr_map.update({"refclk_mmcm_ps_gen": 21, "dmtd_mmcm_ps_gen": 22})
+
     def __init__(self, sys_clk_freq=125e6,
         # PCIe Parameters.
         # ----------------
@@ -265,29 +270,31 @@ class BaseSoC(LiteXWRNICSoC):
             # RefClk MMCM Phase Shift.
             # ------------------------
             self.refclk_mmcm_ps_gen = PSGen(
-                 cd_psclk    = "clk200",
-                 cd_sys      = "wr_sys",
-                 ctrl_size   = 16,
-                 )
+                cd_psclk  = "clk200",
+                cd_sys    = "wr_sys",
+                ctrl_size = 16,
+            )
             self.comb += [
                 self.refclk_mmcm_ps_gen.ctrl_data.eq(self.dac_refclk_data),
                 self.refclk_mmcm_ps_gen.ctrl_load.eq(self.dac_refclk_load),
                 self.crg.refclk_mmcm.psen.eq(self.refclk_mmcm_ps_gen.psen),
                 self.crg.refclk_mmcm.psincdec.eq(self.refclk_mmcm_ps_gen.psincdec),
+                self.refclk_mmcm_ps_gen.psdone.eq(self.crg.refclk_mmcm.psdone),
             ]
 
             # DMTD MMCM Phase Shift.
             # ----------------------
             self.dmtd_mmcm_ps_gen = PSGen(
-                 cd_psclk    = "clk200",
-                 cd_sys      = "wr_sys",
-                 ctrl_size   = 16,
-                 )
+                cd_psclk  = "clk200",
+                cd_sys    = "wr_sys",
+                ctrl_size = 16,
+            )
             self.comb += [
                 self.dmtd_mmcm_ps_gen.ctrl_data.eq(self.dac_dmtd_data),
                 self.dmtd_mmcm_ps_gen.ctrl_load.eq(self.dac_dmtd_load),
                 self.crg.dmtd_mmcm.psen.eq(self.dmtd_mmcm_ps_gen.psen),
                 self.crg.dmtd_mmcm.psincdec.eq(self.dmtd_mmcm_ps_gen.psincdec),
+                self.dmtd_mmcm_ps_gen.psdone.eq(self.crg.dmtd_mmcm.psdone),
             ]
 
             # Timings Constraints.

--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -87,7 +87,8 @@ class _CRG(LiteXModule):
 
         # RefClk MMCM (125MHz).
         # ---------------------
-        self.refclk_mmcm = S7MMCM(speedgrade=-3)
+        # Fine phase shifting requires integer feedback/output division (UG472).
+        self.refclk_mmcm = S7MMCM(speedgrade=-3, fractional=False)
         self.comb += self.refclk_mmcm.reset.eq(self.rst)
         self.refclk_mmcm.register_clkin(ClockSignal("clk200"), 200e6)
         self.refclk_mmcm.create_clkout(self.cd_clk_125m_gtp,  125e6, margin=0)
@@ -97,7 +98,7 @@ class _CRG(LiteXModule):
 
         # DMTD MMCM (62.5MHz).
         # --------------------
-        self.dmtd_mmcm = S7MMCM(speedgrade=-3)
+        self.dmtd_mmcm = S7MMCM(speedgrade=-3, fractional=False)
         self.comb += self.dmtd_mmcm.reset.eq(self.rst)
         self.dmtd_mmcm.register_clkin(ClockSignal("clk200"), 200e6)
         self.dmtd_mmcm.create_clkout(self.cd_clk_62m5_dmtd, 62.5e6, margin=0)

--- a/bench/spec_a7_mmcm.py
+++ b/bench/spec_a7_mmcm.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Temporary SPEC-A7 image for measuring WRMMCMBackend against real MMCMs."""
+
+import argparse
+
+from migen import *
+from migen.genlib.cdc import BusSynchronizer, GrayCounter, GrayDecoder, MultiReg, PulseSynchronizer
+
+from litex.gen import LiteXModule
+
+from litex.soc.cores.clock import S7MMCM, S7PLL
+from litex.soc.integration.builder import Builder
+from litex.soc.integration.soc_core import SoCMini
+from litex.soc.interconnect.csr import CSRStatus, CSRStorage
+
+from spec_a7_platform import Platform
+from litex_wr_nic.gateware.wr_clock import WRMMCMBackend
+
+# Clocking -----------------------------------------------------------------------------------------
+
+class CRG(LiteXModule):
+    def __init__(self, platform):
+        self.cd_sys      = ClockDomain("sys")
+        self.cd_ps       = ClockDomain("ps")
+        self.cd_input100 = ClockDomain("input100")
+        self.cd_command  = ClockDomain("command_raw", reset_less=True)
+        self.pll = pll = S7PLL(speedgrade=-2)
+        self.comb += platform.request("clk125m_oe").eq(1)
+        pll.register_clkin(platform.request("clk125m"), 125e6)
+        pll.create_clkout(self.cd_sys,      62.5e6, margin=0)
+        pll.create_clkout(self.cd_ps,        200e6, margin=0)
+        pll.create_clkout(self.cd_input100,  100e6, margin=0)
+        # Drive the independently gated command clocks directly from a PLL
+        # output. A single BUFG cannot legally cascade into four BUFGCEs.
+        pll.create_clkout(self.cd_command, 62.5e6, margin=0, with_reset=False, buf=None)
+
+# Hardware Qualification Channel ------------------------------------------------------------------
+
+class MMCMChannel(LiteXModule):
+    def __init__(self, name, input_cd, input_freq, output_freq, gate_cycles=2**24):
+        self._code        = CSRStorage(16, reset=32768)
+        self._enable      = CSRStorage()
+        self._period      = CSRStorage(16, reset=1)
+        self._reset       = CSRStorage(reset=1)
+        self._pause       = CSRStorage()
+        self._drop_done   = CSRStorage()
+        self._measure     = CSRStorage()
+        self._locked      = CSRStatus()
+        self._errors      = CSRStatus(32)
+        self._gate_cycles = CSRStatus(32, reset=gate_cycles)
+        self._frequency   = CSRStatus(32, reset=int(output_freq))
+
+        # # #
+
+        # The command clock can be stopped without stopping host access or
+        # PSCLK. All host settings are stable before resuming this clock.
+        self.cd_command = ClockDomain(f"{name}_command")
+        self.specials += Instance("BUFGCE",
+            i_I  = ClockSignal("command_raw"),
+            i_CE = ~self._pause.storage,
+            o_O  = self.cd_command.clk,
+        )
+        self.comb += self.cd_command.rst.eq(ResetSignal("sys") | self._reset.storage)
+
+        # Respect the SPEC-A7's -2 speed grade. The selected VCO is exported
+        # for the host's independent output-frequency prediction.
+        self.cd_output = ClockDomain(f"{name}_output")
+        self.mmcm = mmcm = S7MMCM(speedgrade=-2, fractional=False)
+        mmcm.register_clkin(ClockSignal(input_cd), input_freq)
+        mmcm.create_clkout(self.cd_output, output_freq, margin=0)
+        mmcm.expose_dps("ps", with_csr=False)
+        mmcm.params["p_CLKOUT0_USE_FINE_PS"] = "TRUE"
+        mmcm_reset = Signal()
+        self.specials += MultiReg(self._reset.storage | ResetSignal("sys"), mmcm_reset, input_cd)
+        self.comb += mmcm.reset.eq(mmcm_reset)
+        self._vco = CSRStatus(32, reset=int(mmcm.compute_config()["vco"]))
+
+        self.backend = backend = WRMMCMBackend("ps", self.cd_command.name)
+        period = Signal(16)
+        sync = getattr(self.sync, self.cd_command.name)
+        sync += [
+            backend.command.load.eq(0),
+            If(self._enable.storage,
+                If(period == 0,
+                    backend.command.data.eq(self._code.storage),
+                    backend.command.load.eq(1),
+                    period.eq(self._period.storage - 1),
+                ).Else(
+                    period.eq(period - 1),
+                ),
+            ).Else(
+                period.eq(0),
+            ),
+        ]
+        drop_done = Signal()
+        self.specials += MultiReg(self._drop_done.storage, drop_done, "ps")
+        self.comb += [
+            mmcm.psen.eq(backend.psen),
+            mmcm.psincdec.eq(backend.psincdec),
+            backend.psdone.eq(mmcm.psdone & ~drop_done),
+        ]
+
+        # Count actual output-clock edges and transfer the Gray count to
+        # PSCLK. Only the measurement interval, not the phase accumulator,
+        # participates in the independent frequency measurement.
+        self.counter = counter = ClockDomainsRenamer(self.cd_output.name)(GrayCounter(32))
+        self.decoder = decoder = ClockDomainsRenamer("ps")(GrayDecoder(32))
+        self.comb += counter.ce.eq(1)
+        self.specials += MultiReg(counter.q, decoder.i, "ps")
+
+        pending    = Signal()
+        direction  = Signal()
+        previous   = Signal()
+        age        = Signal(16)
+        issued     = Signal(32)
+        completed  = Signal(32)
+        phase      = Signal(32)
+        errors     = Signal(32)
+        reset_ps   = Signal()
+        locked_ps  = Signal()
+        had_lock   = Signal()
+        self.specials += [
+            MultiReg(self._reset.storage, reset_ps, "ps"),
+            MultiReg(mmcm.locked, locked_ps, "ps"),
+        ]
+        self.sync.ps += [
+            previous.eq(backend.psen),
+            If(reset_ps,
+                pending.eq(0),
+                previous.eq(0),
+                age.eq(0),
+                issued.eq(0),
+                completed.eq(0),
+                phase.eq(0),
+                errors.eq(0),
+                had_lock.eq(0),
+            ).Elif(locked_ps,
+                had_lock.eq(1),
+                If(pending, age.eq(age + 1)),
+                If(backend.psen,
+                    pending.eq(1),
+                    direction.eq(backend.psincdec),
+                    age.eq(0),
+                    issued.eq(issued + 1),
+                    If(pending, errors[0].eq(1)),
+                    If(previous, errors[1].eq(1)),
+                ),
+                If(pending & (backend.psincdec != direction), errors[2].eq(1)),
+                If(mmcm.psdone,
+                    pending.eq(0),
+                    completed.eq(completed + 1),
+                    If(direction,
+                        phase.eq(phase + 1),
+                    ).Else(
+                        phase.eq(phase - 1),
+                    ),
+                    If(~pending, errors[3].eq(1)),
+                    If(age != 11, errors[4].eq(1)),
+                ),
+            ).Elif(had_lock,
+                errors[5].eq(1),
+            ),
+        ]
+        self.live_cdc = live_cdc = BusSynchronizer(33, "ps", "sys")
+        self.comb += [
+            live_cdc.i.eq(Cat(errors, locked_ps)),
+            self._errors.status.eq(live_cdc.o[:32]),
+            self._locked.status.eq(live_cdc.o[32]),
+        ]
+
+        # Freeze all results at the same PSCLK edge and publish a new sample
+        # identifier with them. Host reads cannot mix two measurement windows.
+        self.trigger = trigger = PulseSynchronizer("sys", "ps")
+        self.comb += trigger.i.eq(self._measure.re)
+        measuring = Signal()
+        timer     = Signal(max=gate_cycles)
+        sequence  = Signal(32)
+        signals   = dict(edges=decoder.o, phase=phase, issued=issued,
+            completed=completed, steps=backend.steps, errors=errors)
+        starts    = {name: Signal(32) for name in signals}
+        samples   = {name: Signal(32) for name in signals}
+        self.sync.ps += If(reset_ps,
+            measuring.eq(0),
+        ).Elif(trigger.o & ~measuring,
+            measuring.eq(1),
+            timer.eq(0),
+            *[starts[name].eq(signal) for name, signal in signals.items()],
+        ).Elif(measuring,
+            If(timer == gate_cycles - 1,
+                measuring.eq(0),
+                sequence.eq(sequence + 1),
+                *[samples[name].eq(signal - starts[name]) for name, signal in signals.items()],
+                samples["errors"].eq(errors),
+            ).Else(
+                timer.eq(timer + 1),
+            ),
+        )
+        samples["id"] = sequence
+        self.sample_cdc = sample_cdc = BusSynchronizer(32*len(samples), "ps", "sys")
+        self.comb += sample_cdc.i.eq(Cat(*samples.values()))
+        for index, name in enumerate(samples):
+            csr = CSRStatus(32, name=f"sample_{name}")
+            setattr(self, f"_sample_{name}", csr)
+            self.comb += csr.status.eq(sample_cdc.o[32*index:32*(index + 1)])
+
+# SoC ----------------------------------------------------------------------------------------------
+
+class MMCMTestSoC(SoCMini):
+    def __init__(self):
+        platform = Platform(variant="xc7a50t")
+        self.crg = CRG(platform)
+        SoCMini.__init__(self, platform, clk_freq=62.5e6,
+            ident="WR MMCM hardware qualification", ident_version=False)
+        self.add_jtagbone()
+        platform.add_period_constraint(self.jtagbone_phy.cd_jtag.clk, 1e9/20e6)
+        platform.add_false_path_constraints(self.jtagbone_phy.cd_jtag.clk, self.crg.cd_sys.clk)
+        for input_freq, input_cd in [(100e6, "input100"), (200e6, "ps")]:
+            for kind, output_freq in [("ref", 125e6), ("dmtd", 62.5e6)]:
+                name = f"{kind}{int(input_freq/1e6)}"
+                channel = MMCMChannel(name, input_cd, input_freq, output_freq)
+                setattr(self, name, channel)
+                platform.add_false_path_constraints(channel.cd_command.clk, self.crg.cd_ps.clk)
+                # The tuned clocks can acquire any phase relative to the
+                # free-running clocks. Their only crossings use Gray counters.
+                platform.add_false_path_constraints(channel.cd_output.clk, self.crg.cd_ps.clk)
+                platform.add_false_path_constraints(channel.cd_output.clk, self.crg.cd_sys.clk)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build",      action="store_true",                    help="Build the temporary SRAM image.")
+    parser.add_argument("--output-dir", default="build/spec_a7_mmcm",           help="Build output directory.")
+    args = parser.parse_args()
+    soc = MMCMTestSoC()
+    builder = Builder(soc, output_dir=args.output_dir, compile_software=False,
+        csr_csv=f"{args.output_dir}/csr.csv")
+    builder.build(run=args.build, build_name="spec_a7_mmcm")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/spec_a7_mmcm_test.py
+++ b/bench/spec_a7_mmcm_test.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Measure an already loaded spec_a7_mmcm image through a LiteX server."""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from litex import RemoteClient
+
+# Measurement --------------------------------------------------------------------------------------
+
+class Channel:
+    def __init__(self, bus, name):
+        self.bus  = bus
+        self.name = name
+        self.gate = self.read("gate_cycles")
+        self.freq = self.read("frequency")
+        self.vco  = self.read("vco")
+
+    def read(self, name):
+        return getattr(self.bus.regs, f"{self.name}_{name}").read()
+
+    def write(self, name, value):
+        getattr(self.bus.regs, f"{self.name}_{name}").write(value)
+
+    def reset(self):
+        self.write("enable", 0)
+        self.write("reset", 1)
+        self.write("pause", 0)
+        self.write("drop_done", 0)
+        self.write("code", 32768)
+        time.sleep(0.01)
+        self.write("reset", 0)
+        deadline = time.monotonic() + 3
+        while not self.read("locked"):
+            assert time.monotonic() < deadline, f"{self.name}: MMCM did not lock"
+            time.sleep(0.01)
+        assert self.read("backend_status") == 0
+        assert self.read("errors") == 0
+
+    def measure(self):
+        previous = self.read("sample_id")
+        self.write("measure", 1)
+        deadline = time.monotonic() + 3
+        while self.read("sample_id") == previous:
+            assert time.monotonic() < deadline, f"{self.name}: measurement timed out"
+            time.sleep(0.02)
+        result = {name: self.read(f"sample_{name}") for name in
+            ("id", "edges", "phase", "issued", "completed", "steps", "errors")}
+        if result["phase"] >= 2**31:
+            result["phase"] -= 2**32
+        result.update(channel=self.name, frequency=self.freq, vco=self.vco, gate=self.gate)
+        assert result["errors"] == 0, result
+        assert self.read("locked"), result
+        expected = self.gate*self.freq/200e6 - result["phase"]*self.freq/(56*self.vco)
+        result["expected_edges"] = expected
+        result["edge_error"]     = result["edges"] - expected
+        # Gray synchronization and the two endpoints quantize this count.
+        assert abs(result["edge_error"]) <= 4, result
+        return result
+
+    def check_rate(self, code, period):
+        self.write("period", period)
+        self.write("code", code)
+        self.write("enable", 1)
+        time.sleep(0.01)
+        result = self.measure()
+        result.update(code=code, period=period)
+        expected = self.gate*abs(code - 32768)/2**19
+        result["expected_steps"] = expected
+        assert abs(result["steps"] - expected) <= 1, result
+        assert abs(result["issued"] - result["completed"]) <= 1, result
+        assert abs(result["steps"] - result["completed"]) <= 1, result
+        assert result["phase"] == (1 if code < 32768 else -1)*result["completed"], result
+        assert not self.read("backend_status") & 2, result
+        return result
+
+# Qualification ------------------------------------------------------------------------------------
+
+def read_identifier(bus):
+    contents = []
+    for index in range(256):
+        byte = bus.read(bus.bases.identifier_mem + 4*index) & 0xff
+        if byte == 0:
+            return bytes(contents).decode("ascii")
+        contents.append(byte)
+    raise ValueError("Unterminated FPGA identifier")
+
+
+def qualify(bus, record):
+    identifier = read_identifier(bus)
+    assert identifier == "WR MMCM hardware qualification", identifier
+    channels = [Channel(bus, name) for name in ("ref100", "dmtd100", "ref200", "dmtd200")]
+    for channel in channels:
+        channel.write("enable", 0)
+        channel.write("reset", 1)
+    for channel in channels:
+        channel.reset()
+        # Every-cycle refresh includes the one-LSB regression that previously
+        # discarded fractional phase. A slower cadence checks the same gain.
+        for period in (1, 4096):
+            for code in (32768, 32767, 32769, 0, 65535, 16384, 49152, 32768):
+                record(channel.check_rate(code, period))
+
+        # Missing completion must stop requests and keep a sticky fault.
+        channel.reset()
+        channel.write("drop_done", 1)
+        channel.write("code", 0)
+        channel.write("enable", 1)
+        time.sleep(0.02)
+        assert channel.read("backend_status") == 3
+        channel.write("code", 65535)
+        result = channel.measure()
+        assert result["issued"] == result["completed"] == result["steps"] == 0, result
+        assert channel.read("backend_status") == 3
+        result["case"] = "missing_completion_sticky_fault"
+        record(result)
+        channel.reset()
+        result = channel.check_rate(0, 1)
+        result["case"] = "fault_reset_recovery"
+        record(result)
+
+        # Reset while the producer clock is stopped. Both FIFO ends must stay
+        # reset until the stopped clock resumes; no old code may be replayed.
+        channel.write("pause", 1)
+        channel.write("reset", 1)
+        channel.write("enable", 0)
+        time.sleep(0.01)
+        channel.write("reset", 0)
+        time.sleep(0.01)
+        result = channel.measure()
+        assert result["issued"] == result["completed"] == result["steps"] == 0, result
+        result["case"] = "reset_with_stopped_producer"
+        record(result)
+        channel.write("pause", 0)
+        time.sleep(0.01)
+        result = channel.measure()
+        assert result["issued"] == result["completed"] == result["steps"] == 0, result
+        assert channel.read("backend_status") == 0
+        result["case"] = "resume_without_stale_commands"
+        record(result)
+        result = channel.check_rate(65535, 1)
+        result["case"] = "fresh_command_after_resume"
+        record(result)
+        channel.write("enable", 0)
+        channel.write("reset", 1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csr-csv", required=True,               help="CSR CSV from the loaded test image.")
+    parser.add_argument("--host",    default="localhost",         help="LiteX server host.")
+    parser.add_argument("--port",    default=1234, type=int,      help="LiteX server port.")
+    parser.add_argument("--output",  default="mmcm-results.json", help="Measurement log.")
+    args = parser.parse_args()
+    results = []
+
+    def record(result):
+        results.append(result)
+        Path(args.output).write_text(json.dumps(results, indent=2) + "\n")
+        print(json.dumps(result), flush=True)
+
+    bus = RemoteClient(host=args.host, port=args.port, csr_csv=args.csr_csv,
+        timeout=5, raise_on_timeout=True)
+    bus.open()
+    try:
+        qualify(bus, record)
+    finally:
+        bus.close()
+    print(f"PASS: {len(results)} physical MMCM measurements", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/wr_clock_tuning.md
+++ b/doc/wr_clock_tuning.md
@@ -1,0 +1,92 @@
+# WR clock tuning backends
+
+`WhiteRabbitCore.refclk_tuning` and `.dmtd_tuning` use `WRTuningInterface`:
+an unsigned `data` code and a one-cycle `load` pulse, synchronous to **wr_sys**.
+The existing `dac_refclk_*` and `dac_dmtd_*` signals remain aliases. These
+commands do not belong to the PHY reference domain `wr`.
+
+Both backends accept the same command record and build-time calibration:
+
+```
+output = saturate(center + offset + ((input - center) * polarity * gain >> gain_shift))
+center = 2**(width - 1)
+```
+
+`polarity` is +1 or -1; `gain` is a positive integer, `gain_shift` a nonnegative
+integer, and `offset` a signed code offset. Arithmetic is signed, right shifts
+round toward negative infinity, and the result saturates to the unsigned
+output range. Defaults are identity calibration. Calibration adds one cycle
+of latency and exposes a `clipped` indication for the last command.
+
+## External DAC
+
+`WRDACBackend(width=16, cd="wr_sys", ...)` exposes `command`, `value` and
+`load`. Connect its outputs to a DAC driver in the same domain:
+
+```python
+self.refclk_tuning = WRDACBackend(cd="wr_sys", polarity=1, offset=0)
+self.comb += self.wr_core.refclk_tuning.connect(self.refclk_tuning.command)
+self.refclk_dac = AD5683RDAC(platform, pads,
+    load=self.refclk_tuning.load, value=self.refclk_tuning.value,
+    gain=2, clk_domain="wr_sys")
+```
+
+SPEC-A7 uses this backend for both DACs. The AD5683R `gain` argument controls
+the physical DAC gain independently of the digital calibration above. The
+driver now passes the correct VHDL generic, `g_enable_x2_gain`: previously
+the misspelled generic left the VHDL default gain enabled. The requested
+SPEC-A7 gains are x2 for RefClk and x1 for DMTD. Recheck the DMTD tuning range
+and WR servo behavior on a connected link when qualifying this correction.
+
+Host override retains the `force`, `value`, `load` and `current` CSRs. Write
+`force=1`, set `value`, then write `load=1` for each update; `load` now causes
+one pulse even if the storage register remains high. Write `force=0` to
+return control to WR. Mode/value/load travel together through a command
+FIFO; `current` crosses back coherently. The serial driver can coalesce
+updates while busy, so host override is for oscillator control, not arbitrary
+sample playback. An integration needing every sample needs a paced DAC API.
+
+## MMCM phase shifting
+
+`WRMMCMBackend(cd_psclk, cd_command="wr_sys", width=16, div_n=0, ...)`
+exposes `command`, `psen`, `psincdec` and **input `psdone`**. Connect all three
+phase-shift signals to the MMCM and use its PSCLK domain for `cd_psclk`.
+The Acorn target connects `PSDONE` for both MMCMs. `PSGen` remains a
+compatibility constructor with `ctrl_data`/`ctrl_load` aliases; external
+users must add the `psdone` connection when upgrading.
+
+The nominal rate is `abs(code - center) / 2**(width + div_n + 3)` phase shifts
+per PSCLK cycle. A code below center requests phase increment; a code above
+center requests decrement. Each phase request is one PSCLK cycle. Direction
+stays fixed until completion, and a new request waits for the previous
+`PSDONE` and its deassertion. If the requested rate exceeds completion speed,
+the rate saturates; it does not accumulate an unbounded backlog. A new code
+clears the fractional accumulator without changing an outstanding request.
+
+The backend starts neutral and transfers complete tuning words through an
+asynchronous FIFO. A single pending slot retains the newest command if the
+FIFO fills; replacements increment `superseded`. The same `WRTuningCDC`
+helper is available to other DAC integrations. Both FIFO sides and backend
+state reset when either participating domain resets, with locally
+synchronized reset release. Fresh tuning commands are required afterward.
+
+If `PSDONE` does not arrive within `timeout_cycles` (default 1024 PSCLK
+cycles), a sticky fault stops further requests. Reset the backend **and MMCM**
+together before resuming. Coherent CSRs expose busy/fault, completed steps
+and superseded commands. A stopped PSCLK cannot advance this timeout, so a
+board requiring independent clock-failure detection must monitor PSCLK from
+a free-running domain.
+
+Digital calibration does not make MMCM phase steps equivalent to an analog
+VCXO. The board's MMCM configuration, oscillator polarity and sensitivity,
+WR firmware servo settings, jitter, lock behavior and PPS accuracy still
+require measurement. Keep a free-running clock for WR CPU/control and for
+PSCLK; do not derive the control path from a clock it is trying to recover.
+
+## Validation
+
+`pytest -q test/test_wr_clock.py` checks full-range calibration, saturation,
+coherent command bursts and replacement accounting, neutral startup,
+completion backpressure, stable direction, timeout/reset behavior, and DAC
+host override pulse semantics. CPU/console tests on SPEC-A7 exercise the DAC
+integration; analog tuning range and closed-loop WR operation need a WR peer.

--- a/doc/wr_clock_tuning.md
+++ b/doc/wr_clock_tuning.md
@@ -61,7 +61,11 @@ The Acorn and M2SDR targets explicitly instantiate this backend and connect
 `ctrl_data`/`ctrl_load` interface are unchanged: existing integrations do not
 gain a new completion-input requirement just by updating the dependency.
 An integration adopting `WRMMCMBackend` must connect `psdone` and use the
-WR system domain for its command source.
+WR system domain for its command source. Declare the command and PSCLK
+domains asynchronous in the platform constraints: tuning commands cross a
+FIFO, and the disciplined clock can move relative to PSCLK. The Acorn and
+M2SDR targets include this constraint. Synchronous backend paths still need
+to meet the PSCLK period in the routed design.
 
 For 7-series MMCMs, use `S7MMCM(..., fractional=False)` and enable fine phase
 shifting on each tuned output. Fractional output division is incompatible
@@ -76,7 +80,9 @@ center requests decrement. Each phase request is one PSCLK cycle. Direction
 stays fixed until completion, and a new request waits for the previous
 `PSDONE` and its deassertion. If the requested rate exceeds completion speed,
 the rate saturates; it does not accumulate an unbounded backlog. Same-direction
-updates preserve fractional phase and apply the new magnitude immediately.
+updates preserve fractional phase. Command decoding uses one registered
+PSCLK stage between the FIFO and accumulator to keep the 200 MHz path short;
+the new magnitude applies when that stage loads the accumulator.
 This includes repeated identical codes: refreshing a small correction must
 not prevent it from accumulating a complete step. Neutral or direction
 reversal clears unissued fractional phase without changing an outstanding
@@ -140,6 +146,61 @@ accuracy. Reproduce both layers with:
 ```sh
 pytest -q test/test_wr_clock.py test/test_wr_mmcm.py
 ```
+
+`pytest -q test/test_wr_mmcm_formal.py` uses Yosys, SymbiYosys and Boolector
+to prove the request protocol for arbitrary commands at the FIFO output and
+arbitrary completion inputs, including missing/stuck/early completions and
+resets. Both the default 16-bit/1024-cycle configuration and an 8-bit/divided
+configuration are checked. The proof covers request exclusivity, one-cycle
+PSEN pulses, direction stability during an outstanding shift, completion
+accounting and sticky faults. Cover traces reach both shift directions,
+neutral/reversal during a shift, simultaneous command/completion and a
+timeout fault in the shorter configuration. Rate and code-to-direction
+mapping remain covered by the independent simulation scoreboards above.
+This proof does not model metastability or analog MMCM behavior.
+
+### SPEC-A7 physical MMCM test
+
+`bench/spec_a7_mmcm.py` builds a temporary SRAM image with four actual MMCMs:
+100/200 MHz inputs, 125/62.5 MHz outputs and 200 MHz PSCLK. The SPEC-A7's -2
+speed grade selects a different VCO from the Acorn/M2SDR -3 parts; each VCO
+is exported in the CSR map and used in the output-frequency prediction.
+This qualifies the backend on 7-series hardware, not WR servo lock or PPS
+accuracy on an M2SDR.
+
+From the repository root, with this checkout on `PYTHONPATH`:
+
+```sh
+PYTHONPATH=. python3 bench/spec_a7_mmcm.py --build
+# Check build/spec_a7_mmcm/gateware/spec_a7_mmcm_timing.rpt and *_drc.rpt.
+python3 litex_wr_nic/gateware/xilinx-bitstream.py \
+    build/spec_a7_mmcm/gateware/spec_a7_mmcm.bit \
+    build/spec_a7_mmcm/gateware/spec_a7_mmcm.bin
+openFPGALoader --cable ft4232 --freq 20000000 \
+    --bitstream build/spec_a7_mmcm/gateware/spec_a7_mmcm.bin
+litex_server --jtag --jtag-config=/path/to/spec_a7_openocd.cfg
+```
+
+In another terminal:
+
+```sh
+python3 bench/spec_a7_mmcm_test.py --csr-csv build/spec_a7_mmcm/csr.csv
+```
+
+The runner checks the FPGA identifier before writing test CSRs. It measures
+actual output-clock edges over 2**24 PSCLK cycles against the completed
+signed phase shifts and selected VCO. It checks endpoints, one-LSB codes,
+both polarities, neutral, every-cycle/slower command refresh, missing
+completion, fault recovery and reset with the producer clock stopped.
+An independent hardware monitor records overlapping/stretched requests,
+direction changes while busy, unsolicited/wrong-latency completions and
+loss of MMCM lock. Results are saved as JSON.
+
+Like the main SPEC-A7 target, the bench targets the 50T resource map and uses
+the repository's bitstream conversion for the connected 35T device.
+Stop the LiteX server before restoring your working converted WR bitstream with
+`openFPGALoader --cable ft4232 --bitstream /path/to/working_wr.bin`, then
+check the WR console. These commands load SRAM; they do not update flash.
 
 CPU/console tests on SPEC-A7 exercise the DAC integration; analog tuning range
 and closed-loop WR operation need a WR peer.

--- a/doc/wr_clock_tuning.md
+++ b/doc/wr_clock_tuning.md
@@ -63,20 +63,33 @@ gain a new completion-input requirement just by updating the dependency.
 An integration adopting `WRMMCMBackend` must connect `psdone` and use the
 WR system domain for its command source.
 
+For 7-series MMCMs, use `S7MMCM(..., fractional=False)` and enable fine phase
+shifting on each tuned output. Fractional output division is incompatible
+with fine phase shifting ([AMD UG472, pages 75 and 85](https://docs.amd.com/api/khub/documents/1kFbRqzm2fhwGy~cLQG2yA/content)).
+Acorn and M2SDR explicitly use integer-only configurations for their WR
+MMCMs. The nominal reference/DMTD frequencies remain 125/62.5 MHz; the
+selected 1.5 GHz VCO gives a phase step of approximately 11.905 ps.
+
 The nominal rate is `abs(code - center) / 2**(width + div_n + 3)` phase shifts
 per PSCLK cycle. A code below center requests phase increment; a code above
 center requests decrement. Each phase request is one PSCLK cycle. Direction
 stays fixed until completion, and a new request waits for the previous
 `PSDONE` and its deassertion. If the requested rate exceeds completion speed,
-the rate saturates; it does not accumulate an unbounded backlog. A new code
-clears the fractional accumulator without changing an outstanding request.
+the rate saturates; it does not accumulate an unbounded backlog. Same-direction
+updates preserve fractional phase and apply the new magnitude immediately.
+This includes repeated identical codes: refreshing a small correction must
+not prevent it from accumulating a complete step. Neutral or direction
+reversal clears unissued fractional phase without changing an outstanding
+request.
 
 The backend starts neutral and transfers complete tuning words through an
 asynchronous FIFO. A single pending slot retains the newest command if the
 FIFO fills; replacements increment `superseded`. The same `WRTuningCDC`
 helper is available to other DAC integrations. Both FIFO sides and backend
 state reset when either participating domain resets, with locally
-synchronized reset release. Fresh tuning commands are required afterward.
+synchronized reset release. Both sides remain reset until both clocks have
+resumed, so stale FIFO pointers cannot replay pre-reset commands when one
+clock was stopped. Fresh tuning commands are required afterward.
 
 If `PSDONE` does not arrive within `timeout_cycles` (default 1024 PSCLK
 cycles), a sticky fault stops further requests. Reset the backend **and MMCM**
@@ -102,5 +115,31 @@ driver's SPI initialization/update words, and check the MMCM's nominal rate
 and polarity against the previous accumulator law. The legacy code-zero
 magnitude overflow, non-neutral startup and unsafe overlapping requests are
 not compatibility requirements; the corrected backend handles these cases.
+
+`pytest -q test/test_wr_mmcm.py` adds generated-RTL simulations using Vivado's
+`xvlog`, `xelab` and `xsim` (skipped if unavailable):
+
+- Full 16-bit endpoints and one-LSB corrections in both directions, with
+  repeated updates over more than four million PSCLK cycles. A deterministic
+  varying command stream is checked against its independent code/time integral.
+- Nominal, delayed, stretched, stale-high, absent and timeout-boundary
+  completions; neutral/reversal while busy; completion/CSR accounting; sticky
+  faults; stopped/restarted clocks and reset with a backed-up command FIFO.
+- Actual `MMCME2_ADV`, clock-buffer and reset primitives from `unisims_ver`
+  for Acorn's 200 MHz and M2SDR's 100 MHz inputs, with 125/62.5 MHz outputs
+  and 200 MHz PSCLK. Checks cover the 12-cycle completion protocol, measured
+  output phase, both reference outputs, wraparound in both directions, and
+  reset during a shift followed by relock. Configuration checks separately
+  reject fractional division; the vendor behavioral model does not enforce
+  every hardware configuration restriction.
+
+The phase comparisons allow 10 ps for simulator rounding. This is a digital
+model tolerance, not a claim about hardware jitter or WR synchronization
+accuracy. Reproduce both layers with:
+
+```sh
+pytest -q test/test_wr_clock.py test/test_wr_mmcm.py
+```
+
 CPU/console tests on SPEC-A7 exercise the DAC integration; analog tuning range
 and closed-loop WR operation need a WR peer.

--- a/doc/wr_clock_tuning.md
+++ b/doc/wr_clock_tuning.md
@@ -33,10 +33,15 @@ self.refclk_dac = AD5683RDAC(platform, pads,
 
 SPEC-A7 uses this backend for both DACs. The AD5683R `gain` argument controls
 the physical DAC gain independently of the digital calibration above. The
-driver now passes the correct VHDL generic, `g_enable_x2_gain`: previously
-the misspelled generic left the VHDL default gain enabled. The requested
-SPEC-A7 gains are x2 for RefClk and x1 for DMTD. Recheck the DMTD tuning range
-and WR servo behavior on a connected link when qualifying this correction.
+driver passes the correct VHDL generic, `g_enable_x2_gain`: previously
+the misspelled generic was ignored and both DACs used the VHDL default x2
+gain, including the DMTD DAC whose Python argument said `gain=1`.
+SPEC-A7 now explicitly selects **x2 for both DACs**, and the driver defaults
+to x2, preserving that effective configuration. `gain=1` is an explicit
+opt-in to a different analog range and requires board/servo qualification.
+
+The default digital calibration is identity: no gain, polarity or offset
+change. This series does not retune the WR firmware PI coefficients.
 
 Host override retains the `force`, `value`, `load` and `current` CSRs. Write
 `force=1`, set `value`, then write `load=1` for each update; `load` now causes
@@ -51,9 +56,12 @@ sample playback. An integration needing every sample needs a paced DAC API.
 `WRMMCMBackend(cd_psclk, cd_command="wr_sys", width=16, div_n=0, ...)`
 exposes `command`, `psen`, `psincdec` and **input `psdone`**. Connect all three
 phase-shift signals to the MMCM and use its PSCLK domain for `cd_psclk`.
-The Acorn target connects `PSDONE` for both MMCMs. `PSGen` remains a
-compatibility constructor with `ctrl_data`/`ctrl_load` aliases; external
-users must add the `psdone` connection when upgrading.
+The Acorn and M2SDR targets explicitly instantiate this backend and connect
+`PSDONE` for both MMCMs. The original `PSGen` implementation and its
+`ctrl_data`/`ctrl_load` interface are unchanged: existing integrations do not
+gain a new completion-input requirement just by updating the dependency.
+An integration adopting `WRMMCMBackend` must connect `psdone` and use the
+WR system domain for its command source.
 
 The nominal rate is `abs(code - center) / 2**(width + div_n + 3)` phase shifts
 per PSCLK cycle. A code below center requests phase increment; a code above
@@ -88,5 +96,11 @@ PSCLK; do not derive the control path from a clock it is trying to recover.
 `pytest -q test/test_wr_clock.py` checks full-range calibration, saturation,
 coherent command bursts and replacement accounting, neutral startup,
 completion backpressure, stable direction, timeout/reset behavior, and DAC
-host override pulse semantics. CPU/console tests on SPEC-A7 exercise the DAC
-integration; analog tuning range and closed-loop WR operation need a WR peer.
+host override pulse semantics. Compatibility tests compare the default WR DAC
+command stream with the previous registered path, decode the actual VHDL
+driver's SPI initialization/update words, and check the MMCM's nominal rate
+and polarity against the previous accumulator law. The legacy code-zero
+magnitude overflow, non-neutral startup and unsafe overlapping requests are
+not compatibility requirements; the corrected backend handles these cases.
+CPU/console tests on SPEC-A7 exercise the DAC integration; analog tuning range
+and closed-loop WR operation need a WR peer.

--- a/litex_wr_nic/gateware/ad5683r/core.py
+++ b/litex_wr_nic/gateware/ad5683r/core.py
@@ -19,7 +19,7 @@ from litex_wr_nic.gateware.wr_clock import WRTuningCDC
 # AD5683R DAC --------------------------------------------------------------------------------------
 
 class AD5683RDAC(LiteXModule):
-    def __init__(self, platform, pads, load, value, gain=1, clk_domain="wr"):
+    def __init__(self, platform, pads, load, value, gain=2, clk_domain="wr"):
         assert gain in [1, 2]
         self._force   = CSRStorage(description="Override WR tuning with host DAC commands.")
         self._load    = CSRStorage(1,  description="Write 1 to load the host DAC value.")

--- a/litex_wr_nic/gateware/ad5683r/core.py
+++ b/litex_wr_nic/gateware/ad5683r/core.py
@@ -21,17 +21,17 @@ from litex_wr_nic.gateware.wr_clock import WRTuningCDC
 class AD5683RDAC(LiteXModule):
     def __init__(self, platform, pads, load, value, gain=1, clk_domain="wr"):
         assert gain in [1, 2]
-        self._force   = CSRStorage()
-        self._load    = CSRStorage(1)
-        self._value   = CSRStorage(16)
-        self._current = CSRStatus(16)
+        self._force   = CSRStorage(description="Override WR tuning with host DAC commands.")
+        self._load    = CSRStorage(1,  description="Write 1 to load the host DAC value.")
+        self._value   = CSRStorage(16, description="Host DAC tuning value.")
+        self._current = CSRStatus(16,  description="Current DAC tuning value.")
 
         # # #
 
         # Transfer each host command as one coherent value/mode/load record.
         # The WR tuning interface is already synchronous to clk_domain.
         self.host_cdc = host_cdc = WRTuningCDC(18, "sys", clk_domain)
-        driver_cd = host_cdc.output_cd
+        driver_cd    = host_cdc.output_cd
         forced       = Signal()
         manual_value = Signal(16)
         manual_load  = Signal()
@@ -56,7 +56,10 @@ class AD5683RDAC(LiteXModule):
             ),
         ]
         self.current_cdc = BusSynchronizer(16, driver_cd, "sys")
-        self.comb += [self.current_cdc.i.eq(value_i), self._current.status.eq(self.current_cdc.o)]
+        self.comb += [
+            self.current_cdc.i.eq(value_i),
+            self._current.status.eq(self.current_cdc.o),
+        ]
 
         # DAC Driver Instance.
         self.specials += Instance("serial_dac_arb",
@@ -65,11 +68,11 @@ class AD5683RDAC(LiteXModule):
             p_g_num_extra_bits = 8,
             p_g_enable_x2_gain = {1: 0, 2: 1}[gain],
 
-            i_clk_i        = ClockSignal(driver_cd),
-            i_rst_n_i      = ~ResetSignal(driver_cd),
+            i_clk_i       = ClockSignal(driver_cd),
+            i_rst_n_i     = ~ResetSignal(driver_cd),
 
-            i_val_i        = value_i,
-            i_load_i       = load_i,
+            i_val_i       = value_i,
+            i_load_i      = load_i,
 
             o_dac_ldac_n_o = pads.ldac_n,
             o_dac_clr_n_o  = Open(),

--- a/litex_wr_nic/gateware/ad5683r/core.py
+++ b/litex_wr_nic/gateware/ad5683r/core.py
@@ -2,16 +2,19 @@
 # This file is part of LiteX-WR-NIC.
 #
 # Copyright (c) 2024 Warsaw University of Technology
-# Copyright (c) 2024 Enjoy-Digital <enjoy-digital.fr>
+# Copyright (c) 2024-2026 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
 
 from migen import *
+from migen.genlib.cdc import BusSynchronizer
 
 from litex.gen import *
 
 from litex.soc.interconnect.csr import *
+
+from litex_wr_nic.gateware.wr_clock import WRTuningCDC
 
 # AD5683R DAC --------------------------------------------------------------------------------------
 
@@ -25,32 +28,45 @@ class AD5683RDAC(LiteXModule):
 
         # # #
 
-        # Signals.
-        load_i  = Signal()
-        value_i = Signal(16)
-
-        # Force/Load.
-        sync = getattr(self.sync, clk_domain)
-        sync += [
-            If(self._force.storage,
-                load_i.eq(self._load.storage),
-                value_i.eq(self._value.storage),
-            ).Else(
-                load_i.eq(load),
-                value_i.eq(value),
-            )
+        # Transfer each host command as one coherent value/mode/load record.
+        # The WR tuning interface is already synchronous to clk_domain.
+        self.host_cdc = host_cdc = WRTuningCDC(18, "sys", clk_domain)
+        driver_cd = host_cdc.output_cd
+        forced       = Signal()
+        manual_value = Signal(16)
+        manual_load  = Signal()
+        load_i       = Signal()
+        value_i      = Signal(16)
+        self.comb += [
+            host_cdc.sink.load.eq(self._force.re | (self._load.re & self._load.storage)),
+            host_cdc.sink.data.eq(Cat(self._value.storage, self._force.storage,
+                self._load.re & self._load.storage)),
+            load_i.eq(Mux(forced, manual_load, load)),
+            value_i.eq(Mux(forced, manual_value, value)),
         ]
-        self.comb += self._current.status.eq(value_i)
+        sync = getattr(self.sync, driver_cd)
+        sync += [
+            manual_load.eq(0),
+            If(host_cdc.source.load,
+                forced.eq(host_cdc.source.data[16]),
+                If(host_cdc.source.data[17],
+                    manual_value.eq(host_cdc.source.data[:16]),
+                    manual_load.eq(host_cdc.source.data[16]),
+                ),
+            ),
+        ]
+        self.current_cdc = BusSynchronizer(16, driver_cd, "sys")
+        self.comb += [self.current_cdc.i.eq(value_i), self._current.status.eq(self.current_cdc.o)]
 
         # DAC Driver Instance.
         self.specials += Instance("serial_dac_arb",
             p_g_invert_sclk    = 0,
             p_g_num_data_bits  = 16,
             p_g_num_extra_bits = 8,
-            p_g_x2_gain        = {1: 0, 2: 1}[gain],
+            p_g_enable_x2_gain = {1: 0, 2: 1}[gain],
 
-            i_clk_i        = ClockSignal(clk_domain),
-            i_rst_n_i      = ~ResetSignal(clk_domain),
+            i_clk_i        = ClockSignal(driver_cd),
+            i_rst_n_i      = ~ResetSignal(driver_cd),
 
             i_val_i        = value_i,
             i_load_i       = load_i,
@@ -64,6 +80,6 @@ class AD5683RDAC(LiteXModule):
         self.add_sources(platform)
 
     def add_sources(self, platform):
-       cdir = os.path.abspath(os.path.dirname(__file__))
-       platform.add_source(os.path.join(cdir, "serial_dac.vhd"))
-       platform.add_source(os.path.join(cdir, "serial_dac_arb.vhd"))
+        cdir = os.path.abspath(os.path.dirname(__file__))
+        platform.add_source(os.path.join(cdir, "serial_dac.vhd"))
+        platform.add_source(os.path.join(cdir, "serial_dac_arb.vhd"))

--- a/litex_wr_nic/gateware/ps_gen.py
+++ b/litex_wr_nic/gateware/ps_gen.py
@@ -1,16 +1,77 @@
-#
-# This file is part of LiteX-WR-NIC.
-#
-# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
-# SPDX-License-Identifier: BSD-2-Clause
+from migen import *
+from migen.genlib.cdc import MultiReg
 
-from litex_wr_nic.gateware.wr_clock import WRMMCMBackend
+from litex.gen import *
 
-# Phase Shift Generator ---------------------------------------------------------------------------
+# Phase Shift Generator -----------------------------------------------------------------------------
 
-class PSGen(WRMMCMBackend):
-    """Compatibility constructor; integrations must connect psdone."""
-    def __init__(self, cd_psclk, cd_sys, ctrl_size=16, div_n=0, **kwargs):
-        super().__init__(cd_psclk, cd_sys, ctrl_size, div_n, **kwargs)
-        self.ctrl_data = self.command.data
-        self.ctrl_load = self.command.load
+class PSGen(LiteXModule):
+    def __init__(self, cd_psclk, cd_sys, ctrl_size=16, div_n=0):
+        """
+        Phase Shift Generator module for generating phase shift control signals.
+
+        Parameters:
+        -----------
+        cd_psclk : str
+            Clock domain for phase shift control signals.
+        cd_sys : str
+            System clock domain.
+        ctrl_size : int
+            Size of the control data signal (default: 16 bits).
+        div_n : int
+            Division factor to scale the tuning range and resolution (default: 0).
+        """
+
+        # Control Interface.
+        self.ctrl_data = Signal(ctrl_size)
+        self.ctrl_load = Signal()
+
+        # Phase Shift Interface.
+        self.psen     = Signal()
+        self.psincdec = Signal()
+
+        # # #
+
+        # Scaled command size: Extends control size by div_n for finer resolution.
+        self.scaled_cmd_size = ctrl_size + div_n
+        self.scaled_cmd      = Signal(self.scaled_cmd_size)
+
+        # Neutral points for control and scaled commands.
+        neutral        = 1 << (ctrl_size - 1)
+        scaled_neutral = 1 << (self.scaled_cmd_size - 1)
+        center_cmd     = scaled_neutral
+
+        # System clock domain: Load and scale control data.
+        sync_sys = getattr(self.sync, cd_sys)
+        sync_sys += If(self.ctrl_load,
+                self.scaled_cmd.eq(center_cmd + self.ctrl_data - neutral)
+        )
+
+        # Absolute scaled command for phase shift direction.
+        self.scaled_cmd_abs = Signal(self.scaled_cmd_size - 1)
+        sync_sys += If(self.scaled_cmd >= scaled_neutral,
+            self.psincdec.eq(0), # decrement the phase -> speed up
+            self.scaled_cmd_abs.eq(self.scaled_cmd - scaled_neutral)
+        ).Else(
+            self.psincdec.eq(1), # increment the phase -> slow down
+            self.scaled_cmd_abs.eq(scaled_neutral - self.scaled_cmd)
+        )
+
+        # Clock domain crossing: Transfer absolute command to psclk domain.
+        self.scaled_cmd_psclk = Signal(self.scaled_cmd_size - 1)
+        self.specials += MultiReg(
+            i       = self.scaled_cmd_abs,
+            o       = self.scaled_cmd_psclk,
+            odomain = cd_psclk,
+        )
+
+        # Phase shift clock domain: Accumulate and generate phase shift enable.
+        sync_ps = getattr(self.sync, cd_psclk)
+        self.acc_size = self.scaled_cmd_size + 3
+        self.acc      = Signal(self.acc_size)
+        self.acc_old  = Signal(self.acc_size)
+        sync_ps += [
+            self.acc.eq(self.acc + self.scaled_cmd_psclk),
+            self.acc_old.eq(self.acc),
+            self.psen.eq(self.acc_old > self.acc),
+        ]

--- a/litex_wr_nic/gateware/ps_gen.py
+++ b/litex_wr_nic/gateware/ps_gen.py
@@ -1,77 +1,16 @@
-from migen import *
-from migen.genlib.cdc import MultiReg
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
 
-from litex.gen import *
+from litex_wr_nic.gateware.wr_clock import WRMMCMBackend
 
-# Phase Shift Generator -----------------------------------------------------------------------------
+# Phase Shift Generator ---------------------------------------------------------------------------
 
-class PSGen(LiteXModule):
-    def __init__(self, cd_psclk, cd_sys, ctrl_size=16, div_n=0):
-        """
-        Phase Shift Generator module for generating phase shift control signals.
-
-        Parameters:
-        -----------
-        cd_psclk : str
-            Clock domain for phase shift control signals.
-        cd_sys : str
-            System clock domain.
-        ctrl_size : int
-            Size of the control data signal (default: 16 bits).
-        div_n : int
-            Division factor to scale the tuning range and resolution (default: 0).
-        """
-
-        # Control Interface.
-        self.ctrl_data = Signal(ctrl_size)
-        self.ctrl_load = Signal()
-
-        # Phase Shift Interface.
-        self.psen     = Signal()
-        self.psincdec = Signal()
-
-        # # #
-
-        # Scaled command size: Extends control size by div_n for finer resolution.
-        self.scaled_cmd_size = ctrl_size + div_n
-        self.scaled_cmd      = Signal(self.scaled_cmd_size)
-
-        # Neutral points for control and scaled commands.
-        neutral        = 1 << (ctrl_size - 1)
-        scaled_neutral = 1 << (self.scaled_cmd_size - 1)
-        center_cmd     = scaled_neutral
-
-        # System clock domain: Load and scale control data.
-        sync_sys = getattr(self.sync, cd_sys)
-        sync_sys += If(self.ctrl_load,
-                self.scaled_cmd.eq(center_cmd + self.ctrl_data - neutral)
-        )
-
-        # Absolute scaled command for phase shift direction.
-        self.scaled_cmd_abs = Signal(self.scaled_cmd_size - 1)
-        sync_sys += If(self.scaled_cmd >= scaled_neutral,
-            self.psincdec.eq(0), # decrement the phase -> speed up
-            self.scaled_cmd_abs.eq(self.scaled_cmd - scaled_neutral)
-        ).Else(
-            self.psincdec.eq(1), # increment the phase -> slow down
-            self.scaled_cmd_abs.eq(scaled_neutral - self.scaled_cmd)
-        )
-
-        # Clock domain crossing: Transfer absolute command to psclk domain.
-        self.scaled_cmd_psclk = Signal(self.scaled_cmd_size - 1)
-        self.specials += MultiReg(
-            i       = self.scaled_cmd_abs,
-            o       = self.scaled_cmd_psclk,
-            odomain = cd_psclk,
-        )
-
-        # Phase shift clock domain: Accumulate and generate phase shift enable.
-        sync_ps = getattr(self.sync, cd_psclk)
-        self.acc_size = self.scaled_cmd_size + 3
-        self.acc      = Signal(self.acc_size)
-        self.acc_old  = Signal(self.acc_size)
-        sync_ps += [
-            self.acc.eq(self.acc + self.scaled_cmd_psclk),
-            self.acc_old.eq(self.acc),
-            self.psen.eq(self.acc_old > self.acc),
-        ]
+class PSGen(WRMMCMBackend):
+    """Compatibility constructor; integrations must connect psdone."""
+    def __init__(self, cd_psclk, cd_sys, ctrl_size=16, div_n=0, **kwargs):
+        super().__init__(cd_psclk, cd_sys, ctrl_size, div_n, **kwargs)
+        self.ctrl_data = self.command.data
+        self.ctrl_load = self.command.load

--- a/litex_wr_nic/gateware/wr_cdc.py
+++ b/litex_wr_nic/gateware/wr_cdc.py
@@ -17,8 +17,10 @@ class WRClockCrossing(LiteXModule, DUID):
     """FIFO and protocol logic share synchronized resets at both ends."""
     def __init__(self, layout, cd_from, cd_to, depth=16):
         DUID.__init__(self)
-        self.cd_input  = ClockDomain(f"wr_cdc_in{self.duid}")
-        self.cd_output = ClockDomain(f"wr_cdc_out{self.duid}")
+        self.cd_input        = ClockDomain(f"wr_cdc_in{self.duid}")
+        self.cd_output       = ClockDomain(f"wr_cdc_out{self.duid}")
+        self.cd_input_reset  = ClockDomain(f"wr_cdc_in_reset{self.duid}")
+        self.cd_output_reset = ClockDomain(f"wr_cdc_out_reset{self.duid}")
         self.input_cd  = self.cd_input.name
         self.output_cd = self.cd_output.name
 
@@ -28,10 +30,19 @@ class WRClockCrossing(LiteXModule, DUID):
         self.comb += [
             self.cd_input.clk.eq(ClockSignal(cd_from)),
             self.cd_output.clk.eq(ClockSignal(cd_to)),
+            self.cd_input_reset.clk.eq(ClockSignal(cd_from)),
+            self.cd_output_reset.clk.eq(ClockSignal(cd_to)),
         ]
+        # FIFO pointers have synchronous resets. If one clock is stopped,
+        # keep both sides reset until it has resumed and clocked its reset.
+        # Otherwise the running side can see a stale remote pointer and replay
+        # old commands before the stopped side has cleared its state.
+        ready_reset = self.cd_input_reset.rst | self.cd_output_reset.rst
         self.specials += [
-            AsyncResetSynchronizer(self.cd_input, reset),
-            AsyncResetSynchronizer(self.cd_output, reset),
+            AsyncResetSynchronizer(self.cd_input_reset, reset),
+            AsyncResetSynchronizer(self.cd_output_reset, reset),
+            AsyncResetSynchronizer(self.cd_input, ready_reset),
+            AsyncResetSynchronizer(self.cd_output, ready_reset),
         ]
         if cd_from == cd_to:
             self.fifo = ClockDomainsRenamer(self.input_cd)(stream.SyncFIFO(layout, depth, buffered=True))

--- a/litex_wr_nic/gateware/wr_cdc.py
+++ b/litex_wr_nic/gateware/wr_cdc.py
@@ -8,6 +8,7 @@ from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.gen import *
+
 from litex.soc.interconnect import stream
 
 # WR Clock Crossing -------------------------------------------------------------------------------
@@ -20,6 +21,9 @@ class WRClockCrossing(LiteXModule, DUID):
         self.cd_output = ClockDomain(f"wr_cdc_out{self.duid}")
         self.input_cd  = self.cd_input.name
         self.output_cd = self.cd_output.name
+
+        # # #
+
         reset = ResetSignal(cd_from) | ResetSignal(cd_to)
         self.comb += [
             self.cd_input.clk.eq(ClockSignal(cd_from)),

--- a/litex_wr_nic/gateware/wr_cdc.py
+++ b/litex_wr_nic/gateware/wr_cdc.py
@@ -1,0 +1,38 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.gen import *
+from litex.soc.interconnect import stream
+
+# WR Clock Crossing -------------------------------------------------------------------------------
+
+class WRClockCrossing(LiteXModule, DUID):
+    """FIFO and protocol logic share synchronized resets at both ends."""
+    def __init__(self, layout, cd_from, cd_to, depth=16):
+        DUID.__init__(self)
+        self.cd_input  = ClockDomain(f"wr_cdc_in{self.duid}")
+        self.cd_output = ClockDomain(f"wr_cdc_out{self.duid}")
+        self.input_cd  = self.cd_input.name
+        self.output_cd = self.cd_output.name
+        reset = ResetSignal(cd_from) | ResetSignal(cd_to)
+        self.comb += [
+            self.cd_input.clk.eq(ClockSignal(cd_from)),
+            self.cd_output.clk.eq(ClockSignal(cd_to)),
+        ]
+        self.specials += [
+            AsyncResetSynchronizer(self.cd_input, reset),
+            AsyncResetSynchronizer(self.cd_output, reset),
+        ]
+        if cd_from == cd_to:
+            self.fifo = ClockDomainsRenamer(self.input_cd)(stream.SyncFIFO(layout, depth, buffered=True))
+        else:
+            self.fifo = ClockDomainsRenamer({"write": self.input_cd, "read": self.output_cd})(
+                stream.AsyncFIFO(layout, depth))
+        self.sink   = self.fifo.sink
+        self.source = self.fifo.source

--- a/litex_wr_nic/gateware/wr_clock.py
+++ b/litex_wr_nic/gateware/wr_clock.py
@@ -1,0 +1,186 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.cdc import BusSynchronizer
+
+from litex.gen import *
+from litex.soc.interconnect.csr import CSRStatus
+
+from litex_wr_nic.gateware.wr_cdc import WRClockCrossing
+
+# WR Tuning Command -------------------------------------------------------------------------------
+
+class WRTuningInterface(Record):
+    """Unsigned tuning code, sampled on load in the declared clock domain."""
+    def __init__(self, width=16, name=None):
+        Record.__init__(self, [("data", width, DIR_M_TO_S), ("load", 1, DIR_M_TO_S)], name=name)
+
+
+class WRTuningCalibration(LiteXModule):
+    """Calibrate a centered tuning code with signed arithmetic and saturation."""
+    def __init__(self, width=16, cd="wr_sys", polarity=1, gain=1, gain_shift=0, offset=0):
+        if not all(isinstance(value, int) for value in (width, polarity, gain, gain_shift, offset)):
+            raise ValueError("WR tuning calibration uses integer parameters.")
+        if width < 2 or polarity not in (-1, 1) or gain < 1 or gain_shift < 0:
+            raise ValueError("Invalid WR tuning width, polarity or gain.")
+        self.sink    = sink   = WRTuningInterface(width, name="sink")
+        self.source  = source = WRTuningInterface(width, name="source")
+        self.clipped = Signal()
+
+        # # #
+
+        neutral = 1 << (width - 1)
+        maximum = (1 << width) - 1
+        delta   = Signal((width + 1, True))
+        product = Signal((width + gain.bit_length() + 2, True))
+        result  = Signal((max(len(product), abs(offset).bit_length() + 2) + 1, True))
+        self.comb += [
+            delta.eq(sink.data - neutral),
+            product.eq(delta * (polarity * gain)),
+            result.eq(neutral + offset + (product >> gain_shift)),
+        ]
+        sync = getattr(self.sync, cd)
+        sync += [
+            source.load.eq(sink.load),
+            If(sink.load,
+                self.clipped.eq((result < 0) | (result > maximum)),
+                If(result < 0,
+                    source.data.eq(0),
+                ).Elif(result > maximum,
+                    source.data.eq(maximum),
+                ).Else(
+                    source.data.eq(result),
+                ),
+            ),
+        ]
+
+
+class WRTuningCDC(LiteXModule):
+    """Coherent command FIFO with one pending, replaceable latest command.
+
+    WR emits pulses and cannot be stalled. If the FIFO is full, a newer
+    command replaces the pending command and increments superseded.
+    """
+    def __init__(self, width=16, cd_from="wr_sys", cd_to="sys", depth=4):
+        self.sink   = sink   = WRTuningInterface(width, name="sink")
+        self.source = source = WRTuningInterface(width, name="source")
+        self.superseded = Signal(32)
+
+        # # #
+
+        self.cdc = cdc = WRClockCrossing([("data", width)], cd_from, cd_to, depth)
+        self.input_cd  = cdc.input_cd
+        self.output_cd = cdc.output_cd
+        pending = Signal()
+        latest  = Signal(width)
+        self.comb += [
+            cdc.sink.valid.eq(pending),
+            cdc.sink.data.eq(latest),
+            cdc.source.ready.eq(1),
+            source.load.eq(cdc.source.valid),
+            source.data.eq(cdc.source.data),
+        ]
+        sync = getattr(self.sync, cdc.input_cd)
+        sync += [
+            If(cdc.sink.ready, pending.eq(0)),
+            If(sink.load,
+                pending.eq(1),
+                latest.eq(sink.data),
+                If(pending & ~cdc.sink.ready, self.superseded.eq(self.superseded + 1)),
+            ),
+        ]
+
+# WR Clock Backends -------------------------------------------------------------------------------
+
+class WRDACBackend(LiteXModule):
+    """Calibrated parallel command for an external DAC driver."""
+    def __init__(self, width=16, cd="wr_sys", **calibration):
+        self.calibration = WRTuningCalibration(width, cd, **calibration)
+        self.command = self.calibration.sink
+        self.value   = self.calibration.source.data
+        self.load    = self.calibration.source.load
+        self.clipped = self.calibration.clipped
+
+
+class WRMMCMBackend(LiteXModule):
+    """Rate accumulator with one outstanding MMCM phase shift at a time."""
+    def __init__(self, cd_psclk, cd_command="wr_sys", width=16, div_n=0,
+        timeout_cycles=1024, **calibration):
+        if div_n < 0 or timeout_cycles < 2:
+            raise ValueError("Invalid MMCM rate divider or completion timeout.")
+        self.command  = WRTuningInterface(width, name="command")
+        self.psen     = Signal()
+        self.psincdec = Signal()
+        self.psdone   = Signal()
+        self.busy     = Signal()
+        self.fault    = Signal()
+        self.steps    = Signal(32)
+
+        # # #
+
+        self.cdc = cdc = WRTuningCDC(width, cd_command, cd_psclk)
+        self.calibration = calibrated = WRTuningCalibration(width, cdc.input_cd, **calibration)
+        self.comb += [self.command.connect(calibrated.sink), calibrated.source.connect(cdc.sink)]
+
+        # Nominal rate: |code - center| / 2**(width+div_n+3) shifts per PSCLK.
+        # Reset residual phase on every new command.
+        neutral   = 1 << (width - 1)
+        acc_width = width + div_n + 3
+        magnitude = Signal(width)
+        direction = Signal()
+        acc       = Signal(acc_width)
+        total     = Signal(acc_width + 1)
+        timer     = Signal(max=timeout_cycles)
+        self.comb += total.eq(acc + magnitude)
+        sync = getattr(self.sync, cdc.output_cd)
+        sync += [
+            self.psen.eq(0),
+            If(cdc.source.load,
+                direction.eq(cdc.source.data < neutral),
+                magnitude.eq(Mux(cdc.source.data < neutral,
+                    neutral - cdc.source.data, cdc.source.data - neutral)),
+                acc.eq(0),
+            ).Elif(~self.fault,
+                # Keep a due request while busy; never overlap PSEN pulses.
+                If(total[acc_width],
+                    If(~self.busy & ~self.psdone,
+                        acc.eq(total[:acc_width]),
+                        self.psen.eq(1),
+                        self.psincdec.eq(direction),
+                        self.busy.eq(1),
+                        timer.eq(0),
+                    ).Else(
+                        acc.eq((1 << acc_width) - 1),
+                    ),
+                ).Else(
+                    acc.eq(total),
+                ),
+            ),
+            If(self.busy,
+                If(self.psdone,
+                    self.busy.eq(0),
+                    self.steps.eq(self.steps + 1),
+                ).Elif(timer == timeout_cycles - 1,
+                    self.fault.eq(1),
+                ).Else(
+                    timer.eq(timer + 1),
+                ),
+            ),
+        ]
+
+        self.status_cdc = BusSynchronizer(34, cdc.output_cd, "sys")
+        self._status = CSRStatus(2, description="Bit 0: busy; bit 1: completion timeout (reset required).")
+        self._steps  = CSRStatus(32, description="Completed MMCM phase shifts, wrapping at 32 bits.")
+        self._superseded = CSRStatus(32, description="Commands replaced while the tuning FIFO was full.")
+        self.superseded_cdc = BusSynchronizer(32, cdc.input_cd, "sys")
+        self.comb += [
+            self.status_cdc.i.eq(Cat(self.busy, self.fault, self.steps)),
+            self._status.status.eq(self.status_cdc.o[:2]),
+            self._steps.status.eq(self.status_cdc.o[2:]),
+            self.superseded_cdc.i.eq(cdc.superseded),
+            self._superseded.status.eq(self.superseded_cdc.o),
+        ]

--- a/litex_wr_nic/gateware/wr_clock.py
+++ b/litex_wr_nic/gateware/wr_clock.py
@@ -132,22 +132,32 @@ class WRMMCMBackend(LiteXModule):
         ]
 
         # Nominal rate: |code - center| / 2**(width+div_n+3) shifts per PSCLK.
-        # Reset residual phase on every new command.
-        neutral   = 1 << (width - 1)
-        acc_width = width + div_n + 3
-        magnitude = Signal(width)
-        direction = Signal()
-        acc       = Signal(acc_width)
-        total     = Signal(acc_width + 1)
-        timer     = Signal(max=timeout_cycles)
-        self.comb += total.eq(acc + magnitude)
+        # Preserve fractional phase across same-direction updates, otherwise
+        # frequent servo commands can prevent small corrections from issuing.
+        # Neutral/reversal cancels only unissued phase; an active shift finishes.
+        neutral       = 1 << (width - 1)
+        acc_width     = width + div_n + 3
+        magnitude     = Signal(width)
+        direction     = Signal()
+        new_magnitude = Signal(width)
+        new_direction = Signal()
+        acc           = Signal(acc_width)
+        total         = Signal(acc_width + 1)
+        timer         = Signal(max=timeout_cycles)
+        self.comb += [
+            new_direction.eq(cdc.source.data < neutral),
+            new_magnitude.eq(Mux(new_direction,
+                neutral - cdc.source.data, cdc.source.data - neutral)),
+            total.eq(acc + Mux(cdc.source.load, new_magnitude, magnitude)),
+        ]
         sync = getattr(self.sync, cdc.output_cd)
         sync += [
             self.psen.eq(0),
             If(cdc.source.load,
-                direction.eq(cdc.source.data < neutral),
-                magnitude.eq(Mux(cdc.source.data < neutral,
-                    neutral - cdc.source.data, cdc.source.data - neutral)),
+                direction.eq(new_direction),
+                magnitude.eq(new_magnitude),
+            ),
+            If(cdc.source.load & ((new_magnitude == 0) | (new_direction != direction)),
                 acc.eq(0),
             ).Elif(~self.fault,
                 # Keep a due request while busy; never overlap PSEN pulses.

--- a/litex_wr_nic/gateware/wr_clock.py
+++ b/litex_wr_nic/gateware/wr_clock.py
@@ -141,23 +141,28 @@ class WRMMCMBackend(LiteXModule):
         direction     = Signal()
         new_magnitude = Signal(width)
         new_direction = Signal()
+        new_load      = Signal()
         acc           = Signal(acc_width)
         total         = Signal(acc_width + 1)
         timer         = Signal(max=timeout_cycles)
-        self.comb += [
-            new_direction.eq(cdc.source.data < neutral),
-            new_magnitude.eq(Mux(new_direction,
-                neutral - cdc.source.data, cdc.source.data - neutral)),
-            total.eq(acc + Mux(cdc.source.load, new_magnitude, magnitude)),
-        ]
         sync = getattr(self.sync, cdc.output_cd)
+        # Register command decoding before the accumulator. In particular,
+        # FIFO readable/Gray-pointer logic must not feed the carry chain and
+        # phase-request control in the same 200 MHz cycle.
+        sync += [
+            new_load.eq(cdc.source.load),
+            new_direction.eq(cdc.source.data < neutral),
+            new_magnitude.eq(Mux(cdc.source.data < neutral,
+                neutral - cdc.source.data, cdc.source.data - neutral)),
+        ]
+        self.comb += total.eq(acc + Mux(new_load, new_magnitude, magnitude))
         sync += [
             self.psen.eq(0),
-            If(cdc.source.load,
+            If(new_load,
                 direction.eq(new_direction),
                 magnitude.eq(new_magnitude),
             ),
-            If(cdc.source.load & ((new_magnitude == 0) | (new_direction != direction)),
+            If(new_load & ((new_magnitude == 0) | (new_direction != direction)),
                 acc.eq(0),
             ).Elif(~self.fault,
                 # Keep a due request while busy; never overlap PSEN pulses.
@@ -167,7 +172,6 @@ class WRMMCMBackend(LiteXModule):
                         self.psen.eq(1),
                         self.psincdec.eq(direction),
                         self.busy.eq(1),
-                        timer.eq(0),
                     ).Else(
                         acc.eq((1 << acc_width) - 1),
                     ),
@@ -184,6 +188,10 @@ class WRMMCMBackend(LiteXModule):
                 ).Else(
                     timer.eq(timer + 1),
                 ),
+            ).Else(
+                # Prepare the watchdog while idle so the accumulator carry
+                # does not also drive the timer's reset/enable path.
+                timer.eq(0),
             ),
         ]
 

--- a/litex_wr_nic/gateware/wr_clock.py
+++ b/litex_wr_nic/gateware/wr_clock.py
@@ -8,7 +8,8 @@ from migen import *
 from migen.genlib.cdc import BusSynchronizer
 
 from litex.gen import *
-from litex.soc.interconnect.csr import CSRStatus
+
+from litex.soc.interconnect.csr import CSRField, CSRStatus
 
 from litex_wr_nic.gateware.wr_cdc import WRClockCrossing
 
@@ -68,6 +69,7 @@ class WRTuningCDC(LiteXModule):
     def __init__(self, width=16, cd_from="wr_sys", cd_to="sys", depth=4):
         self.sink   = sink   = WRTuningInterface(width, name="sink")
         self.source = source = WRTuningInterface(width, name="source")
+
         self.superseded = Signal(32)
 
         # # #
@@ -124,7 +126,10 @@ class WRMMCMBackend(LiteXModule):
 
         self.cdc = cdc = WRTuningCDC(width, cd_command, cd_psclk)
         self.calibration = calibrated = WRTuningCalibration(width, cdc.input_cd, **calibration)
-        self.comb += [self.command.connect(calibrated.sink), calibrated.source.connect(cdc.sink)]
+        self.comb += [
+            self.command.connect(calibrated.sink),
+            calibrated.source.connect(cdc.sink),
+        ]
 
         # Nominal rate: |code - center| / 2**(width+div_n+3) shifts per PSCLK.
         # Reset residual phase on every new command.
@@ -173,13 +178,17 @@ class WRMMCMBackend(LiteXModule):
         ]
 
         self.status_cdc = BusSynchronizer(34, cdc.output_cd, "sys")
-        self._status = CSRStatus(2, description="Bit 0: busy; bit 1: completion timeout (reset required).")
-        self._steps  = CSRStatus(32, description="Completed MMCM phase shifts, wrapping at 32 bits.")
+        self._status = CSRStatus(fields=[
+            CSRField("busy",  size=1, description="An MMCM phase shift is pending."),
+            CSRField("fault", size=1, description="Completion timeout; reset the backend and MMCM."),
+        ])
+        self._steps      = CSRStatus(32, description="Completed MMCM phase shifts, wrapping at 32 bits.")
         self._superseded = CSRStatus(32, description="Commands replaced while the tuning FIFO was full.")
         self.superseded_cdc = BusSynchronizer(32, cdc.input_cd, "sys")
         self.comb += [
             self.status_cdc.i.eq(Cat(self.busy, self.fault, self.steps)),
-            self._status.status.eq(self.status_cdc.o[:2]),
+            self._status.fields.busy.eq(self.status_cdc.o[0]),
+            self._status.fields.fault.eq(self.status_cdc.o[1]),
             self._steps.status.eq(self.status_cdc.o[2:]),
             self.superseded_cdc.i.eq(cdc.superseded),
             self._superseded.status.eq(self.superseded_cdc.o),

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -14,6 +14,7 @@ from migen.genlib.cdc import MultiReg
 
 from litex.gen import *
 
+from litex_wr_nic.gateware.wr_clock import WRTuningInterface
 from litex.build.io import SDRTristate
 
 from litex.soc.interconnect import wishbone
@@ -111,10 +112,12 @@ class WhiteRabbitCore(LiteXModule):
         self.led_pps         = Signal()
         self.led_link        = Signal()
         self.led_act         = Signal()
-        self.dac_refclk_load = Signal()
-        self.dac_refclk_data = Signal(dac_bits)
-        self.dac_dmtd_load   = Signal()
-        self.dac_dmtd_data   = Signal(dac_bits)
+        self.refclk_tuning   = WRTuningInterface(dac_bits, name="refclk_tuning")
+        self.dmtd_tuning     = WRTuningInterface(dac_bits, name="dmtd_tuning")
+        self.dac_refclk_load = self.refclk_tuning.load
+        self.dac_refclk_data = self.refclk_tuning.data
+        self.dac_dmtd_load   = self.dmtd_tuning.load
+        self.dac_dmtd_data   = self.dmtd_tuning.data
         self.pps_in          = Signal()
         self.pps_out_valid   = Signal()
         self.pps_out         = Signal()

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -14,7 +14,6 @@ from migen.genlib.cdc import MultiReg
 
 from litex.gen import *
 
-from litex_wr_nic.gateware.wr_clock import WRTuningInterface
 from litex.build.io import SDRTristate
 
 from litex.soc.interconnect import wishbone
@@ -39,6 +38,7 @@ from litex_wr_nic.gateware.wrf_wb2stream     import Wishbone2Stream
 from litex_wr_nic.gateware.wb_clock_crossing import WishboneClockCrossing
 from litex_wr_nic.gateware.wr_info           import WRInfo
 from litex_wr_nic.gateware.wr_time           import WRApplicationTime
+from litex_wr_nic.gateware.wr_clock          import WRTuningInterface
 
 # White Rabbit Core -------------------------------------------------------------------------------
 
@@ -109,23 +109,23 @@ class WhiteRabbitCore(LiteXModule):
 
         # Signals.
         # --------
-        self.led_pps         = Signal()
-        self.led_link        = Signal()
-        self.led_act         = Signal()
-        self.refclk_tuning   = WRTuningInterface(dac_bits, name="refclk_tuning")
-        self.dmtd_tuning     = WRTuningInterface(dac_bits, name="dmtd_tuning")
+        self.led_pps        = Signal()
+        self.led_link       = Signal()
+        self.led_act        = Signal()
+        self.refclk_tuning  = WRTuningInterface(dac_bits, name="refclk_tuning")
+        self.dmtd_tuning    = WRTuningInterface(dac_bits, name="dmtd_tuning")
         self.dac_refclk_load = self.refclk_tuning.load
         self.dac_refclk_data = self.refclk_tuning.data
         self.dac_dmtd_load   = self.dmtd_tuning.load
         self.dac_dmtd_data   = self.dmtd_tuning.data
-        self.pps_in          = Signal()
-        self.pps_out_valid   = Signal()
-        self.pps_out         = Signal()
-        self.pps_out_pulse   = Signal()
-        self.tm_link_up      = Signal()
-        self.tm_time_valid   = Signal()
-        self.tm_seconds      = Signal(40)
-        self.tm_cycles       = Signal(28)
+        self.pps_in         = Signal()
+        self.pps_out_valid  = Signal()
+        self.pps_out        = Signal()
+        self.pps_out_pulse  = Signal()
+        self.tm_link_up     = Signal()
+        self.tm_time_valid  = Signal()
+        self.tm_seconds     = Signal(40)
+        self.tm_cycles      = Signal(28)
 
         self.wr_time = WRApplicationTime(
             seconds        = self.tm_seconds,

--- a/litex_wr_nic/gateware/wrf.py
+++ b/litex_wr_nic/gateware/wrf.py
@@ -8,6 +8,7 @@ from migen import *
 from migen.genlib.cdc import BusSynchronizer
 
 from litex.gen import *
+
 from litex.soc.interconnect import wishbone
 from litex.soc.interconnect.csr import CSRStatus
 

--- a/litex_wr_nic/gateware/wrf.py
+++ b/litex_wr_nic/gateware/wrf.py
@@ -6,12 +6,12 @@
 
 from migen import *
 from migen.genlib.cdc import BusSynchronizer
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.gen import *
-
-from litex.soc.interconnect import stream, wishbone
+from litex.soc.interconnect import wishbone
 from litex.soc.interconnect.csr import CSRStatus
+
+from litex_wr_nic.gateware.wr_cdc import WRClockCrossing
 
 # WR Fabric Interfaces -----------------------------------------------------------------------------
 
@@ -25,34 +25,7 @@ class WRFInterface(wishbone.Interface):
             self.layout.append((name, 1, DIR_S_TO_M))
 
 
-class WRFClockCrossing(LiteXModule, DUID):
-    """FIFO and protocol logic share synchronized resets at both ends."""
-    def __init__(self, layout, cd_from, cd_to, depth=16):
-        DUID.__init__(self)
-        self.cd_input  = ClockDomain(f"wrf_in{self.duid}")
-        self.cd_output = ClockDomain(f"wrf_out{self.duid}")
-        self.input_cd  = self.cd_input.name
-        self.output_cd = self.cd_output.name
-
-        # # #
-
-        reset = ResetSignal(cd_from) | ResetSignal(cd_to)
-        self.comb += [
-            self.cd_input.clk.eq(ClockSignal(cd_from)),
-            self.cd_output.clk.eq(ClockSignal(cd_to)),
-        ]
-        self.specials += [
-            AsyncResetSynchronizer(self.cd_input, reset),
-            AsyncResetSynchronizer(self.cd_output, reset),
-        ]
-        if cd_from == cd_to:
-            self.fifo = ClockDomainsRenamer(self.input_cd)(stream.SyncFIFO(layout, depth, buffered=True))
-        else:
-            self.fifo = ClockDomainsRenamer({"write": self.input_cd, "read": self.output_cd})(
-                stream.AsyncFIFO(layout, depth))
-        self.sink   = self.fifo.sink
-        self.source = self.fifo.source
-
+WRFClockCrossing = WRClockCrossing
 
 class WRFCounters(LiteXModule):
     def __init__(self, cd):

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -356,7 +356,7 @@ class BaseSoC(LiteXWRNICSoC):
                 pads  = dac_dmtd_pads,
                 load  = self.dmtd_tuning.load,
                 value = self.dmtd_tuning.value,
-                gain  = 1,
+                gain  = 2, # Preserve the effective gain used before g_enable_x2_gain was connected.
                 clk_domain = "wr_sys",
             )
 

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -44,6 +44,7 @@ from litex_wr_nic.gateware.soc               import LiteXWRNICSoC
 from litex_wr_nic.gateware.time              import TimeGenerator
 from litex_wr_nic.gateware.qpll              import SharedQPLL
 from litex_wr_nic.gateware.ad5683r.core      import AD5683RDAC
+from litex_wr_nic.gateware.wr_clock          import WRDACBackend
 from litex_wr_nic.gateware.ad9516.core       import AD9516PLL, AD9516_MAIN_CONFIG, AD9516_EXT_CONFIG
 from litex_wr_nic.gateware.measurement       import MultiClkMeasurement
 from litex_wr_nic.gateware.delay.core        import MacroDelay, CoarseDelay, FineDelay
@@ -338,19 +339,23 @@ class BaseSoC(LiteXWRNICSoC):
             # ---------------------------------------
 
             # RefClk DAC.
+            self.refclk_tuning = WRDACBackend(cd="wr_sys")
+            self.comb += self.wr_core.refclk_tuning.connect(self.refclk_tuning.command)
             self.refclk_dac = AD5683RDAC(platform,
                 pads  = dac_refclk_pads,
-                load  = self.dac_refclk_load,
-                value = self.dac_refclk_data,
+                load  = self.refclk_tuning.load,
+                value = self.refclk_tuning.value,
                 gain  = 2, # 2 for 0-3V range to be able to accelerate enough RefClk, not working with 1.
                 clk_domain = "wr_sys",
             )
 
             # DMTD DAC.
+            self.dmtd_tuning = WRDACBackend(cd="wr_sys")
+            self.comb += self.wr_core.dmtd_tuning.connect(self.dmtd_tuning.command)
             self.dmtd_dac = AD5683RDAC(platform,
                 pads  = dac_dmtd_pads,
-                load  = self.dac_dmtd_load,
-                value = self.dac_dmtd_data,
+                load  = self.dmtd_tuning.load,
+                value = self.dmtd_tuning.value,
                 gain  = 1,
                 clk_domain = "wr_sys",
             )

--- a/test/hdl/wr_dac_tb.vhd
+++ b/test/hdl/wr_dac_tb.vhd
@@ -1,0 +1,93 @@
+--
+-- This file is part of LiteX-WR-NIC.
+--
+-- Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+-- SPDX-License-Identifier: BSD-2-Clause
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity wr_dac_tb is
+  generic (x2_gain : boolean := true);
+end;
+
+architecture test of wr_dac_tb is
+  signal clk, rst_n, load : std_logic := '0';
+  signal value : std_logic_vector(15 downto 0) := (others => '0');
+  signal sync_n, sclk, sdi : std_logic;
+  signal legacy_sync_n, legacy_sclk, legacy_sdi : std_logic;
+  signal words : natural := 0;
+  type t_values is array (natural range <>) of std_logic_vector(15 downto 0);
+  constant values : t_values := (x"0000", x"8000", x"FFFF", x"AAAA", x"5555");
+begin
+  clk <= not clk after 8 ns;
+
+  dut : entity work.serial_dac_arb
+    generic map (g_invert_sclk => false, g_enable_x2_gain => x2_gain)
+    port map (
+      clk_i => clk, rst_n_i => rst_n, val_i => value, load_i => load,
+      dac_ldac_n_o => open, dac_clr_n_o => open,
+      dac_sync_n_o => sync_n, dac_sclk_o => sclk, dac_din_o => sdi);
+
+  -- The old Python generic was ignored by Vivado. Omitting it reproduces
+  -- the VHDL default actually used by both SPEC-A7 DACs before this series.
+  legacy : entity work.serial_dac_arb
+    generic map (g_invert_sclk => false)
+    port map (
+      clk_i => clk, rst_n_i => rst_n, val_i => value, load_i => load,
+      dac_ldac_n_o => open, dac_clr_n_o => open,
+      dac_sync_n_o => legacy_sync_n, dac_sclk_o => legacy_sclk, dac_din_o => legacy_sdi);
+
+  compare_legacy : postponed process(all)
+  begin
+    if x2_gain and rst_n = '1' then
+      assert sync_n = legacy_sync_n and sclk = legacy_sclk and sdi = legacy_sdi
+        report "Default DAC serial waveform changed" severity failure;
+    end if;
+  end process;
+
+  decode : process
+    variable word : std_logic_vector(23 downto 0);
+  begin
+    wait until falling_edge(sync_n);
+    for bit_index in 23 downto 0 loop
+      wait until falling_edge(sclk);
+      word(bit_index) := sdi;
+    end loop;
+    wait until rising_edge(sync_n);
+    if words = 0 then
+      if x2_gain then
+        assert word = x"408000" report "Expected legacy x2 initialization" severity failure;
+      else
+        assert word = x"400000" report "Expected explicit x1 initialization" severity failure;
+      end if;
+    else
+      assert words <= values'length report "Unexpected DAC update" severity failure;
+      assert word = x"3" & values(words - 1) & x"0"
+        report "DAC tuning code changed" severity failure;
+    end if;
+    words <= words + 1;
+  end process;
+
+  stimulus : process
+  begin
+    wait for 100 ns;
+    wait until falling_edge(clk);
+    rst_n <= '1';
+    wait until words = 1;
+    for index in values'range loop
+      wait until falling_edge(clk);
+      value <= values(index);
+      load <= '1';
+      wait until falling_edge(clk);
+      load <= '0';
+      wait until words = index + 2;
+    end loop;
+    wait for 1 us;
+    assert words = values'length + 1 report "Missing DAC update" severity failure;
+    report "DAC serial checks passed";
+    std.env.stop;
+    wait;
+  end process;
+end;

--- a/test/hdl/wr_mmcm_backend_tb.sv
+++ b/test/hdl/wr_mmcm_backend_tb.sv
@@ -1,0 +1,312 @@
+//
+// This file is part of LiteX-WR-NIC.
+//
+// Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Full-width RTL regression with independent clock/command and MMCM stimulus.
+// The completion model deliberately includes responses outside UG472's normal
+// 12-cycle contract to test backpressure, timeout and reset recovery.
+`timescale 1ps/1ps
+
+module wr_mmcm_tb;
+    reg sys_clk = 0, wr_clk = 0, ps_clk = 0;
+    reg sys_rst = 1, wr_rst = 1, ps_rst = 1;
+    reg run_wr = 1, run_ps = 1;
+    integer wr_half_period = 8000;
+    reg [15:0] command_data = 32768;
+    reg command_load = 0, psdone = 0;
+    wire psen, psincdec, busy, fault, accepted_load;
+    wire [15:0] accepted_data;
+    wire [31:0] steps, status_steps, superseded;
+    wire [1:0] status;
+
+    wr_mmcm_dut dut (
+        .sys_clk(sys_clk), .sys_rst(sys_rst),
+        .wr_clk(wr_clk),   .wr_rst(wr_rst),
+        .ps_clk(ps_clk),   .ps_rst(ps_rst),
+        .command_data(command_data), .command_load(command_load),
+        .psen(psen), .psincdec(psincdec), .psdone(psdone),
+        .busy(busy), .fault(fault), .steps(steps),
+        .accepted_load(accepted_load), .accepted_data(accepted_data),
+        .status(status), .status_steps(status_steps), .superseded(superseded)
+    );
+
+    always #4000 sys_clk = ~sys_clk;
+    always begin
+        #(wr_half_period);
+        if (run_wr) wr_clk = ~wr_clk;
+    end
+    always #2500 if (run_ps) ps_clk = ~ps_clk;
+
+    integer cycles = 0, issued = 0, completed = 0, last_issue = 0;
+    integer response_latency = 12, response_width = 1, response_due = -1000;
+    integer active_code = 32768;
+    reg resetting = 1, pending = 0, active_direction = 0, previous_psen = 0;
+    reg force_done = 0, recording = 0, expected_direction = 0;
+    longint unsigned integral = 0;
+    integer measured_steps = 0;
+
+    // Protocol scoreboard: no access to the accumulator/timer implementation.
+    always @(posedge ps_clk) begin
+        cycles = cycles + 1;
+        if (resetting) begin
+            pending = 0;
+            previous_psen = 0;
+            issued = 0;
+            completed = 0;
+            response_due = -1000;
+            active_code = 32768;
+        end else begin
+            if (accepted_load) active_code = accepted_data;
+            if (recording)
+                integral = integral + ((active_code < 32768) ?
+                    32768 - active_code : active_code - 32768);
+            if (psen && previous_psen) $fatal(1, "PSEN wider than one cycle");
+            if (pending && psincdec != active_direction)
+                $fatal(1, "Direction changed during an outstanding shift");
+            if (psen) begin
+                if (pending || psdone || fault) $fatal(1, "Unsafe phase request");
+                pending = 1;
+                active_direction = psincdec;
+                last_issue = cycles;
+                issued = issued + 1;
+                if (response_latency != 0) response_due = cycles + response_latency;
+                if (recording) begin
+                    if (psincdec != expected_direction) $fatal(1, "Wrong tuning polarity");
+                    measured_steps = measured_steps + 1;
+                end
+            end
+            if (pending && psdone) begin
+                pending = 0;
+                completed = completed + 1;
+            end
+            previous_psen = psen;
+        end
+    end
+
+    // Drive away from the DUT sampling edge, avoiding testbench/DUT races.
+    always @(negedge ps_clk)
+        psdone = !resetting && (force_done ||
+            (cycles >= response_due - 1 && cycles < response_due - 1 + response_width));
+
+    task command(input integer code);
+        @(negedge wr_clk);
+        command_data = code;
+        command_load = 1;
+        @(negedge wr_clk);
+        command_load = 0;
+    endtask
+
+    task reset_backend(input integer domain);
+        resetting = 1;
+        @(negedge ps_clk);
+        if (domain == 0) wr_rst = 1;
+        else ps_rst = 1;
+        repeat (20) @(negedge ps_clk);
+        wr_rst = 0;
+        ps_rst = 0;
+        repeat (20) @(negedge ps_clk);
+        if (psen || busy || fault || steps) $fatal(1, "Reset failed");
+        resetting = 0;
+    endtask
+
+    task drain;
+        command(32768);
+        repeat (200) @(negedge ps_clk);
+        if (psen || busy || issued != completed || steps != completed)
+            $fatal(1, "Completion accounting did not converge");
+        if (status != 0 || status_steps != steps)
+            $fatal(1, "CSR status did not converge");
+    endtask
+
+    task start_measurement(input integer direction);
+        @(negedge ps_clk);
+        integral = 0;
+        measured_steps = 0;
+        expected_direction = direction;
+        recording = 1;
+    endtask
+
+    task finish_measurement;
+        real expected;
+        @(negedge ps_clk);
+        recording = 0;
+        expected = real'(integral)/524288.0;
+        if (measured_steps < expected - 1.01 || measured_steps > expected + 1.01)
+            $fatal(1, "Lost fractional phase: actual=%0d expected=%0f", measured_steps, expected);
+        $display("MMCM rate: code=%0d actual=%0d expected=%0f", active_code, measured_steps, expected);
+    endtask
+
+    task check_rate(input integer code, input integer duration);
+        reg refreshing;
+        command(code);
+        repeat (200) @(negedge ps_clk);
+        refreshing = 1;
+        fork
+            begin
+                while (refreshing) begin
+                    command(code);
+                    repeat (7) @(negedge wr_clk);
+                end
+            end
+            begin
+                start_measurement(code < 32768);
+                repeat (duration) @(negedge ps_clk);
+                finish_measurement();
+                refreshing = 0;
+            end
+        join
+        drain();
+        if (fault) $fatal(1, "Unexpected rate-test timeout");
+    endtask
+
+    reg [31:0] random_state = 32'h13a5c079;
+    function integer random_code;
+        // Fixed seed, reproducible across simulators.
+        random_state = random_state ^ (random_state << 13);
+        random_state = random_state ^ (random_state >> 17);
+        random_state = random_state ^ (random_state << 5);
+        random_code = random_state[14:0];
+    endfunction
+
+    integer index, code, before_steps;
+    initial begin
+        #200000;
+        sys_rst = 0;
+        reset_backend(0);
+        repeat (200) @(negedge ps_clk);
+        if (psen || steps) $fatal(1, "Backend did not start neutral");
+
+        // Real 16-bit arithmetic: endpoints and both one-LSB corrections.
+        check_rate(0,     8192);
+        check_rate(1,     8192);
+        check_rate(16384, 8192);
+        check_rate(32767, 2097152);
+        check_rate(32768, 8192);
+        check_rate(32769, 2097152);
+        check_rate(49152, 8192);
+        check_rate(65535, 8192);
+
+        // Integrate a varying command stream in each direction. The expected
+        // rate comes from the accepted code/time integral, not DUT state.
+        // Also exercise a faster-than-PSCLK source and FIFO replacement.
+        wr_half_period = 1700;
+        for (integer direction = 0; direction < 2; direction = direction + 1) begin
+            command(direction ? 16384 : 49152);
+            repeat (100) @(negedge ps_clk);
+            start_measurement(direction);
+            for (index = 0; index < 1000; index = index + 1) begin
+                code = random_code();
+                command(direction ? code : 32769 + code%32767);
+                repeat (index%7) @(negedge wr_clk);
+            end
+            finish_measurement();
+            drain();
+        end
+        wr_half_period = 8000;
+
+        // Slow and stretched completions limit the physical request rate.
+        response_latency = 40;
+        command(0);
+        repeat (1000) @(negedge ps_clk);
+        command(65535); // Reverse with a shift outstanding.
+        repeat (1000) @(negedge ps_clk);
+        drain();
+        response_latency = 12;
+        response_width = 20;
+        command(0);
+        repeat (1000) @(negedge ps_clk);
+        drain();
+        response_width = 1;
+
+        // A stale high PSDONE must not acknowledge a new request.
+        force_done = 1;
+        before_steps = issued;
+        command(0);
+        repeat (200) @(negedge ps_clk);
+        if (issued != before_steps) $fatal(1, "Request issued while PSDONE high");
+        force_done = 0;
+        repeat (200) @(negedge ps_clk);
+        if (issued == before_steps) $fatal(1, "Requests did not resume");
+        drain();
+
+        // Completion on the timeout boundary takes priority; a completion
+        // one cycle later is counted but must not clear the sticky fault.
+        response_latency = 63;
+        command(0);
+        repeat (500) @(negedge ps_clk);
+        drain();
+        if (fault) $fatal(1, "Deadline completion lost to timeout");
+        response_latency = 64;
+        command(0);
+        wait (fault);
+        repeat (200) @(negedge ps_clk);
+        if (busy || issued != completed) $fatal(1, "Late completion not counted");
+        before_steps = issued;
+        command(65535);
+        repeat (200) @(negedge ps_clk);
+        if (!fault || issued != before_steps) $fatal(1, "Fault was not sticky");
+        reset_backend(0);
+
+        response_latency = 0;
+        command(0);
+        wait (fault);
+        repeat (100) @(negedge ps_clk);
+        if (!busy || steps || issued != 1) $fatal(1, "Missing-completion behavior");
+        reset_backend(1);
+        response_latency = 12;
+        check_rate(16384, 4096);
+
+        // A paused PSCLK pauses both the MMCM transaction and the watchdog.
+        command(0);
+        wait (psen);
+        @(negedge ps_clk);
+        run_ps = 0;
+        repeat (300) @(negedge wr_clk);
+        if (fault) $fatal(1, "Stopped PSCLK advanced the watchdog");
+        run_ps = 1;
+        repeat (200) @(negedge ps_clk);
+        if (fault) $fatal(1, "Clock restart failed to complete the pending shift");
+        drain();
+
+        // Stop PSCLK while a request is active, overflow the command FIFO,
+        // then reset from WR while the destination clock remains stopped.
+        command(0);
+        wait (psen);
+        @(negedge ps_clk);
+        run_ps = 0;
+        for (index = 0; index < 40; index = index + 1) command(65535 - index);
+        if (superseded == 0) $fatal(1, "FIFO overflow scenario did not replace commands");
+        resetting = 1;
+        wr_rst = 1;
+        repeat (20) @(negedge wr_clk);
+        wr_rst = 0;
+        repeat (20) @(negedge wr_clk);
+        run_ps = 1;
+        repeat (200) @(negedge ps_clk);
+        resetting = 0;
+        repeat (200) @(negedge ps_clk);
+        if (accepted_load || psen || busy || fault || steps)
+            $fatal(1, "Pre-reset command replayed after PSCLK restart");
+        check_rate(49152, 4096);
+
+        // Reset from PSCLK with the command source stopped, then restart it.
+        @(negedge wr_clk);
+        run_wr = 0;
+        reset_backend(1);
+        run_wr = 1;
+        repeat (200) @(negedge ps_clk);
+        if (accepted_load || psen || busy || fault || steps)
+            $fatal(1, "Pre-reset command replayed after WR clock restart: load=%0d psen=%0d busy=%0d fault=%0d steps=%0d code=%0d",
+                accepted_load, psen, busy, fault, steps, active_code);
+        check_rate(16384, 4096);
+        $display("PASS: MMCM full-width rate, updates, CDC, completion, fault and reset");
+        $finish;
+    end
+
+    initial begin
+        #30000000000.0;
+        $fatal(1, "MMCM backend watchdog");
+    end
+endmodule

--- a/test/hdl/wr_mmcm_formal.sv
+++ b/test/hdl/wr_mmcm_formal.sv
@@ -1,0 +1,72 @@
+//
+// This file is part of LiteX-WR-NIC.
+//
+// Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+// SPDX-License-Identifier: BSD-2-Clause
+
+module wr_mmcm_formal(input wire clk);
+    localparam WIDTH = @WIDTH@;
+    localparam TIMEOUT = @TIMEOUT@;
+    localparam CENTER = 1 << (WIDTH - 1);
+
+    (* anyseq *) reg rst;
+    (* anyseq *) reg psdone;
+    wire psen, psincdec, busy, fault, core_reset, accepted_load;
+    wire [WIDTH-1:0] accepted_data;
+    wire [31:0] steps;
+    wr_mmcm_dut dut (
+        .sys_clk(clk), .sys_rst(rst), .core_reset(core_reset),
+        .psen(psen), .psincdec(psincdec), .psdone(psdone),
+        .busy(busy), .fault(fault), .steps(steps),
+        .accepted_data(accepted_data), .accepted_load(accepted_load)
+    );
+
+    reg past_valid = 0;
+    reg outstanding = 0;
+    reg active_direction = 0;
+    reg [31:0] completed = 0;
+    reg saw_increment = 0, saw_decrement = 0;
+
+    always @(posedge clk) begin
+        past_valid <= 1;
+        if (!past_valid) assume(rst);
+        if (core_reset) begin
+            outstanding <= 0;
+            active_direction <= 0;
+            completed <= 0;
+            saw_increment <= 0;
+            saw_decrement <= 0;
+        end else begin
+            // Independent transaction tracker, driven only by MMCM pins.
+            if (psen) begin
+                assert(!outstanding);
+                assert(busy);
+                assert(!fault);
+                outstanding <= 1;
+                active_direction <= psincdec;
+                if (psincdec) saw_increment <= 1;
+                else saw_decrement <= 1;
+            end
+            if (psdone) begin
+                outstanding <= 0;
+                if (outstanding || psen) completed <= completed + 1;
+            end
+            if (outstanding && !psdone) assert(psincdec == active_direction);
+            assert(busy == (outstanding || psen));
+            assert(steps == completed);
+            if (past_valid && !$past(core_reset)) begin
+                if ($past(psen)) assert(!psen);
+                if ($past(fault)) assert(fault);
+            end
+
+            // Non-vacuity: reach both directions, commands while busy,
+            // neutral during a shift and completion concurrent with a load.
+            cover(saw_increment && saw_decrement);
+            cover(outstanding && accepted_load && accepted_data == CENTER);
+            cover(outstanding && accepted_load &&
+                (accepted_data < CENTER) != active_direction);
+            cover(outstanding && psdone && accepted_load);
+            if (TIMEOUT <= 32) cover(fault);
+        end
+    end
+endmodule

--- a/test/hdl/wr_mmcm_unisim_tb.sv
+++ b/test/hdl/wr_mmcm_unisim_tb.sv
@@ -1,0 +1,179 @@
+//
+// This file is part of LiteX-WR-NIC.
+//
+// Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Real MMCME2_ADV/BUFG/reset primitives from Vivado's unisims_ver library.
+// Protocol and 1/56 VCO-period phase step: AMD UG472, Dynamic Phase Shift.
+`timescale 1ps/1ps
+
+module wr_mmcm_tb;
+    `include "parameters.vh"
+
+    reg sys_clk = 0, wr_clk = 0, ps_clk = 0, input_clk = 0;
+    reg sys_rst = 1, wr_rst = 1, ps_rst = 1;
+    reg [15:0] command_data = 32768;
+    reg command_load = 0;
+    wire psen, psincdec, psdone, busy, fault, locked;
+    wire [31:0] steps, status_steps;
+    wire [1:0] status;
+    wire output0_clk;
+    `ifdef SECOND_OUTPUT
+        wire output1_clk;
+    `endif
+
+    wr_mmcm_dut dut (
+        .sys_clk(sys_clk), .sys_rst(sys_rst),
+        .wr_clk(wr_clk),   .wr_rst(wr_rst),
+        .ps_clk(ps_clk),   .ps_rst(ps_rst),
+        .input_clk(input_clk),
+        .command_data(command_data), .command_load(command_load),
+        .psen(psen), .psincdec(psincdec), .psdone(psdone),
+        .busy(busy), .fault(fault), .steps(steps),
+        .status(status), .status_steps(status_steps), .locked(locked),
+        `ifdef SECOND_OUTPUT
+            .output1_clk(output1_clk),
+        `endif
+        .output0_clk(output0_clk)
+    );
+
+    always #4000 sys_clk = ~sys_clk;
+    always #8000 wr_clk = ~wr_clk;
+    always #2500 ps_clk = ~ps_clk;
+    always #(INPUT_PERIOD/2) input_clk = ~input_clk;
+
+    integer cycles = 0, issued = 0, completed = 0, started = 0, signed_steps = 0;
+    reg pending = 0, active_direction = 0, previous_psen = 0, previous_psdone = 0;
+    reg checking = 0;
+
+    always @(posedge ps_clk) begin
+        cycles = cycles + 1;
+        if (checking) begin
+            if (!locked || fault) $fatal(1, "MMCM lost lock or backend faulted");
+            if (psen && previous_psen) $fatal(1, "PSEN wider than one cycle");
+            if (psdone && previous_psdone) $fatal(1, "PSDONE wider than one cycle");
+            if (pending && psincdec != active_direction)
+                $fatal(1, "Direction changed before completion");
+            if (psen) begin
+                if (pending) $fatal(1, "Overlapping phase requests");
+                pending = 1;
+                active_direction = psincdec;
+                started = cycles;
+                issued = issued + 1;
+            end
+            if (psdone) begin
+                if (!pending) $fatal(1, "Unsolicited completion");
+                if (cycles - started != 12)
+                    $fatal(1, "Unexpected completion latency: %0d", cycles - started);
+                pending = 0;
+                completed = completed + 1;
+                signed_steps = signed_steps + (active_direction ? 1 : -1);
+            end
+        end
+        previous_psen = psen;
+        previous_psdone = psdone;
+    end
+
+    task command(input integer code);
+        @(negedge wr_clk);
+        command_data = code;
+        command_load = 1;
+        @(negedge wr_clk);
+        command_load = 0;
+    endtask
+
+    function real wrap(input real value);
+        wrap = value - $floor(value/OUTPUT_PERIOD)*OUTPUT_PERIOD;
+    endfunction
+
+    real baseline, edge_time, phase, expected, error;
+    task check_phase;
+        // Measure only after the command/PSDONE pipelines have drained.
+        repeat (200) @(negedge ps_clk);
+        if (busy || issued != completed || steps != completed)
+            $fatal(1, "Completion accounting mismatch");
+        if (status != 0 || status_steps != steps)
+            $fatal(1, "CSR status did not converge");
+        @(posedge output0_clk);
+        edge_time = $realtime;
+        phase = wrap(edge_time - baseline);
+        expected = wrap(signed_steps*PHASE_STEP);
+        error = wrap(phase - expected + OUTPUT_PERIOD/2) - OUTPUT_PERIOD/2;
+        if (error > 10.0 || error < -10.0)
+            $fatal(1, "Clock phase: steps=%0d measured=%0f expected=%0f error=%0f ps",
+                signed_steps, phase, expected, error);
+        @(posedge output0_clk);
+        if ($realtime - edge_time < OUTPUT_PERIOD - 2.0 ||
+            $realtime - edge_time > OUTPUT_PERIOD + 2.0)
+            $fatal(1, "Incorrect settled output period");
+        `ifdef SECOND_OUTPUT
+            // Both fine-phase-enabled reference outputs must move together.
+            fork
+                begin @(posedge output0_clk); edge_time = $realtime; end
+                begin @(posedge output1_clk); phase = $realtime; end
+            join
+            if (edge_time != phase) $fatal(1, "Reference outputs lost phase alignment");
+        `endif
+        $display("MMCM phase: signed_steps=%0d error=%0f ps", signed_steps, error);
+    endtask
+
+    integer before_steps;
+    initial begin
+        #200000;
+        @(negedge ps_clk);
+        sys_rst = 0;
+        wr_rst = 0;
+        ps_rst = 0;
+        wait (locked);
+        repeat (200) @(negedge ps_clk);
+        checking = 1;
+        @(posedge output0_clk);
+        baseline = $realtime;
+        check_phase();
+
+        // Shift through more than a complete output period in each direction,
+        // including all fine-phase and output-divider wrap boundaries.
+        command(0);
+        wait (completed >= WRAP_STEPS + 37);
+        command(32768);
+        check_phase();
+        before_steps = completed;
+        command(65535);
+        wait (completed >= before_steps + 2*WRAP_STEPS + 73);
+        command(32768);
+        check_phase();
+
+        // Reset during an outstanding shift, then acquire lock and tune again.
+        command(0);
+        wait (psen);
+        repeat (3) @(negedge ps_clk);
+        checking = 0;
+        @(negedge ps_clk);
+        ps_rst = 1;
+        repeat (40) @(negedge ps_clk);
+        ps_rst = 0;
+        wait (!locked);
+        wait (locked);
+        repeat (200) @(negedge ps_clk);
+        if (steps || busy || fault || psen) $fatal(1, "Reset did not restore neutral state");
+        issued = 0;
+        completed = 0;
+        signed_steps = 0;
+        pending = 0;
+        checking = 1;
+        @(posedge output0_clk);
+        baseline = $realtime;
+        command(0);
+        wait (completed >= 17);
+        command(32768);
+        check_phase();
+        $display("PASS: MMCM UNISIM phase, wraparound, completion and relock");
+        $finish;
+    end
+
+    initial begin
+        #2000000000;
+        $fatal(1, "MMCM simulation watchdog");
+    end
+endmodule

--- a/test/test_wr_clock.py
+++ b/test/test_wr_clock.py
@@ -1,0 +1,210 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from types import SimpleNamespace
+
+import pytest
+
+from migen import *
+from migen.fhdl.structure import _Assign
+
+from litex_wr_nic.gateware.ad5683r.core import AD5683RDAC
+from litex_wr_nic.gateware.wr_clock import WRTuningCalibration, WRTuningCDC, WRMMCMBackend
+
+
+def simulate(dut, generators, clocks=None):
+    dut.cd_sys = ClockDomain("sys")
+    dut.cd_wr  = ClockDomain("wr")
+    dut.cd_ps  = ClockDomain("ps")
+    fragment = dut.get_fragment()
+    clocks = dict(clocks or {"sys": 10, "wr": 16, "ps": 6})
+    for statement in fragment.comb:
+        if isinstance(statement, _Assign) and isinstance(statement.r, ClockSignal):
+            if statement.r.cd in clocks:
+                for domain in fragment.clock_domains:
+                    if statement.l is domain.clk:
+                        clocks[domain.name] = clocks[statement.r.cd]
+    run_simulation(fragment, generators, clocks=clocks)
+
+
+@pytest.mark.parametrize("calibration,values", [
+    ({}, [(0, 0, 0), (32768, 32768, 0), (65535, 65535, 0)]),
+    ({"polarity": -1}, [(0, 65535, 1), (32768, 32768, 0), (65535, 1, 0)]),
+    ({"gain": 3, "gain_shift": 1, "offset": 100},
+        [(0, 0, 1), (32767, 32866, 0), (32768, 32868, 0), (65535, 65535, 1)]),
+])
+def test_calibration_full_range_and_saturation(calibration, values):
+    dut = WRTuningCalibration(cd="sys", **calibration)
+
+    def check():
+        for value, expected, clipped in values:
+            yield dut.sink.data.eq(value)
+            yield dut.sink.load.eq(1)
+            yield
+            yield dut.sink.load.eq(0)
+            yield
+            assert (yield dut.source.load) == 1
+            assert (yield dut.source.data) == expected
+            assert (yield dut.clipped) == clipped
+            yield
+            assert (yield dut.source.load) == 0
+    simulate(dut, check())
+
+
+def test_tuning_cdc_is_coherent_and_eventually_delivers_latest_command():
+    dut = WRTuningCDC(cd_from="wr", cd_to="ps", depth=4)
+    sent = [((index * 977) ^ 0xa55a) & 0xffff for index in range(100)]
+    received = []
+    superseded = []
+
+    def producer():
+        for _ in range(10):
+            yield
+        yield dut.sink.load.eq(1)
+        for value in sent:
+            yield dut.sink.data.eq(value)
+            yield
+        yield dut.sink.load.eq(0)
+        for _ in range(1000):
+            yield
+        superseded.append((yield dut.superseded))
+
+    def consumer():
+        for _ in range(140):
+            if (yield dut.source.load):
+                received.append((yield dut.source.data))
+            yield
+    simulate(dut, {"wr": producer(), "ps": consumer()}, {"sys": 10, "wr": 6, "ps": 60})
+    assert received[-1] == sent[-1]
+    assert all(value in sent for value in received)
+    assert [sent.index(value) for value in received] == sorted(sent.index(value) for value in received)
+    assert len(received) + superseded[0] == len(sent)
+    assert superseded[0] > 0
+
+
+def test_mmcm_starts_neutral_and_holds_direction_until_completion():
+    dut = WRMMCMBackend("ps", "wr", width=8, timeout_cycles=100)
+    directions = []
+    issued = []
+
+    def command():
+        for _ in range(100):
+            yield
+        for value, wait in [(0, 130), (255, 130), (128, 100)]:
+            yield dut.command.data.eq(value)
+            yield dut.command.load.eq(1)
+            yield
+            yield dut.command.load.eq(0)
+            for _ in range(wait):
+                yield
+
+    def mmcm():
+        remaining = 0
+        direction = None
+        previous_psen = 0
+        for tick in range(1500):
+            psen = yield dut.psen
+            assert not (psen and previous_psen), "PSEN must be a one-cycle pulse"
+            previous_psen = psen
+            if tick < 250:
+                assert not psen, "Phase shift issued before the first tuning command"
+            if remaining:
+                assert not psen, "Overlapping MMCM phase shifts"
+                assert (yield dut.psincdec) == direction
+                remaining -= 1
+            if psen:
+                direction = yield dut.psincdec
+                directions.append(direction)
+                issued.append(tick)
+                remaining = 23  # Slower than the requested maximum rate.
+            yield dut.psdone.eq(remaining == 1)
+            if tick > 1300:
+                assert not psen, "Neutral command did not stop phase shifts"
+            assert not (yield dut.fault)
+            yield
+    simulate(dut, {"wr": command(), "ps": mmcm()})
+    assert 0 in directions and 1 in directions
+    assert all(b - a >= 23 for a, b in zip(issued, issued[1:]))
+
+
+def test_mmcm_timeout_stops_requests_and_reset_recovers():
+    dut = WRMMCMBackend("ps", "wr", width=8, timeout_cycles=20)
+    issued = []
+
+    def command():
+        for _ in range(10):
+            yield
+        yield dut.command.data.eq(0)
+        yield dut.command.load.eq(1)
+        yield
+        yield dut.command.load.eq(0)
+        for _ in range(200):
+            yield
+        yield dut.cd_wr.rst.eq(1)
+        for _ in range(10):
+            yield
+        yield dut.cd_wr.rst.eq(0)
+
+    def monitor():
+        for tick in range(800):
+            if (yield dut.psen):
+                issued.append(tick)
+            if 200 < tick < 500:
+                assert (yield dut.fault)
+            if tick > 650:
+                assert not (yield dut.fault)
+                assert not (yield dut.busy)
+                assert not (yield dut.psen)
+            yield
+    simulate(dut, {"wr": command(), "ps": monitor()})
+    assert len(issued) == 1
+
+
+def test_dac_host_command_is_coherent_and_load_is_a_pulse():
+    pads = Record([(name, 1) for name in ("ldac_n", "sync_n", "sclk", "sdi")], name="pads")
+    dut = AD5683RDAC(SimpleNamespace(add_source=lambda path: None), pads,
+        load=Signal(), value=Signal(16, reset=0x1234), gain=1, clk_domain="wr")
+    dut.cd_sys = ClockDomain("sys")
+    dut.cd_wr  = ClockDomain("wr")
+    fragment = dut.get_fragment()
+    instance = next(s for s in fragment.specials if isinstance(s, Instance) and s.of == "serial_dac_arb")
+    params = {item.name: item.value for item in instance.items if isinstance(item, Instance.Parameter)}
+    assert params["g_enable_x2_gain"].value == 0
+    signals = {item.name: item.expr for item in instance.items if isinstance(item, Instance.Input)}
+    fragment.specials.remove(instance)
+    loaded = []
+
+    def host():
+        yield dut._force.storage.eq(1)
+        yield dut._force.re.eq(1)
+        yield
+        yield dut._force.re.eq(0)
+        for _ in range(30):
+            yield
+        yield dut._value.storage.eq(0xabcd)
+        yield dut._load.storage.eq(1)
+        yield dut._load.re.eq(1)
+        yield
+        yield dut._load.re.eq(0)
+        for _ in range(80):
+            yield
+        # A level left high in the storage register must not hold load high.
+        yield dut._force.storage.eq(0)
+        yield dut._force.re.eq(1)
+        yield
+        yield dut._force.re.eq(0)
+        for _ in range(50):
+            yield
+        assert (yield signals["val_i"]) == 0x1234
+
+    def driver():
+        for _ in range(120):
+            if (yield signals["load_i"]):
+                loaded.append((yield signals["val_i"]))
+            yield
+    clocks = {"sys": 10, "wr": 16, dut.host_cdc.input_cd: 10, dut.host_cdc.output_cd: 16}
+    run_simulation(fragment, {"sys": host(), "wr": driver()}, clocks=clocks)
+    assert loaded == [0xabcd]

--- a/test/test_wr_clock.py
+++ b/test/test_wr_clock.py
@@ -4,6 +4,9 @@
 # Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import shutil
+import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -11,8 +14,16 @@ import pytest
 from migen import *
 from migen.fhdl.structure import _Assign
 
+from litex.gen import LiteXModule
+
+from litex_wr_nic.gateware.ps_gen import PSGen
+from litex_wr_nic.gateware.wr_clock import WRTuningCalibration, WRTuningCDC, WRDACBackend, WRMMCMBackend
+from litex_wr_nic.gateware.wr_core import WhiteRabbitCore
 from litex_wr_nic.gateware.ad5683r.core import AD5683RDAC
-from litex_wr_nic.gateware.wr_clock import WRTuningCalibration, WRTuningCDC, WRMMCMBackend
+
+# Constants ----------------------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[1]
 
 # Simulation Helpers -------------------------------------------------------------------------------
 
@@ -210,3 +221,155 @@ def test_dac_host_command_is_coherent_and_load_is_a_pulse():
     clocks = {"sys": 10, "wr": 16, dut.host_cdc.input_cd: 10, dut.host_cdc.output_cd: 16}
     run_simulation(fragment, {"sys": host(), "wr": driver()}, clocks=clocks)
     assert loaded == [0xabcd]
+
+
+def test_default_dac_path_preserves_registered_wr_commands():
+    dut = LiteXModule()
+    dut.tuning = WRDACBackend(cd="wr")
+    pads = Record([(name, 1) for name in ("ldac_n", "sync_n", "sclk", "sdi")], name="pads")
+    dut.dac = AD5683RDAC(SimpleNamespace(add_source=lambda path: None), pads,
+        load=dut.tuning.load, value=dut.tuning.value, clk_domain="wr")
+    dut.cd_sys = ClockDomain("sys")
+    dut.cd_wr  = ClockDomain("wr")
+
+    # Before the backend was introduced, the DAC driver registered WR's code
+    # and load once in wr_sys. Preserve the same stream with default settings.
+    expected_value = Signal(16)
+    expected_load  = Signal()
+    dut.sync.wr += [
+        expected_value.eq(dut.tuning.command.data),
+        expected_load.eq(dut.tuning.command.load),
+    ]
+    fragment = dut.get_fragment()
+    instance = next(
+        s for s in fragment.specials
+        if isinstance(s, Instance) and s.of == "serial_dac_arb"
+    )
+    inputs = {item.name: item.expr for item in instance.items if isinstance(item, Instance.Input)}
+    fragment.specials.remove(instance)
+
+    def check():
+        # Include boundaries, alternating bits and repeated/bursty load pulses.
+        for index, value in enumerate([0, 1, 32767, 32768, 32769, 65535, 0xaaaa, 0x5555]*4):
+            yield dut.tuning.command.data.eq(value)
+            yield dut.tuning.command.load.eq(index % 3 != 0)
+            yield
+            assert (yield inputs["load_i"]) == (yield expected_load)
+            if (yield expected_load):
+                assert (yield inputs["val_i"]) == (yield expected_value)
+        yield dut.tuning.command.load.eq(0)
+        yield
+        yield
+        assert not (yield inputs["load_i"])
+
+    clocks = {"sys": 10, "wr": 16, dut.dac.host_cdc.input_cd: 10, dut.dac.host_cdc.output_cd: 16}
+    run_simulation(fragment, {"wr": check()}, clocks=clocks)
+
+
+@pytest.mark.parametrize("gain", [None, 1, 2])
+def test_dac_serial_words_preserve_default_x2_gain(tmp_path, gain):
+    if shutil.which("ghdl") is None:
+        pytest.skip("GHDL is required for the DAC serial regression")
+    pads = Record([(name, 1) for name in ("ldac_n", "sync_n", "sclk", "sdi")], name="pads")
+    kwargs = {} if gain is None else dict(gain=gain)
+    dut = AD5683RDAC(SimpleNamespace(add_source=lambda path: None), pads,
+        load=Signal(), value=Signal(16), **kwargs)
+    instance = next(
+        s for s in dut.get_fragment().specials
+        if isinstance(s, Instance) and s.of == "serial_dac_arb"
+    )
+    params = {item.name: item.value for item in instance.items if isinstance(item, Instance.Parameter)}
+    x2 = params["g_enable_x2_gain"].value
+    assert x2 == int(gain != 1)
+    driver = ROOT / "litex_wr_nic/gateware/ad5683r"
+
+    def run(*args):
+        result = subprocess.run(["ghdl", args[0], "--std=08", *args[1:]],
+            cwd            = tmp_path,
+            capture_output = True,
+            text           = True,
+            timeout        = 30,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        return result.stdout + result.stderr
+
+    run("-a", str(driver / "serial_dac.vhd"), str(driver / "serial_dac_arb.vhd"),
+        str(ROOT / "test/hdl/wr_dac_tb.vhd"))
+    run("-e", "wr_dac_tb")
+    output = run("-r", "wr_dac_tb", f"-gx2_gain={'true' if x2 else 'false'}",
+        "--assert-level=error", "--stop-time=100us")
+    assert "DAC serial checks passed" in output
+
+
+def test_spec_a7_preserves_effective_refclk_and_dmtd_gain(monkeypatch):
+    from spec_a7_wr_nic import BaseSoC
+
+    monkeypatch.setattr(WhiteRabbitCore, "add_sources", staticmethod(lambda platform: None))
+    soc = BaseSoC(with_pcie=False, with_rf_out=False, with_sync_in_pll=False)
+    for dac in (soc.refclk_dac, soc.dmtd_dac):
+        instance = next(
+            s for s in dac.get_fragment().specials
+            if isinstance(s, Instance) and s.of == "serial_dac_arb"
+        )
+        params = {item.name: item.value for item in instance.items if isinstance(item, Instance.Parameter)}
+        assert params["g_enable_x2_gain"].value == 1
+
+
+@pytest.mark.parametrize("code,div_n", [(1, 0), (64, 0), (128, 0), (192, 0), (255, 0), (64, 2), (192, 2)])
+def test_mmcm_preserves_legacy_steady_state_rate_and_polarity(code, div_n):
+    dut    = WRMMCMBackend("ps", "wr", width=8, div_n=div_n)
+    issued = []
+    cycles = 4096
+
+    def command():
+        for _ in range(10):
+            yield
+        yield dut.command.data.eq(code)
+        yield dut.command.load.eq(1)
+        yield
+        yield dut.command.load.eq(0)
+
+    def mmcm():
+        pending = 0
+        # Completion is faster than the highest nominal rate. Check steady
+        # commands after CDC/startup, independently of the accumulator phase.
+        for tick in range(200 + cycles):
+            if pending:
+                pending -= 1
+            if (yield dut.psen):
+                assert pending == 0
+                pending = 8
+                assert (yield dut.psincdec) == int(code < 128)
+                if tick >= 200:
+                    issued.append(tick)
+            yield dut.psdone.eq(pending == 1)
+            assert not (yield dut.fault)
+            yield
+
+    simulate(dut, {"wr": command(), "ps": mmcm()})
+    # The original PSGen uses this transfer function. Endpoint code zero had
+    # a magnitude-width bug and is covered by the corrected full-range tests.
+    expected = cycles * abs(code - 128) / (1 << (8 + div_n + 3))
+    assert abs(len(issued) - expected) <= 1
+
+
+def test_legacy_psgen_keeps_running_without_completion_input():
+    dut    = PSGen("ps", "wr", ctrl_size=8)
+    issued = []
+
+    def command():
+        yield dut.ctrl_data.eq(192)
+        yield dut.ctrl_load.eq(1)
+        yield
+        yield dut.ctrl_load.eq(0)
+
+    def monitor():
+        for tick in range(1024):
+            if (yield dut.psen):
+                assert (yield dut.psincdec) == 0
+                issued.append(tick)
+            yield
+
+    simulate(dut, {"wr": command(), "ps": monitor()})
+    assert len(issued) >= 30
+    assert issued[-1] > 900

--- a/test/test_wr_clock.py
+++ b/test/test_wr_clock.py
@@ -14,13 +14,14 @@ from migen.fhdl.structure import _Assign
 from litex_wr_nic.gateware.ad5683r.core import AD5683RDAC
 from litex_wr_nic.gateware.wr_clock import WRTuningCalibration, WRTuningCDC, WRMMCMBackend
 
+# Simulation Helpers -------------------------------------------------------------------------------
 
 def simulate(dut, generators, clocks=None):
     dut.cd_sys = ClockDomain("sys")
     dut.cd_wr  = ClockDomain("wr")
     dut.cd_ps  = ClockDomain("ps")
     fragment = dut.get_fragment()
-    clocks = dict(clocks or {"sys": 10, "wr": 16, "ps": 6})
+    clocks   = dict(clocks or {"sys": 10, "wr": 16, "ps": 6})
     for statement in fragment.comb:
         if isinstance(statement, _Assign) and isinstance(statement.r, ClockSignal):
             if statement.r.cd in clocks:
@@ -29,6 +30,7 @@ def simulate(dut, generators, clocks=None):
                         clocks[domain.name] = clocks[statement.r.cd]
     run_simulation(fragment, generators, clocks=clocks)
 
+# Clock Tuning Tests -------------------------------------------------------------------------------
 
 @pytest.mark.parametrize("calibration,values", [
     ({}, [(0, 0, 0), (32768, 32768, 0), (65535, 65535, 0)]),
@@ -102,8 +104,8 @@ def test_mmcm_starts_neutral_and_holds_direction_until_completion():
                 yield
 
     def mmcm():
-        remaining = 0
-        direction = None
+        remaining     = 0
+        direction     = None
         previous_psen = 0
         for tick in range(1500):
             psen = yield dut.psen
@@ -119,7 +121,7 @@ def test_mmcm_starts_neutral_and_holds_direction_until_completion():
                 direction = yield dut.psincdec
                 directions.append(direction)
                 issued.append(tick)
-                remaining = 23  # Slower than the requested maximum rate.
+                remaining = 23 # Slower than the requested maximum rate.
             yield dut.psdone.eq(remaining == 1)
             if tick > 1300:
                 assert not psen, "Neutral command did not stop phase shifts"

--- a/test/test_wr_clock.py
+++ b/test/test_wr_clock.py
@@ -13,6 +13,7 @@ import pytest
 
 from migen import *
 from migen.fhdl.structure import _Assign
+from migen.sim import passive
 
 from litex.gen import LiteXModule
 
@@ -373,3 +374,41 @@ def test_legacy_psgen_keeps_running_without_completion_input():
     simulate(dut, {"wr": command(), "ps": monitor()})
     assert len(issued) >= 30
     assert issued[-1] > 900
+
+
+@pytest.mark.parametrize("code", [64, 192])
+def test_mmcm_repeated_commands_preserve_fractional_phase(code):
+    dut    = WRMMCMBackend("ps", "wr", width=8)
+    issued = []
+    cycles = 2048
+
+    @passive
+    def command():
+        # Refresh the command more often than one requested phase step. A
+        # constant servo output must have the same rate at every update rate.
+        while True:
+            yield dut.command.data.eq(code)
+            yield dut.command.load.eq(1)
+            yield
+            yield dut.command.load.eq(0)
+            for _ in range(7):
+                yield
+
+    def mmcm():
+        pending = 0
+        for tick in range(200 + cycles):
+            if pending:
+                pending -= 1
+            if (yield dut.psen):
+                assert pending == 0
+                assert (yield dut.psincdec) == int(code < 128)
+                pending = 12
+                if tick >= 200:
+                    issued.append(tick)
+            yield dut.psdone.eq(pending == 1)
+            assert not (yield dut.fault)
+            yield
+
+    simulate(dut, {"wr": command(), "ps": mmcm()})
+    expected = cycles * abs(code - 128) / (1 << 11)
+    assert abs(len(issued) - expected) <= 1

--- a/test/test_wr_mmcm.py
+++ b/test/test_wr_mmcm.py
@@ -1,0 +1,153 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Exercise generated backend RTL and real 7-series MMCM models with XSim."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from migen import *
+
+from litex.gen import LiteXModule
+
+from litex.build.xilinx import XilinxPlatform
+from litex.soc.cores.clock import S7MMCM
+
+from litex_wr_nic.gateware.wr_clock import WRMMCMBackend
+
+# Constants ----------------------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Simulation Helpers -------------------------------------------------------------------------------
+
+class MMCMTestSoC(LiteXModule):
+    def __init__(self, input_freq=None, output_freq=None, outputs=1):
+        self.cd_sys = ClockDomain("sys")
+        self.cd_wr  = ClockDomain("wr")
+        self.cd_ps  = ClockDomain("ps")
+        self.backend = backend = WRMMCMBackend("ps", "wr", timeout_cycles=64)
+        ports = {
+            "command_data":  backend.command.data,
+            "command_load":  backend.command.load,
+            "psen":          backend.psen,
+            "psincdec":      backend.psincdec,
+            "busy":          backend.busy,
+            "fault":         backend.fault,
+            "steps":         backend.steps,
+            "accepted_data": backend.cdc.source.data,
+            "accepted_load": backend.cdc.source.load,
+            "status":        backend._status.status,
+            "status_steps":  backend._steps.status,
+            "superseded":    backend.cdc.superseded,
+        }
+        self.ios = {cd.clk for cd in (self.cd_sys, self.cd_wr, self.cd_ps)}
+        self.ios.update(cd.rst for cd in (self.cd_sys, self.cd_wr, self.cd_ps))
+        if input_freq is None:
+            ports["psdone"] = backend.psdone
+        else:
+            self.cd_input = ClockDomain("input")
+            self.ios.add(self.cd_input.clk)
+            self.mmcm = mmcm = S7MMCM(speedgrade=-3, fractional=False)
+            mmcm.register_clkin(self.cd_input.clk, input_freq)
+            mmcm.expose_dps("ps", with_csr=False)
+            for index in range(outputs):
+                cd = ClockDomain(f"output{index}")
+                setattr(self, f"cd_output{index}", cd)
+                mmcm.create_clkout(cd, output_freq, margin=0)
+                mmcm.params[f"p_CLKOUT{index}_USE_FINE_PS"] = "TRUE"
+                self.ios.add(cd.clk)
+            self.comb += [
+                mmcm.reset.eq(self.cd_ps.rst),
+                mmcm.psen.eq(backend.psen),
+                mmcm.psincdec.eq(backend.psincdec),
+                backend.psdone.eq(mmcm.psdone),
+            ]
+            ports["psdone"] = mmcm.psdone
+            ports["locked"] = mmcm.locked
+            self.config = mmcm.compute_config()
+
+        # Explicit top-level port names keep the HDL bench independent of
+        # Migen's generated internal names. Accepted commands are observed at
+        # the CDC output; accumulator state is not part of the test interface.
+        for name, source in ports.items():
+            source.name_override = name
+            self.ios.add(source)
+
+
+def run_xsim(tmp_path, dut, bench, parameters=""):
+    for tool in ("xvlog", "xelab", "xsim"):
+        if shutil.which(tool) is None:
+            pytest.skip(f"{tool} is required for the MMCM RTL regression")
+    platform = XilinxPlatform("xc7a200tsbg484-3", [])
+    platform.get_verilog(dut, ios=dut.ios, name="wr_mmcm_dut").write(str(tmp_path / "dut.v"))
+    (tmp_path / "parameters.vh").write_text(parameters)
+
+    def run(tool, *args):
+        result = subprocess.run([tool, *map(str, args)],
+            cwd            = tmp_path,
+            capture_output = True,
+            text           = True,
+            timeout        = 180,
+        )
+        output = result.stdout + result.stderr
+        (tmp_path / f"{tool}-output.log").write_text(output)
+        assert result.returncode == 0, output
+        assert "ERROR:" not in output, output
+        return output
+
+    vivado = Path(shutil.which("xsim")).resolve().parents[1]
+    run("xvlog", "--sv", vivado / "data/verilog/src/glbl.v",
+        tmp_path / "dut.v", ROOT / "test/hdl" / bench)
+    run("xelab", "work.wr_mmcm_tb", "work.glbl", "-L", "unisims_ver", "--snapshot", "wr_mmcm_tb")
+    output = run("xsim", "wr_mmcm_tb", "--runall")
+    # XSim can return zero after a fatal assertion or Tcl startup failure.
+    assert "PASS: MMCM" in output, output
+    assert not any(message in output for message in ("Fatal:", "Error:", "Warning: [Unisim")), output
+
+# Backend RTL Tests --------------------------------------------------------------------------------
+
+def test_acorn_mmcm_configuration_supports_fine_phase_shifting():
+    from acorn_wr_nic import _CRG
+    from litex_boards.platforms import sqrl_acorn
+
+    crg = _CRG(sqrl_acorn.Platform(), 125e6)
+    for mmcm, frequency in [(crg.refclk_mmcm, 125e6), (crg.dmtd_mmcm, 62.5e6)]:
+        config = mmcm.compute_config()
+        assert config["clkfbout_mult"] == int(config["clkfbout_mult"])
+        assert config["clkout0_divide"] == int(config["clkout0_divide"])
+        assert config["clkout0_freq"] == frequency
+        assert mmcm.params["p_CLKOUT0_USE_FINE_PS"] == "TRUE"
+
+
+def test_mmcm_full_width_commands_resets_and_completion(tmp_path):
+    run_xsim(tmp_path, MMCMTestSoC(), "wr_mmcm_backend_tb.sv")
+
+
+@pytest.mark.parametrize("input_freq,output_freq,outputs", [
+    (100e6, 125e6,  2), # M2SDR reference, both outputs use fine phase shifting.
+    (100e6, 62.5e6, 1), # M2SDR DMTD.
+    (200e6, 125e6,  1), # Acorn reference.
+    (200e6, 62.5e6, 1), # Acorn DMTD.
+])
+def test_mmcm_unisim_clock_phase_and_wraparound(tmp_path, input_freq, output_freq, outputs):
+    dut = MMCMTestSoC(input_freq, output_freq, outputs)
+    config = dut.config
+    # UG472: interpolated fine phase shifting requires integer division.
+    assert config["clkfbout_mult"] == int(config["clkfbout_mult"])
+    assert config["clkout0_divide"] == int(config["clkout0_divide"])
+    parameters = (
+        f"localparam real INPUT_PERIOD = {1e12/input_freq};\n"
+        f"localparam real OUTPUT_PERIOD = {1e12/output_freq};\n"
+        f"localparam real PHASE_STEP = {1e12/config['vco']/56};\n"
+        f"localparam integer OUTPUTS = {outputs};\n"
+        f"localparam integer WRAP_STEPS = {int(config['clkout0_divide'])*56};\n"
+        + ("`define SECOND_OUTPUT\n" if outputs == 2 else "")
+    )
+    run_xsim(tmp_path, dut, "wr_mmcm_unisim_tb.sv", parameters)

--- a/test/test_wr_mmcm_formal.py
+++ b/test/test_wr_mmcm_formal.py
@@ -1,0 +1,102 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Prove the phase-request protocol at the accepted-command boundary."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from migen import *
+
+from litex.gen import LiteXModule
+from litex.build.xilinx import XilinxPlatform
+
+from litex_wr_nic.gateware.wr_clock import WRMMCMBackend
+
+# Formal Protocol Tests ----------------------------------------------------------------------------
+
+@pytest.mark.parametrize("width,div_n,timeout", [(16, 0, 1024), (8, 2, 32)])
+def test_mmcm_protocol_for_arbitrary_accepted_commands(tmp_path, width, div_n, timeout):
+    for tool in ("yosys", "sby", "boolector"):
+        if shutil.which(tool) is None:
+            pytest.skip(f"{tool} is required for the MMCM formal regression")
+
+    dut = LiteXModule()
+    dut.cd_sys = ClockDomain("sys")
+    dut.backend = backend = WRMMCMBackend("sys", "sys",
+        width=width, div_n=div_n, timeout_cycles=timeout)
+    reset = Signal(name_override="core_reset")
+    dut.comb += reset.eq(ResetSignal(backend.cdc.output_cd))
+    ports = dict(
+        psen          = backend.psen,
+        psincdec      = backend.psincdec,
+        psdone        = backend.psdone,
+        busy          = backend.busy,
+        fault         = backend.fault,
+        steps         = backend.steps,
+        accepted_data = backend.cdc.source.data,
+        accepted_load = backend.cdc.source.load,
+    )
+    for name, signal in ports.items():
+        signal.name_override = name
+        signal.attr.add("keep")
+    platform = XilinxPlatform("xc7a200tsbg484-3", [])
+    platform.get_verilog(dut, name="wr_mmcm_dut",
+        ios={dut.cd_sys.clk, dut.cd_sys.rst, reset, *ports.values()},
+    ).write(str(tmp_path / "dut.v"))
+    root = Path(__file__).resolve().parent
+    (tmp_path / "formal.sv").write_text((root / "hdl/wr_mmcm_formal.sv").read_text()
+        .replace("@WIDTH@", str(width)).replace("@TIMEOUT@", str(timeout)))
+
+    # Cut only the accepted command wires: all values/load patterns are now
+    # arbitrary, including patterns a paced FIFO would never produce. The
+    # phase accumulator, request state, watchdog and reset logic are the real
+    # generated RTL. CDC coherence itself is covered by separate RTL/hardware
+    # tests; this proof does not model metastability or the analog MMCM.
+    # Rate, neutral-code behavior and code-to-direction mapping are checked
+    # by the independent command integral in the full-width XSim regression.
+    (tmp_path / "mmcm.sby").write_text("""[tasks]
+prove
+cover
+
+[options]
+prove: mode prove
+prove: depth 32
+timeout 180
+cover: mode cover
+cover: depth 180
+
+[engines]
+prove: smtbmc boolector
+cover: smtbmc boolector
+
+[script]
+read_verilog +/xilinx/cells_sim.v
+read_verilog -formal dut.v formal.sv
+prep -top wr_mmcm_formal -flatten
+cutpoint w:dut.accepted_data w:dut.accepted_load
+opt_clean -purge
+async2sync
+dffunmap
+
+[files]
+dut.v
+formal.sv
+""")
+    result = subprocess.run(["sby", "-f", "mmcm.sby"],
+        cwd            = tmp_path,
+        capture_output = True,
+        text           = True,
+        timeout        = 240,
+    )
+    output = result.stdout + result.stderr
+    (tmp_path / "formal-output.log").write_text(output)
+    assert result.returncode == 0, output
+    for task in ("prove", "cover"):
+        assert (tmp_path / f"mmcm_{task}/status").read_text().split()[0] == "PASS", output


### PR DESCRIPTION
Add calibrated DAC and MMCM tuning backends with coherent commands from WR's system clock. The MMCM backend permits one outstanding phase shift, keeps direction stable until PSDONE, counts completions and stops on a missing-completion fault. Depends on #76.

Same-direction updates preserve fractional phase, including frequent one-LSB commands. Neutral/reversal cancels only unissued phase. Reset holds both FIFO ends until both clocks resume, preventing stale commands from replaying after a stopped-clock reset. Earlier regressions reproduced lost small corrections and unwanted post-reset shifts before these fixes.

Routed qualification adds a registered command-decode stage and prepares the watchdog while idle, shortening the 200 MHz request path. Acorn and M2SDR explicitly constrain the asynchronous tuning FIFO crossing; timing inside the backend remains checked. Command latency increases by one PSCLK cycle, while tuning rate and polarity are preserved.

Acorn's tunable MMCMs explicitly use integer division, required for fine phase shifting. The matching M2SDR change is in enjoy-digital/litex_m2sdr#166. Nominal outputs remain 125/62.5 MHz. Correcting the previous invalid fractional configuration selects a 1.5 GHz VCO instead of 1.59375 GHz and increases phase-step size by 6.25% where applicable. Firmware PI coefficients are unchanged, so physical WR servo qualification remains necessary.

Digital calibration defaults to unity gain, unchanged polarity and zero offset. SPEC-A7 AD5683Rs retain their effective legacy **x2 gain**; host override crosses mode/value/load coherently. The original `PSGen` implementation is unchanged from #76. Acorn and M2SDR explicitly select the new backend and connect PSDONE.

See `doc/wr_clock_tuning.md` for contracts and reproducible simulation, formal and hardware commands. `bench/spec_a7_mmcm.py` and `bench/spec_a7_mmcm_test.py` provide the physical test image and host runner.

### Validation at `bac7b7a7af1215f741bbeeb095cac5a01a732b8a`

- **All six M2SDR #166 GitHub checks pass** with CI pinned to this exact WR commit.
- **30 clock tests passed, no skips**: Migen, GHDL DAC serial checks, generated RTL in XSim, real Xilinx MMCM models and two formal configurations. Full rebased stack through #80: **110 passed, no skips**. M2SDR: **183 passed**.
- **84 SPEC-A7 physical measurements passed**, covering four MMCM configurations (100/200 MHz input, 125/62.5 MHz output, 200 MHz PSCLK), both directions, neutral, endpoints, one-LSB codes, every-cycle/slower refresh, missing completion, fault recovery and reset with a stopped producer clock.
- **33,554,560 phase shifts completed inside the measurement windows**, with zero overlap, pulse-width, direction, completion-latency or loss-of-lock errors. Independent output-clock edge counts agree with the selected VCO/phase-step prediction within **0.949 edge**. Every one-LSB window produced the expected 32 shifts.
- SPEC-A7 test image fully routed: **WNS +0.330 ns, WHS +0.055 ns**, zero routing errors. Its -2 part uses a 1.375 GHz VCO, so this is backend qualification on 7-series hardware, not an exact M2SDR board/servo measurement.
- Formal induction proves request exclusivity, one-cycle PSEN, stable direction while pending, completion accounting and sticky faults under arbitrary accepted commands, completions and resets. Cover traces reach both directions, command changes while busy and timeout. Rate/code mapping is checked independently in simulation; analog behavior and metastability are outside the proof.
- Full-width simulation integrates a varying command stream over more than four million PSCLK cycles. Vendor-model tests cover actual reference/DMTD configurations, both M2SDR reference outputs, 12-cycle completion, phase wraparound and reset/relock.
- M2SDR's complete generated implementation flow passes after removing an unused IDELAYCTRL in #166: **WNS +0.006 ns, WHS +0.046 ns**, all 34,206 routable nets routed. MMCM backend setup margin is **+0.595 ns** at 200 MHz. Existing DRC/CDC warnings remain; whole-design setup margin is small.
- The working SPEC-A7 uRV/private WR image was restored after testing. Fresh WR startup, version response and increasing uptime were verified. Flash was not modified.

WR servo lock, jitter and PPS measurements against a reference peer are planned as follow-up testing. Passing frequency/count/protocol tests does not establish those analog/system properties. No M2SDR FPGA image was loaded.
