### PR TITLE
spec_a7: improve HyperRAM read sampling and cache timing

### DIFF
--- a/doc/wr_boot_policy.md
+++ b/doc/wr_boot_policy.md
@@ -30,6 +30,15 @@ memory controller is ready and the host has written and verified all 128 KiB.
 Failed validation leaves the CPU held. A host reboot or disconnect does not
 release a waiting CPU. A normal CPU restart keeps the verified memory image.
 
+SPEC-A7 samples HyperRAM DQ/RWDS with a 180-degree shifted system PLL output.
+The cache uses local 17-bit byte addresses for the reserved 128 KiB window;
+the SoC decoder enforces that window's address bounds. Full host readback
+exercises physical RAM after cache eviction, which is essential: immediate
+readback from the cache alone did not expose the read corruption observed
+with the original sampling configuration. The system clock remains derived
+from its PLL so implementation checks its real relationship to the input
+capture clock.
+
 `--wr-cpu-memory integrated --wr-cpu-boot spi` reads the same SPI boot slot as
 HyperRAM boot. The default `auto` boot source preserves the previous selection
 for each memory mode. Private uRV RAM is physically inside the WR wrapper;

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -286,9 +286,11 @@ class BaseSoC(LiteXWRNICSoC):
 
             # PCIe <-> Sys-Clk false paths.
             platform.toolchain.pre_placement_commands.append(
-                "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout*}}] -to [get_clocks -of_objects [get_nets sys_clk]]")
+                "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout*}}] "
+                "-to [get_clocks -of_objects [get_nets sys_clk]]")
             platform.toolchain.pre_placement_commands.append(
-                "set_false_path -quiet -from [get_clocks -of_objects [get_nets sys_clk]] -to [get_clocks -quiet {{*s7pciephy_clkout*}}]")
+                "set_false_path -quiet -from [get_clocks -of_objects [get_nets sys_clk]] "
+                "-to [get_clocks -quiet {{*s7pciephy_clkout*}}]")
             platform.toolchain.pre_placement_commands.append(
                 "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout0}}] -to [get_clocks -quiet {{*s7pciephy_clkout1}}]")
             platform.toolchain.pre_placement_commands.append(

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -203,13 +203,19 @@ class BaseSoC(LiteXWRNICSoC):
         wr_cpu_region = None
         if wr_cpu_memory == "hyperram":
             wr_cpu_region = SoCRegion(origin=WR_CPU_MEMORY_ORIGIN, size=WR_CPU_MEMORY_SIZE, mode="rwx")
-            wr_cpu_bus    = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+            # The SoC decoder owns the region bounds. Only the local 128 KiB
+            # address belongs in the cache tag, not the constant SoC prefix.
+            wr_cpu_bus    = wishbone.Interface(data_width=32, address_width=17, addressing="word")
             self.bus.add_slave(name="wr_cpu_mem", slave=wr_cpu_bus, region=wr_cpu_region)
             self.wr_cpu_cache = FullMemoryWE()(wishbone.Cache(
                 cachesize = (8*KILOBYTE)//4,
                 master    = wr_cpu_bus,
-                slave     = wishbone.Interface(data_width=32, address_width=32, addressing="word"),
+                slave     = wishbone.Interface(data_width=32, address_width=17, addressing="word"),
             ))
+            self.cd_hyperram_input = ClockDomain("hyperram_input")
+            self.crg.pll.create_clkout(self.cd_hyperram_input, sys_clk_freq,
+                phase=180, margin=0, with_reset=False)
+            self.comb += self.cd_hyperram_input.rst.eq(ResetSignal("sys"))
             self.hyperram = HyperRAM(
                 pads         = platform.request("hyperram"),
                 latency      = 7,
@@ -219,6 +225,7 @@ class BaseSoC(LiteXWRNICSoC):
                 # system clock and avoids introducing a timing-critical 250 MHz
                 # FPGA domain on the Artix-7.
                 clk_ratio    = "4:1",
+                dq_i_cd      = "hyperram_input",
             )
             self.comb += self.wr_cpu_cache.slave.connect(self.hyperram.bus)
             self.add_config("WR_CPU_CACHE_SIZE", 8*KILOBYTE)
@@ -272,15 +279,16 @@ class BaseSoC(LiteXWRNICSoC):
             })
             self.comb += ClockSignal("refclk_pcie").eq(self.pcie_phy.pcie_refclk)
             self.pcie_phy.use_external_qpll(qpll_channel=self.qpll.get_channel("pcie"))
-            platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
+            # Keep sys derived from the free-running PLL. A primary clock on
+            # this net would hide its phase relationship to HyperRAM capture.
             platform.toolchain.pre_placement_commands.append("reset_property LOC [get_cells -hierarchical -filter {{NAME=~pcie_s7/*gtp_channel.gtpe2_channel_i}}]")
             platform.toolchain.pre_placement_commands.append("set_property LOC GTPE2_CHANNEL_X0Y0 [get_cells -hierarchical -filter {{NAME=~pcie_s7/*gtp_channel.gtpe2_channel_i}}]")
 
             # PCIe <-> Sys-Clk false paths.
             platform.toolchain.pre_placement_commands.append(
-                "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout*}}] -to [get_clocks -quiet sys_clk]")
+                "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout*}}] -to [get_clocks -of_objects [get_nets sys_clk]]")
             platform.toolchain.pre_placement_commands.append(
-                "set_false_path -quiet -from [get_clocks -quiet sys_clk] -to [get_clocks -quiet {{*s7pciephy_clkout*}}]")
+                "set_false_path -quiet -from [get_clocks -of_objects [get_nets sys_clk]] -to [get_clocks -quiet {{*s7pciephy_clkout*}}]")
             platform.toolchain.pre_placement_commands.append(
                 "set_false_path -quiet -from [get_clocks -quiet {{*s7pciephy_clkout0}}] -to [get_clocks -quiet {{*s7pciephy_clkout1}}]")
             platform.toolchain.pre_placement_commands.append(

--- a/test/test_wr_hyperram_cache.py
+++ b/test/test_wr_hyperram_cache.py
@@ -1,0 +1,57 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.fhdl.simplify import FullMemoryWE
+
+from litex.gen import LiteXModule
+from litex.soc.interconnect import wishbone
+
+
+def test_local_cache_addresses_preserve_region_data_across_eviction():
+    dut = LiteXModule()
+    host = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+    local = wishbone.Interface(data_width=32, address_width=17, addressing="word")
+    memory = wishbone.Interface(data_width=32, address_width=17, addressing="word")
+    dut.comb += host.connect(local)
+    dut.cache = FullMemoryWE()(wishbone.Cache(cachesize=32, master=local, slave=memory))
+    contents = {}
+    # Repeatedly collide cache lines, including the last word of the region.
+    offsets = [base + word*4 for base in (0, 0x2000, 0x10000, 0x1ff80) for word in range(32)]
+    expected = {offset: (offset * 977) ^ 0xa55a5aa5 for offset in offsets}
+
+    @passive
+    def ram():
+        while True:
+            if (yield memory.cyc) and (yield memory.stb):
+                address = yield memory.adr
+                assert 0 <= address < 128*1024//4
+                data = yield memory.dat_w
+                write = yield memory.we
+                for _ in range(3):
+                    yield
+                if write:
+                    assert (yield memory.sel) == 15
+                    contents[address] = data
+                yield memory.dat_r.eq(contents.get(address, 0))
+                yield memory.ack.eq(1)
+                yield
+                yield memory.ack.eq(0)
+                yield
+            else:
+                yield
+
+    def check():
+        for offset, value in expected.items():
+            yield from host.write((0x40000000 + offset)//4, value)
+        for offset, value in expected.items():
+            assert (yield from host.read((0x40000000 + offset)//4)) == value
+        # Partial writes retain the other byte lanes through an eviction.
+        yield from host.write(0x40000000//4, 0x00112200, sel=6)
+        yield from host.read((0x40000000 + 0x2000)//4)
+        value = yield from host.read(0x40000000//4)
+        assert value == (expected[0] & 0xff0000ff) | 0x00112200
+    run_simulation(dut, [check(), ram()])

--- a/test/test_wr_hyperram_cache.py
+++ b/test/test_wr_hyperram_cache.py
@@ -10,11 +10,12 @@ from migen.fhdl.simplify import FullMemoryWE
 from litex.gen import LiteXModule
 from litex.soc.interconnect import wishbone
 
+# HyperRAM Cache Tests -----------------------------------------------------------------------------
 
 def test_local_cache_addresses_preserve_region_data_across_eviction():
-    dut = LiteXModule()
-    host = wishbone.Interface(data_width=32, address_width=32, addressing="word")
-    local = wishbone.Interface(data_width=32, address_width=17, addressing="word")
+    dut    = LiteXModule()
+    host   = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+    local  = wishbone.Interface(data_width=32, address_width=17, addressing="word")
     memory = wishbone.Interface(data_width=32, address_width=17, addressing="word")
     dut.comb += host.connect(local)
     dut.cache = FullMemoryWE()(wishbone.Cache(cachesize=32, master=local, slave=memory))
@@ -29,7 +30,7 @@ def test_local_cache_addresses_preserve_region_data_across_eviction():
             if (yield memory.cyc) and (yield memory.stb):
                 address = yield memory.adr
                 assert 0 <= address < 128*1024//4
-                data = yield memory.dat_w
+                data  = yield memory.dat_w
                 write = yield memory.we
                 for _ in range(3):
                     yield
@@ -54,4 +55,5 @@ def test_local_cache_addresses_preserve_region_data_across_eviction():
         yield from host.read((0x40000000 + 0x2000)//4)
         value = yield from host.read(0x40000000//4)
         assert value == (expected[0] & 0xff0000ff) | 0x00112200
+
     run_simulation(dut, [check(), ram()])


### PR DESCRIPTION
Full host firmware readback exposed SPEC-A7 HyperRAM corruption after cache eviction, despite immediate cache readback succeeding. Sample DQ/RWDS using a 180-degree shifted system PLL output and limit the cache to local addresses within the decoded 128 KiB region. Preserve the PLL-derived system clock so timing analysis sees the real capture-clock phase relationship.

Depends on #78. Adds a cache regression covering conflicting addresses throughout the region, eviction, and partial writes. The boot-policy documentation explains why verification must go beyond cache hits.

Earlier hardware qualification (original bitstreams): the constrained implementation meets timing (WNS +0.018 ns, WHS +0.018 ns). It passed two SPEC-A7 reloads, each with a full typed 128 KiB VexRiscv firmware upload/readback (114.04 and 113.84 seconds), full WR console commands, increasing uptime, coherent time snapshots and restart. CPU memory-error counters stayed zero. The final default-uRV build also meets timing (+0.006/+0.053 ns). Initial failing readback/probe logs are retained as evidence of the reproduced issue.

Physical HyperRAM margins across voltage/temperature and WR servo/PPS/network behavior are outside these smoke checks; no WR reference peer is attached.

### Current validation

Rebased onto #77's hardware-qualified MMCM fix (`bac7b7a`). This PR's own patches are unchanged (`git range-diff`). The complete stack passes **110 tests with no skips**, including real MMCM/uRV XSim tests and two unbounded protocol proofs; **183 M2SDR tests** pass against the updated dependency.

Additional SPEC-A7 testing passed **84 physical MMCM measurements** across four input/output configurations, with **33,554,560 completed phase shifts**, zero monitor errors and output-frequency predictions accurate to within one counted edge. The temporary test image meets routed timing (+0.330 ns setup / +0.055 ns hold). The previously working uRV/private WR image was restored and its console and increasing uptime verified. Hardware/timing figures in this PR's earlier sections refer to their original recorded bitstreams.

SPEC-A7 effective x2 DAC gain, firmware PI coefficients and legacy PSGen behavior remain unchanged. WR servo lock, jitter and PPS accuracy against a WR reference peer remain outside these checks.
