### PR TITLE
spec_a7: constrain mutually exclusive PIPE clock modes

### DIFF
--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -254,6 +254,16 @@ class BaseSoC(LiteXWRNICSoC):
                 refclk_freq               = 100e6,
                 pclk_mux_direct_from_mmcm = True,
             )
+            # These dedicated MMCM outputs only feed the two inputs of the
+            # PIPE BUFGCTRL. One mode reaches pclk at a time. Keep timing
+            # within each mode; exclude impossible 125 MHz <-> 250 MHz paths.
+            platform.toolchain.pre_placement_commands.add(
+                "set_clock_groups -logically_exclusive "
+                "-group [get_clocks -of_objects [get_nets {pclk125}]] "
+                "-group [get_clocks -of_objects [get_nets {pclk250}]]",
+                pclk125 = self.pcie_phy.mmcm.clkouts[4][0],
+                pclk250 = self.pcie_phy.mmcm.clkouts[5][0],
+            )
             self.pcie_phy.update_config({
                 "Base_Class_Menu"          : "Network_controller",
                 "Sub_Class_Interface_Menu" : "Ethernet_controller",


### PR DESCRIPTION
SPEC-A7 drives the PCIe PIPE clock mux from two dedicated MMCM outputs (125 and 250 MHz). Vivado otherwise analyzes impossible paths between those alternatives on the same mux output, creating false setup/hold failures in the PTM sniffer. Declare only those dedicated outputs logically exclusive; all timing within each mode and the other MMCM output relationships remain checked.

Validation on three routed designs confirms that the two nets feed only BUFGCTRL/I0 and I1. The host/integrated and fabric/uRV designs then meet timing (WNS +0.096 and +0.036 ns). Both PIPE modes also pass in the VexRiscv/HyperRAM design; its separate, real cache path violation (-0.049 ns) remains visible. The final-series default-uRV routed image meets timing with the constraint (WNS +0.038 ns, WHS +0.034 ns) and passed two board reload/console/restart checks. The final source applies the constraint after clock derivation, before placement; generated Tcl ordering was checked. A fresh complete build with the HyperRAM fixes in #79 meets setup/hold timing (+0.018/+0.018 ns). The fresh complete default-uRV build also meets timing (+0.006/+0.053 ns) and passed two reload/console/restart/snapshot checks. No gateware logic changes.

Depends on #77 as a follow-up from hardware qualification. Constraint rationale follows AMD UG903: https://docs.amd.com/r/2024.1-English/ug903-vivado-using-constraints/Exclusive-Clock-Groups .

### Current validation

Rebased onto #77's hardware-qualified MMCM fix (`bac7b7a`). This PR's own patches are unchanged (`git range-diff`). The complete stack passes **110 tests with no skips**, including real MMCM/uRV XSim tests and two unbounded protocol proofs; **183 M2SDR tests** pass against the updated dependency.

Additional SPEC-A7 testing passed **84 physical MMCM measurements** across four input/output configurations, with **33,554,560 completed phase shifts**, zero monitor errors and output-frequency predictions accurate to within one counted edge. The temporary test image meets routed timing (+0.330 ns setup / +0.055 ns hold). The previously working uRV/private WR image was restored and its console and increasing uptime verified. Hardware/timing figures in this PR's earlier sections refer to their original recorded bitstreams.

SPEC-A7 effective x2 DAC gain, firmware PI coefficients and legacy PSGen behavior remain unchanged. WR servo lock, jitter and PPS accuracy against a WR reference peer remain outside these checks.
