### PR TITLE
ad5683r: synchronize host control and latch DAC readback

### DIFF
--- a/doc/wr_integration.md
+++ b/doc/wr_integration.md
@@ -141,3 +141,19 @@ External build integrations can pass `wr_cpu_type`, `wr_cpu_variant`, and
 contains the validated selection; the caller must pass that selection to its
 SoC constructor. Firmware lookup and rebuild select the corresponding CPU
 profile. Defaults remain uRV with private memory.
+
+## SPEC DAC control
+
+The AD5683R CSRs keep the `force`, `load`, `value`, `current` register order.
+`status` adds `ready` (bit 0), sticky `overflow` (bit 1), and applied `forced`
+(bit 2). Check `ready` before writing `force` or writing 1 to `load`.
+Set `force=1`, write `value`, then write `load=1` to submit one command.
+The value and mode travel together through the clock crossing; later value
+writes cannot change an already queued command. Writing `load=0` is optional
+and has no effect. Writing `force=0` returns control to WR in queue order.
+
+`current` holds the last code accepted by the serial DAC driver, including WR
+commands, with synchronization latency before host readback. It does not read
+the analog voltage or confirm SPI completion. The serial driver may coalesce
+updates that arrive while it is busy. A write when `ready=0` is discarded and
+sets `overflow`; reset clears the queue, applied host mode and overflow state.

--- a/litex_wr_nic/gateware/ad5683r/core.py
+++ b/litex_wr_nic/gateware/ad5683r/core.py
@@ -8,10 +8,13 @@
 import os
 
 from migen import *
+from migen.genlib.cdc import BusSynchronizer
 
 from litex.gen import *
 
 from litex.soc.interconnect.csr import *
+
+from litex_wr_nic.gateware.wr_cdc import WRClockCrossing
 
 # AD5683R DAC --------------------------------------------------------------------------------------
 
@@ -19,29 +22,67 @@ class AD5683RDAC(LiteXModule):
     def __init__(self, platform, pads, load, value, gain=2, clk_domain="wr"):
         # Preserve the old effective default; gain=1 explicitly selects the x1 range.
         assert gain in [1, 2]
-        self._force   = CSRStorage()
-        self._load    = CSRStorage(1)
-        self._value   = CSRStorage(16)
-        self._current = CSRStatus(16)
+        self._force   = CSRStorage(description="Select host control; takes effect in command order.")
+        self._load    = CSRStorage(1, description="Write 1 to queue one host load; writing 0 has no effect.")
+        self._value   = CSRStorage(16, description="Host code sampled when load is written.")
+        self._current = CSRStatus(16, description="Last command accepted by the DAC driver, synchronized to sys; not analog readback.")
+        self._status  = CSRStatus(fields=[
+            CSRField("ready", description="A force/load write can be queued."),
+            CSRField("overflow", description="A force/load write was dropped while not ready; cleared by reset."),
+            CSRField("forced", description="Host control has taken effect in the DAC clock domain."),
+        ])
 
         # # #
 
-        # Signals.
-        load_i  = Signal()
-        value_i = Signal(16)
-
-        # Force/Load.
-        sync = getattr(self.sync, clk_domain)
-        sync += [
-            If(self._force.storage,
-                load_i.eq(self._load.storage),
-                value_i.eq(self._value.storage),
-            ).Else(
-                load_i.eq(load),
-                value_i.eq(value),
-            )
+        # Transfer mode changes and load snapshots together. Synchronizing a
+        # pulse independently of the value would allow later writes to tear a
+        # command or change its ownership before it reaches the DAC.
+        self.commands = commands = WRClockCrossing(
+            [("force", 1), ("load", 1), ("value", 16)], "sys", clk_domain, depth=4)
+        host_load = self._load.re & self._load.storage
+        ready     = commands.sink.ready & ~ResetSignal(commands.input_cd)
+        overflow  = Signal()
+        self.comb += [
+            commands.sink.valid.eq(self._force.re | host_load),
+            commands.sink.force.eq(self._force.storage),
+            commands.sink.load.eq(host_load),
+            commands.sink.value.eq(self._value.storage),
+            self._status.fields.ready.eq(ready),
+            self._status.fields.overflow.eq(overflow),
         ]
-        self.comb += self._current.status.eq(value_i)
+        input_sync = getattr(self.sync, commands.input_cd)
+        input_sync += If(commands.sink.valid & ~ready, overflow.eq(1))
+
+        load_i    = Signal()
+        value_i   = Signal(16)
+        current   = Signal(16)
+        forced    = Signal()
+        accepted  = commands.source.valid & commands.source.ready
+        next_force = Mux(accepted, commands.source.force, forced)
+        # Leave a low cycle after a load before accepting another host command.
+        self.comb += commands.source.ready.eq(~load_i)
+        sync = getattr(self.sync, commands.output_cd)
+        sync += [
+            load_i.eq(0),
+            If(accepted, forced.eq(commands.source.force)),
+            If(accepted & commands.source.force & commands.source.load,
+                load_i.eq(1),
+                value_i.eq(commands.source.value),
+            ).Elif(~next_force & load,
+                load_i.eq(1),
+                value_i.eq(value),
+            ),
+            # The SPI arbiter samples these signals on the same edge. It can
+            # coalesce pending updates; current reports the accepted command,
+            # not completion of the serial transfer or the output voltage.
+            If(load_i, current.eq(value_i)),
+        ]
+        self.readback = BusSynchronizer(17, commands.output_cd, "sys")
+        self.comb += [
+            self.readback.i.eq(Cat(current, forced)),
+            self._current.status.eq(self.readback.o[:16]),
+            self._status.fields.forced.eq(self.readback.o[16]),
+        ]
 
         # DAC Driver Instance.
         self.specials += Instance("serial_dac_arb",
@@ -51,7 +92,7 @@ class AD5683RDAC(LiteXModule):
             p_g_enable_x2_gain = {1: 0, 2: 1}[gain],
 
             i_clk_i        = ClockSignal(clk_domain),
-            i_rst_n_i      = ~ResetSignal(clk_domain),
+            i_rst_n_i      = ~ResetSignal(commands.output_cd),
 
             i_val_i        = value_i,
             i_load_i       = load_i,

--- a/test/test_dac_control.py
+++ b/test/test_dac_control.py
@@ -1,0 +1,192 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from types import SimpleNamespace
+
+import pytest
+from migen import ClockDomain, ClockSignal, Instance, Record, Signal, run_simulation
+from migen.fhdl.structure import _Assign
+from migen.sim import passive
+
+from litex_wr_nic.gateware.ad5683r.core import AD5683RDAC
+
+
+def make_dut():
+    pads = Record([(name, 1) for name in ("ldac_n", "sync_n", "sclk", "sdi")])
+    load, value = Signal(), Signal(16)
+    dut = AD5683RDAC(SimpleNamespace(add_source=lambda path: None), pads, load, value, clk_domain="wr")
+    dut.cd_sys = ClockDomain("sys")
+    dut.cd_wr = ClockDomain("wr")
+    fragment = dut.get_fragment()
+    driver, = [s for s in fragment.specials if isinstance(s, Instance)]
+    ports = {item.name: item.expr for item in driver.items if isinstance(item, Instance.Input)}
+    # Observe the actual serial arbiter inputs; its physical SPI is tested in
+    # test_ad5683r.py. This simulation exercises the complete CSR/CDC wrapper.
+    fragment.specials.remove(driver)
+    return dut, fragment, load, value, ports
+
+
+def simulate(fragment, generators, clocks):
+    clocks = dict(clocks)
+    for statement in fragment.comb:
+        if isinstance(statement, _Assign) and isinstance(statement.r, ClockSignal):
+            if statement.r.cd in clocks:
+                for domain in fragment.clock_domains:
+                    if statement.l is domain.clk:
+                        clocks[domain.name] = clocks[statement.r.cd]
+    run_simulation(fragment, generators, clocks=clocks)
+
+
+def wait_ready(dut):
+    for _ in range(500):
+        if (yield dut._status.fields.ready):
+            return
+        yield
+    raise AssertionError("DAC command queue did not become ready")
+
+
+def test_current_latches_only_commands_delivered_to_driver():
+    dut, fragment, load, value, ports = make_dut()
+    delivered, observed = [], []
+
+    def wr():
+        for tick in range(250):
+            yield value.eq((tick * 997) & 0xffff)
+            yield load.eq(tick in (20, 70, 120))
+            yield
+
+    @passive
+    def driver():
+        while True:
+            if (yield ports["rst_n_i"]) and (yield ports["load_i"]):
+                delivered.append((yield ports["val_i"]))
+            yield
+
+    def host():
+        for _ in range(600):
+            observed.append((yield dut._current.status))
+            yield
+
+    simulate(fragment, {"sys": host(), "wr": [wr(), driver()]}, {"sys": 10, "wr": 17})
+    assert delivered == [20 * 997, (70 * 997) & 0xffff, (120 * 997) & 0xffff]
+    assert set(observed) == {0, *delivered}
+    assert observed[-1] == delivered[-1]
+
+
+@pytest.mark.parametrize("clocks", [{"sys": 10, "wr": 17}, {"sys": 19, "wr": 6}])
+def test_host_loads_are_ordered_pulses_with_atomic_values(clocks):
+    dut, fragment, load, value, ports = make_dut()
+    delivered = []
+
+    def host():
+        yield from wait_ready(dut)
+        yield from dut._force.write(1)
+        for code in (0x00ff, 0xff00, 0xa55a):
+            yield from dut._value.write(code)
+            yield from wait_ready(dut)
+            yield from dut._load.write(1)
+            # The old 1/0 write sequence remains accepted, without a second
+            # load; changing value afterward must not change the queued word.
+            yield from dut._load.write(0)
+            yield from dut._value.write(code ^ 0xffff)
+        for _ in range(400):
+            yield
+        assert (yield dut._status.fields.forced) == 1
+        assert (yield dut._status.fields.overflow) == 0
+        assert (yield dut._current.status) == 0xa55a
+
+    @passive
+    def driver():
+        previous = 0
+        while True:
+            yield value.eq(0x1234)
+            active = yield ports["load_i"]
+            assert not (previous and active), "Host loads must have a low cycle between pulses"
+            previous = active
+            if active:
+                delivered.append((yield ports["val_i"]))
+            yield
+
+    simulate(fragment, {"sys": host(), "wr": driver()}, clocks)
+    assert delivered == [0x00ff, 0xff00, 0xa55a]
+
+
+def test_mode_changes_do_not_load_and_release_restores_wr_commands():
+    dut, fragment, load, value, ports = make_dut()
+    delivered = []
+    resume = Signal()
+
+    def host():
+        yield from wait_ready(dut)
+        yield from dut._value.write(0xdead)
+        yield from dut._force.write(1)
+        for _ in range(100):
+            yield
+        assert (yield dut._current.status) == 0
+        yield from dut._value.write(0xabcd)
+        yield from dut._load.write(1)
+        yield from wait_ready(dut)
+        yield from dut._force.write(0)
+        for _ in range(150):
+            yield
+        assert (yield dut._status.fields.forced) == 0
+        assert (yield dut._current.status) == 0xabcd
+        yield resume.eq(1)
+        for _ in range(200):
+            yield
+        assert (yield dut._current.status) == 0x5678
+
+    @passive
+    def wr():
+        sent = False
+        while True:
+            yield load.eq(0)
+            yield value.eq(0x5678)
+            if (yield resume) and not sent:
+                yield load.eq(1)
+                sent = True
+            if (yield ports["load_i"]):
+                delivered.append((yield ports["val_i"]))
+            yield
+
+    simulate(fragment, {"sys": host(), "wr": wr()}, {"sys": 10, "wr": 17})
+    assert delivered == [0xabcd, 0x5678]
+
+
+def test_overflow_is_reported_and_wr_reset_clears_queued_commands():
+    dut, fragment, load, value, ports = make_dut()
+    delivered_after_reset = []
+    after_reset = Signal()
+
+    def host():
+        yield from wait_ready(dut)
+        yield from dut._force.write(1)
+        for code in range(20):
+            yield from dut._value.write(code)
+            yield from dut._load.write(1)
+        for _ in range(10):
+            yield
+        assert (yield dut._status.fields.overflow) == 1
+        yield dut.cd_wr.rst.eq(1)
+        for _ in range(120):
+            yield
+        yield dut.cd_wr.rst.eq(0)
+        yield after_reset.eq(1)
+        for _ in range(600):
+            yield
+        assert (yield dut._status.fields.overflow) == 0
+        assert (yield dut._status.fields.forced) == 0
+        assert (yield dut._current.status) == 0
+
+    @passive
+    def driver():
+        while True:
+            if (yield after_reset) and (yield ports["load_i"]):
+                delivered_after_reset.append((yield ports["val_i"]))
+            yield
+
+    simulate(fragment, {"sys": host(), "wr": driver()}, {"sys": 6, "wr": 50})
+    assert delivered_after_reset == []

--- a/test/test_dacs.py
+++ b/test/test_dacs.py
@@ -17,7 +17,6 @@ def set_dac(bus, dac_value, dac_load, value):
     """Sets a DAC value and loads it."""
     dac_value.write(value)
     dac_load.write(1)
-    dac_load.write(0)
 
 def ramp_dac(bus, dac_value, dac_load):
     """Continuously ramps DAC from 0 to 65535 in 1 second, updating every 10 ms, restarting at 0 when done."""


### PR DESCRIPTION
The DAC `current` CSR previously followed unrelated WR bus data, and host load/mode signals crossed directly into the WR clock domain. Latch the command when the SPI driver accepts it, synchronize readback, and queue atomic host mode/value/load requests across the clock boundary. Each load write produces one pulse. Append ready, overflow and applied-force status without moving the existing four registers.

Builds on merged #85 and targets main; this PR contains only the DAC implementation, focused tests and CSR documentation. #84 remains the historical qualification record.

Validation:
- 22 relevant DAC/WR simulations pass, including asynchronous clock ratios, force/release ordering, overflow and reset.
- Rebuilt and SRAM-loaded on SPEC-A7 with the qualified read-only firmware; timing passes (setup +0.068 ns, hold +0.056 ns).
- 17 hardware assertions pass for both DACs, including unrelated bus traffic, host loads and return to WR control.
- Acorn master / SPEC slave and the reverse direction each pass 120 seconds of uninterrupted WR tracking at measured per-board trims. No RX error increases. This is not an independent PPS accuracy measurement.

Readback is the last command accepted by the serial driver; it does not confirm analog voltage or SPI completion. Busy SPI updates may still coalesce as before. No capture files or build artifacts are committed.
