### PR TITLE
tools: bound private uRV upload backlog and TCP latency

### DIFF
--- a/litex_wr_nic/wr.py
+++ b/litex_wr_nic/wr.py
@@ -10,6 +10,7 @@ import sys
 import json
 import time
 import select
+import socket
 import termios
 import argparse
 import contextlib
@@ -37,6 +38,10 @@ class WRClient:
         timeout=5.0):
         self.bus     = bus
         self.timeout = timeout
+        if isinstance(bus, RemoteClient) and hasattr(bus, "socket"):
+            # Register write/read pairs must not wait for TCP's small-packet
+            # coalescing timer (especially during private RAM verification).
+            bus.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self.region  = getattr(bus.mems, wr_region)
         self.memory  = getattr(bus.mems, memory_region, None)
         self.regs    = vars(bus.regs)
@@ -171,6 +176,10 @@ class WRClient:
         else:
             for index, word in enumerate(words):
                 self.write_word(4*index, word)
+                # Each private-RAM word uses two unacknowledged register
+                # writes. Bound the backlog here as on the SoC memory path.
+                if (index + 1) % 8 == 0:
+                    self.read_cpu(CPU_RESET)
             for index, word in enumerate(words):
                 if self.read_word(4*index) != word:
                     raise RuntimeError(

--- a/test/test_wr_management.py
+++ b/test/test_wr_management.py
@@ -330,3 +330,29 @@ def test_time_snapshot_command_and_stopped_clock_timeout():
     bus.regs.wr_time_done.value = 0
     with pytest.raises(TimeoutError, match="reference clock"):
         wr.read_time()
+
+
+def test_private_upload_bounds_transport_backlog():
+    class QueuedBus(Bus):
+        def __init__(self):
+            super().__init__(info=True)
+            self.queued = 0
+
+        def write(self, address, value):
+            if address - self.mems.wr_wb_slave.base - CPU_CSR in (4, 8):
+                self.queued += 1
+                assert self.queued <= 16, "Private RAM upload exceeded the transport backlog"
+            super().write(address, value)
+
+        def read(self, address, length=None):
+            self.queued = 0
+            return super().read(address, length)
+
+    bus = QueuedBus()
+    wr = WRClient(bus)
+    wr.size = 512
+    image = bytes(range(256))*2
+    wr.load_firmware(image, "urv")
+    assert wr.read_cpu(CPU_RESET) == 0
+    assert [bus.words[index] for index in range(128)] == [
+        int.from_bytes(image[offset:offset+4], "big") for offset in range(0, 512, 4)]


### PR DESCRIPTION
Private uRV RAM loading writes an address and data register for every firmware word. RemoteClient writes have no response, so a complete upload could accumulate a large backlog ahead of verification and exceed the read timeout on JTAGBone/UARTBone. Add a read barrier every eight words, matching the bounded backlog already used for SoC memory. Disable TCP small-packet coalescing on connected RemoteClient sockets so private verification write/read pairs do not incur a delayed-ACK wait for every word. Full readback still precedes CPU release.

Depends on #79. Management regressions cover bounded private-upload queues, byte-order verification and actual uRV execution in XSim.

On SPEC-A7, a full 128 KiB private-uRV upload/readback passed in 1584 seconds (26 minutes 24 seconds) over 5 MHz JTAGBone. Firmware then executed with full ver/help/time/uptime replies, increasing uptime, coherent time snapshots and successful halt-before-reset restart; fabric errors and overflow stayed zero. Private RAM uses individual address/data transactions, so this path remains much slower than burst access to SoC memory. The earlier TCP-coalescing run was stopped during verification and is retained as an aborted run, not a passing test. No gateware changes.

### Current validation

Rebased onto #77's hardware-qualified MMCM fix (`bac7b7a`). This PR's own patches are unchanged (`git range-diff`). The complete stack passes **110 tests with no skips**, including real MMCM/uRV XSim tests and two unbounded protocol proofs; **183 M2SDR tests** pass against the updated dependency.

Additional SPEC-A7 testing passed **84 physical MMCM measurements** across four input/output configurations, with **33,554,560 completed phase shifts**, zero monitor errors and output-frequency predictions accurate to within one counted edge. The temporary test image meets routed timing (+0.330 ns setup / +0.055 ns hold). The previously working uRV/private WR image was restored and its console and increasing uptime verified. Hardware/timing figures in this PR's earlier sections refer to their original recorded bitstreams.

SPEC-A7 effective x2 DAC gain, firmware PI coefficients and legacy PSGen behavior remain unchanged. WR servo lock, jitter and PPS accuracy against a WR reference peer remain outside these checks.
