### PR TITLE
bench: reproduce USB WR builds and derive per-board master trims

### DIFF
--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -423,6 +423,11 @@ def main():
         help="LiteX WR CPU variant (VexRiscv defaults to lite).")
     parser.add_argument("--output-dir", default=None, help="Build directory.")
 
+    parser.add_argument("--skip-firmware-build", action="store_true",
+        help="Reuse firmware built separately (for example the read-only bench profile).")
+    parser.add_argument("--skip-software-headers", action="store_true",
+        help="Do not overwrite the checked-in PCIe software headers.")
+
     # Probes.
     # -------
     parser.add_argument("--with-wishbone-fabric-interface-probe", action="store_true")
@@ -434,7 +439,7 @@ def main():
 
     # Build Firmware.
     # ---------------
-    if args.build:
+    if args.build and not args.skip_firmware_build:
         print("Building firmware...")
         r = os.system("cd litex_wr_nic/firmware && ./build.py --target acorn --wr-cpu-type {}".format(
             args.wr_cpu_type))
@@ -462,7 +467,8 @@ def main():
 
     # Generate PCIe C Headers.
     # ------------------------
-    generate_litepcie_software_headers(soc, "litex_wr_nic/software/kernel")
+    if not args.skip_software_headers:
+        generate_litepcie_software_headers(soc, "litex_wr_nic/software/kernel")
 
     # Load FPGA.
     # ----------

--- a/doc/wr_bench.example.json
+++ b/doc/wr_bench.example.json
@@ -1,0 +1,25 @@
+{
+  "state_dir": "wr-jtag",
+  "boards": {
+    "acorn": {
+      "uart": "/dev/serial/by-path/REPLACE-ACORN-FT4232-INTERFACE-2",
+      "usb_location": "5-2",
+      "jtag_port": 1236,
+      "stream_port": 20002,
+      "csr": "bench-acorn/csr.csv",
+      "bitstream": "bench-acorn/gateware/sqrl_acorn.bit",
+      "identifier": "Acorn Baseboard Mini",
+      "master_trim": 36301
+    },
+    "spec": {
+      "uart": "/dev/serial/by-path/REPLACE-SPEC-FT4232-INTERFACE-2",
+      "usb_location": "1-3",
+      "jtag_port": 1235,
+      "stream_port": 20001,
+      "csr": "bench-spec/csr.csv",
+      "bitstream": "bench-spec/gateware/spec_a7_wr_nic.bin",
+      "identifier": "SPEC-A7",
+      "master_trim": 19677
+    }
+  }
+}

--- a/doc/wr_bench_sources.json
+++ b/doc/wr_bench_sources.json
@@ -1,0 +1,23 @@
+{
+  "python": {
+    "migen": {"url": "https://github.com/m-labs/migen.git", "revision": "4c2ae8dfeea37f235b52acb8166f12acaaae4f7c"},
+    "litex": {"url": "https://github.com/enjoy-digital/litex.git", "revision": "905384c2437b27fd35f50340dfdc23e2c0def5c1"},
+    "litepcie": {"url": "https://github.com/enjoy-digital/litepcie.git", "revision": "f9a2d43e4e9c29ae837641fb1c86cc0ffdec5da4"},
+    "liteeth": {"url": "https://github.com/enjoy-digital/liteeth.git", "revision": "8c9150ff121cb3148d8ea26ce3b1c5200479848d"},
+    "litescope": {"url": "https://github.com/enjoy-digital/litescope.git", "revision": "6bf3b92f261c50b8c7c74947f84e692ae846f512"},
+    "litex_boards": {"url": "https://github.com/litex-hub/litex-boards.git", "revision": "3e606b50b3f14e31d4bf565e5ba3cac3d21f841d"}
+  },
+  "wr_cores": {
+    "url": "https://gitlab.com/ohwr/project/wr-cores.git",
+    "revision": "8cc5e53275d229fbbf50b96a6ae4cb9c87626d53",
+    "general_cores": "d99c8460ae8b939ada406fe23198c41d236bf49b",
+    "urv": "de05caf973e17d1fa46f4fdb95762230bd1ab8c4"
+  },
+  "wrpc": {
+    "url": "https://gitlab.com/ohwr/project/wrpc-sw.git",
+    "revision": "13527cd68e1833214a89e4ee8c5b208188ff0e6a",
+    "ppsi": "33d8c46c8353be56d35dc57dd3492769e276c00f",
+    "ual": "57a9484c343cbda804ceaa39e6025ba425c9a252"
+  },
+  "tools": {"vivado": "2024.1", "riscv32-elf-gcc": "11.2.0 (riscv-11.2-small)"}
+}

--- a/doc/wr_usb_bench.md
+++ b/doc/wr_usb_bench.md
@@ -1,0 +1,202 @@
+# Acorn / SPEC-A7 USB bench
+
+This profile uses Acorn CLE215+ on the Acorn Baseboard Mini, SPEC-A7 with
+the physical XC7A35T, Acorn SFP0 connected to **SPEC J12 / SFP0**, and each
+board's FT4232H UART and JTAG interfaces. PCIe and host Ethernet are not needed.
+The WR CPU is uRV with private 128 KiB RAM. SPEC uses RefClk DAC ×2 and DMTD
+DAC ×1; Acorn uses the qualified MMCM implementation.
+The measurements below describe the connected pair on 2026-09-11.
+
+## Build from pinned sources
+
+Use a separate checkout of this branch. The build helper verifies the clean
+Python dependency revisions in [wr_bench_sources.json](wr_bench_sources.json).
+Install those checkouts in a virtual environment, for example:
+
+```python
+import json, pathlib, subprocess, sys
+pins = json.loads(pathlib.Path("doc/wr_bench_sources.json").read_text())
+root = pathlib.Path("build/deps")
+root.mkdir(parents=True, exist_ok=True)
+for name, pin in pins["python"].items():
+    path = root / name
+    subprocess.run(["git", "clone", pin["url"], str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "checkout", "--detach", pin["revision"]], check=True)
+    subprocess.run([sys.executable, "-m", "pip", "install", "-e", str(path)], check=True)
+```
+
+Use Vivado 2024.1 and GHDL (the bench uses 4.0.0-dev, gbd6c861b1), with
+`pyserial` for the UART tools and OpenOCD/openFPGALoader for JTAG access.
+The firmware helper obtains the pinned `riscv-11.2-small` GCC 11.2 toolchain.
+Official WR sources now live under `https://gitlab.com/ohwr/project/`.
+The build initializes and checks recursive submodules; WRPC is built separately
+from the older WRPC submodule carried inside wr-cores.
+
+Run the builds sequentially because the target-specific firmware filename is
+shared. Each output preserves its firmware, CSR map, source revision, hashes
+and timing report. Build outputs are not intended for version control.
+
+```sh
+python3 tools/build_wr_bench.py --board acorn --output build/bench-acorn
+python3 tools/build_wr_bench.py --board spec --output build/bench-spec
+```
+
+Firmware SPI writes/erases return read-only errors; automatic calibration
+updates remain in RAM. Existing flash configuration can still be read.
+The ordinary firmware build remains writable unless `--read-only-storage`
+is selected. Reusing a firmware checkout restores the owned source overlays
+before applying the selected profile.
+
+The relevant earlier clock work from #77 is included through the clean
+integration #85, followed by DAC control #86. #77 merged into
+`wr-fabric-flow-control`, not main. This profile does not require merging that
+whole branch or the experimental PICXO alternative. LitePCIe #186 and LiteX
+#2590 are merged; the dependency pin also includes LiteX cleanup #2591.
+CPU diagnostic-map and SFP-storage fixes remain explicit overlays on the
+official WR sources, so an unmerged contribution mirror is not a build input.
+#84 retains the historical qualification material.
+
+## Connect, load and observe
+
+Copy `doc/wr_bench.example.json` to `build/wr-bench.json` and edit it.
+**All relative paths are relative to the configuration file.** Replace the
+UART paths and USB locations with the actual connections. Select the FT4232H
+UART interface 2; JTAG uses channel 0. The example master trims identify this
+measured pair, not every board of
+these models. Preserve module serials and temperature/reference details in
+your local measurement record.
+
+Stop managed servers before programming:
+
+```sh
+python3 tools/wr_jtag.py --config build/wr-bench.json stop
+```
+
+Resolve each configured USB location under `/sys/bus/usb/devices/` to its
+`busnum` and `devnum`, and verify VID/PID `0403:6011`. Load one selected board
+at a time with openFPGALoader, using those numbers as `BUS:DEVICE`:
+
+```sh
+openFPGALoader --cable ft4232 --busdev-num BUS:DEVICE --freq 5000000 --bitstream build/bench-acorn/gateware/sqrl_acorn.bit
+openFPGALoader --cable ft4232 --busdev-num BUS:DEVICE --freq 5000000 --bitstream build/bench-spec/gateware/spec_a7_wr_nic.bin
+```
+
+These commands program SRAM. SPEC's target builds for XC7A50T and converts
+the image for the physical XC7A35T; use the resulting **`.bin`**, not the raw
+50T `.bit`. Retain the matching `csr.csv` from each build.
+
+```sh
+python3 tools/wr_jtag.py --config build/wr-bench.json start
+python3 tools/wr_qualify.py --config build/wr-bench.json --master-board acorn --configure --duration 120 --output build/check-acorn-master
+python3 tools/wr_qualify.py --config build/wr-bench.json --master-board spec --configure --duration 120 --output build/check-spec-master
+python3 tools/wr_jtag.py --config build/wr-bench.json stop
+```
+
+The manager binds separate local server/stream ports, verifies FPGA identity
+and the WR host signature, and limits startup to three attempts. Ownership
+records include Linux boot ID, process group and PID start times. Cleanup can
+recover a recorded OpenOCD child after its server was killed; it refuses to
+signal an unverified/reused process group. Preserve the state directory across
+interruptions. LiteX #2591 handles normal SIGTERM cleanup; a later manager
+invocation handles recorded SIGKILL orphans. The shared bench lock prevents
+managed reconnects during qualification; physical UART opens are exclusive.
+
+The checker requires complete UART GUI frames and coherent JTAG diagnostics,
+WR extension, correct roles, PLL locks, phase tracking, advancing time and
+servo updates, and unchanged RX error counts. Acquisition has a separate
+timeout; the requested duration starts only after every check passes.
+An unnormalized PPS-counter snapshot can occur during initial clock
+adjustment. It is retained as invalid acquisition data and cannot qualify
+tracking. Invalid timestamps during the tracking interval still fail the run.
+
+## Measure and set the master trim
+
+At Acorn code 32768, SPEC's main oscillator is about 26 ppm faster. Even SPEC
+code 0 remains about **1.4 ppm faster**: the slave reaches its low rail before
+matching Acorn. SPEC's main frequency also plateaus above roughly code 40000.
+Consequently digital midscale is not the center of its usable frequency range.
+
+The measured pair gave the following approximate ranges and sensitivities:
+
+| Actuator | Measured full span | Linear sensitivity |
+| --- | ---: | ---: |
+| Acorn main MMCM | 298 ppm | 0.00454 ppm/code |
+| Acorn helper MMCM | 297 ppm | 0.00454 ppm/code |
+| SPEC main, DAC ×2 | 29.6 ppm | 0.000754 ppm/code, before plateau |
+| SPEC helper, DAC ×1 | 176 ppm | 0.00268 ppm/code |
+
+These are reciprocal frequency measurements using each peer's recovered RX
+clock, not an independent absolute reference. Counter resolution is about
+0.2 ppm; sequential sweeps can also include oscillator drift. The plateau is
+consistent with DAC output headroom, but its voltage cause is not measured.
+
+To reproduce the main-clock calibration, keep both CPUs running, stop PTP and
+the PLL loops on both boards, and hold both main/helper commands at 32768:
+
+```text
+ptp stop
+pll init 0 0 0
+pll sdac 0 32768
+pll sdac -1 32768
+freqmon rx
+freqmon
+```
+
+The first `freqmon` read primes the firmware's cached monitor configuration.
+For each board in turn, leave the peer at 32768 and sweep main channel 0 over
+`0, 4096, 8192, 16384, 24576, 32768, 35000, 38500, 40960, 49152, 57344, 65535`.
+At each point issue `pll sdac 0 CODE`, then `freqmon rx`, wait at least three
+seconds, and read `freqmon`. Record CSV columns `board,code,ref_hz,rx_hz`, using
+board names `acorn` and `spec`. Restore the swept main to 32768 before changing
+boards. Channel -1 and the DMTD readout can separately characterize the helper.
+
+```sh
+python3 tools/wr_trim.py build/main-sweep.csv > build/trim-fit.json
+```
+
+The fit normalizes REF by RX, anchors Acorn's sweep to its measured 32768
+point, and chooses the midpoint between SPEC's low endpoint and averaged upper
+plateau. It fits SPEC only through code 38500. Inspect the measured curve and
+adjust the linear/plateau thresholds for other hardware. The fitted target is
+about +16.16 ppm relative to this Acorn at 32768, giving **Acorn 36301 / SPEC
+19677**. Put the resulting codes in the corresponding local `master_trim`
+fields. `wr_qualify --configure` applies the selected master's value with
+`pll sdac 0 CODE`; the slave keeps automatic control. Reapply after reset.
+
+Both master directions passed 120 seconds of uninterrupted tracking at these
+settings. With Acorn master, SPEC main/helper settled near 19500. The helper
+at ×1 then has roughly 52 ppm to its measured low endpoint and 123 ppm to its
+high endpoint. This supports static actuator headroom at the measured condition;
+it does not establish phase margin or temperature coverage. Do not change PI
+coefficients solely from these static slopes. Temperature characterization
+requires recorded board temperatures, repeated sweeps/operating points and
+settling measurements across the intended range.
+
+## Physical work still required
+
+Acorn's FPGA SCL/SDA pad readbacks followed driven high/low combinations, but
+the module NACKed address 0x50. SPEC ACKed and identified Tyco Electronics
+2127931-2, serial 11274837; its calibration database was empty. Acorn's all-FF
+EEPROM read is invalid, despite its optical data link working.
+
+The [baseboard schematic](https://github.com/enjoy-digital/litex-acorn-baseboard/blob/master/hardware/acorn-baseboard-mini-2022-06-06.pdf)
+routes SFP0 SCL through **JP1** and SDA through **JP4**, via the PCA9306 level
+shifter (FPGA side 1.8 V, SFP side 3.3 V). JP5/JP6 serve SFP1. Confirm the
+actual board revision and jumper continuity, then observe SCL/SDA on both
+sides during address 0x50. Pad readback alone does not prove module-side
+continuity. After correcting the path, verify address ACK, EEPROM checksums,
+vendor/part/serial with `sfp info`, and calibration lookup with `sfp match`.
+The same routing requirement is recorded in [bring-up issue #2](https://github.com/enjoy-digital/litex_wr_nic/issues/2).
+
+Independent PPS alignment and jitter remain unmeasured. Compare the actual
+PPS outputs on two channels of a scope/time-interval instrument; characterize
+channel and cable skew by applying one source to both and swapping channels.
+Use compatible input levels/termination, retain edge timestamps, and report
+mean delay, standard deviation, peak-to-peak spread, sample count and reference
+uncertainty for both role directions. Account for the physical output paths:
+Acorn drives 3.3 V GPIO H5 (`debug[0]`), requiring a high-impedance probe or
+appropriate buffer; SPEC's default bypasses macro/coarse delay but still has its
+external fine-delay/output path. A repeatable cable/channel correction must
+precede board delay calibration. SFP TX/RX fixed delays and fiber asymmetry
+need measured calibration; one PPS comparison cannot uniquely determine all
+of them. Internal WR servo offsets are not absolute PPS accuracy measurements.

--- a/litex_wr_nic/firmware/build.py
+++ b/litex_wr_nic/firmware/build.py
@@ -87,7 +87,7 @@ def checkout_commit(target="spec_a7"):
     # only those owned files so repeated uRV/VexRiscv builds cannot leak flags.
     run_command(
         f"git checkout {COMMIT_HASH} -- Makefile arch/risc-v/crt0.S arch/risc-v/irq_helper.c "
-        "include/board.h dev/sfp.c",
+        "include/board.h dev/sfp.c dev/spi_flash.c dev/storage-cal.c",
         cwd=CLONE_DIR)
 
     # Acorn's MMCM actuator needs more tracking bandwidth than the old
@@ -145,7 +145,7 @@ def configure_cpu_profile(cpu_type):
         "#endif\n\n",
     )
 
-def configure_source_fixes():
+def configure_source_fixes(read_only_storage=False):
     """Apply compatibility fixes to the pinned WRPC sources."""
     from litex_wr_nic.gateware.wr_common import _replace_once
     def patch(name, before, after):
@@ -164,11 +164,28 @@ def configure_source_fixes():
         "\tif (match <= 0) {\n\t\tsfp_info.sfp_in_db = SFP_NOT_MATCHED;\n"
         "\t\treturn match < 0 ? match : -ENXIO;")
 
+    if read_only_storage:
+        # SRAM qualification must not silently save automatic PHY/RX calibration.
+        # Keep new calibration in RAM, and reject all SPI flash writes/erases,
+        # including commands from an existing startup script.
+        patch("dev/storage-cal.c", "return storage_save_calibration();",
+            "/* SRAM qualification: the updated calibration remains in RAM. */\n\treturn 0;")
+        patch("dev/spi_flash.c", '#include "wrc-debug.h"',
+            '#include <errno.h>\n#include "wrc-debug.h"')
+        for signature, result in (
+            ("int spi_flash_write(struct spi_flash_device *dev, uint32_t addr, uint8_t *buf, int count)", "-EROFS"),
+            ("int spi_flash_erase(struct spi_flash_device *dev, uint32_t addr, int count)", "-EROFS"),
+            ("void spi_flash_erase_sector(struct spi_flash_device *dev, uint32_t addr)", ""),
+        ):
+            patch("dev/spi_flash.c", signature + "\n{",
+                signature + "\n{\n\t/* SRAM qualification: persistent flash is read-only. */\n"
+                + (f"\treturn {result};\n" if result else "\treturn;\n"))
 
-def build_firmware(cpu_type):
+
+def build_firmware(cpu_type, read_only_storage=False):
     """Build the firmware."""
     configure_cpu_profile(cpu_type)
-    configure_source_fixes()
+    configure_source_fixes(read_only_storage)
     run_command("make clean", cwd=CLONE_DIR)
     run_command("make spec_a7_defconfig", cwd=CLONE_DIR)
     cpu_flags = "-DWR_CPU_VEXRISCV" if cpu_type == "vexriscv" else ""
@@ -218,6 +235,8 @@ def main():
     parser.add_argument("--target", default="spec_a7", help="Target Board.", choices=["spec_a7", "acorn"])
     parser.add_argument("--wr-cpu-type", default="urv", choices=WR_CPU_TYPES,
         help="WR CPU firmware profile (default: urv).")
+    parser.add_argument("--read-only-storage", action="store_true",
+        help="Retain calibration in RAM and disable firmware SPI flash writes/erases.")
     args = parser.parse_args()
 
     init_riscv_toolchain()
@@ -225,7 +244,7 @@ def main():
     clone_repository()
     checkout_commit(args.target)
     copy_config_file()
-    build_firmware(args.wr_cpu_type)
+    build_firmware(args.wr_cpu_type, args.read_only_storage)
     copy_firmware(args.wr_cpu_type)
     build_sdbfs()
     print("Build process completed successfully.")

--- a/test/test_firmware_fixes.py
+++ b/test/test_firmware_fixes.py
@@ -141,4 +141,3 @@ int main(void) {
 '''
     result = run_c(path, prefix + code + checks)
     assert result.returncode == 0, result.stderr
-

--- a/test/test_firmware_fixes.py
+++ b/test/test_firmware_fixes.py
@@ -29,7 +29,7 @@ def firmware(tmp_path, monkeypatch):
     spec = importlib.util.spec_from_file_location('wr_build', ROOT / 'litex_wr_nic/firmware/build.py')
     build = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(build)
-    for name in ('include/board.h', 'dev/sfp.c'):
+    for name in ('include/board.h', 'dev/sfp.c', 'dev/spi_flash.c', 'dev/storage-cal.c'):
         path = tmp_path / name
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(subprocess.check_output(['git', '-C', str(SOURCE), 'show', build.COMMIT_HASH + ':' + name]))
@@ -97,3 +97,48 @@ def test_diagnostics_use_cpu_map_not_host_map(firmware):
     expected = int(re.search(r'#define WRC_DEVICES_MAP_WDIAG (0x[0-9a-f]+)', cpu_map).group(1), 16)
     actual = int(re.search(r'#define BASE_WDIAGS_PRIV\s+\(DEV_BASE \+ (0x[0-9a-f]+)\)', board).group(1), 16)
     assert actual == expected == 0x800
+
+
+def test_read_only_firmware_retains_calibration_without_writes(firmware):
+    build, path = firmware
+    build.configure_source_fixes(read_only_storage=True)
+    contents = {p: p.read_text() for p in path.rglob('*.c')}
+    build.configure_source_fixes(read_only_storage=True)
+    assert all(p.read_text() == text for p, text in contents.items())
+    flash = (path / 'dev/spi_flash.c').read_text()
+    cal = (path / 'dev/storage-cal.c').read_text()
+    prefix = r'''
+#include <stdint.h>
+#include <errno.h>
+#include <assert.h>
+struct spi_flash_device { void *bus; int use_4byte_addr; int sector_size; };
+static int spi_accesses, saved, set_result;
+static uint32_t parameter, value;
+void bb_spi_cs(void *bus, int level) { spi_accesses++; }
+void bb_spi_write(void *bus, int val, int count) { spi_accesses++; }
+void bb_spi_delay(void *bus) { spi_accesses++; }
+void spi_flash_write_addr(struct spi_flash_device *dev, uint32_t addr) { spi_accesses++; }
+int spi_flash_rsr(struct spi_flash_device *dev) { spi_accesses++; return 0; }
+int storage_set_calibration_parameter(uint32_t id, uint32_t val) { parameter=id; value=val; return set_result; }
+int storage_save_calibration(void) { saved++; return 0; }
+'''
+    code = '\n'.join(function(flash, name) for name in ('spi_flash_write', 'spi_flash_erase_sector', 'spi_flash_erase'))
+    code += function(cal, 'storage_set_calibration_parameter_and_save')
+    checks = r'''
+int main(void) {
+    struct spi_flash_device dev = {.sector_size = 65536}; uint8_t byte = 0;
+    assert(spi_flash_write(&dev, 0, &byte, 1) == -EROFS);
+    assert(spi_flash_erase(&dev, 0, 65536) == -EROFS);
+    spi_flash_erase_sector(&dev, 0);
+    assert(spi_accesses == 0);
+    assert(storage_set_calibration_parameter_and_save(7, 1234) == 0);
+    assert(parameter == 7 && value == 1234 && saved == 0);
+    set_result = -1;
+    assert(storage_set_calibration_parameter_and_save(7, 5678) == -1);
+    assert(saved == 0);
+    return 0;
+}
+'''
+    result = run_c(path, prefix + code + checks)
+    assert result.returncode == 0, result.stderr
+

--- a/test/test_wr_bench_build.py
+++ b/test/test_wr_bench_build.py
@@ -1,0 +1,53 @@
+"""A successful Vivado build must still produce a usable board image and map."""
+import hashlib
+import importlib.util
+from pathlib import Path
+import subprocess
+
+import pytest
+
+spec = importlib.util.spec_from_file_location('wr_bench_build', Path(__file__).resolve().parents[1] / 'tools/build_wr_bench.py')
+build = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build)
+
+
+@pytest.fixture
+def generated(tmp_path, monkeypatch):
+    monkeypatch.setattr(build, 'ROOT', tmp_path)
+    (tmp_path / 'test').mkdir()
+    (tmp_path / 'test/csr.csv').write_text('csr_register,refclk_dac_current,0xf000a80c,1,ro\n')
+    output = tmp_path / 'output'
+    (output / 'gateware').mkdir(parents=True)
+    (output / 'gateware/board_timing.rpt').write_text('All user specified timing constraints are met.')
+    return output
+
+
+@pytest.mark.parametrize('board', ['acorn', 'spec'])
+def test_build_only_outputs_become_programmable(board, generated, monkeypatch):
+    image = generated / 'gateware' / ('sqrl_acorn.bit' if board == 'acorn' else 'spec_a7_wr_nic.bit')
+    image.write_bytes(b'Vivado output')
+    def convert(command, **kwargs):
+        assert board == 'spec'
+        assert Path(command[-2]) == image
+        assert Path(command[-1]) == image.with_suffix('.bin')
+        assert kwargs['check'] is True
+        Path(command[-1]).write_bytes(b'Converted 35T image')
+    monkeypatch.setattr(build.subprocess, 'run', convert)
+    hashes = build.finish_build(board, generated)
+    expected_image = image if board == 'acorn' else image.with_suffix('.bin')
+    assert str(expected_image.relative_to(generated)) in hashes
+    assert (generated / 'csr.csv').read_bytes() == (build.ROOT / 'test/csr.csv').read_bytes()
+    assert hashes['csr.csv'] == hashlib.sha256((generated / 'csr.csv').read_bytes()).hexdigest()
+
+
+def test_converter_failure_is_not_a_successful_build(generated, monkeypatch):
+    def fail(command, **kwargs):
+        raise subprocess.CalledProcessError(1, command)
+    monkeypatch.setattr(build.subprocess, 'run', fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        build.finish_build('spec', generated)
+
+
+def test_missing_programming_image_is_rejected(generated):
+    with pytest.raises(RuntimeError, match='programming image'):
+        build.finish_build('acorn', generated)

--- a/test/test_wr_console.py
+++ b/test/test_wr_console.py
@@ -1,0 +1,41 @@
+"""An asynchronous prompt redraw must not acknowledge a command prematurely."""
+
+import importlib.util
+from pathlib import Path
+
+
+def test_command_waits_for_its_echo_and_completion_prompt(monkeypatch):
+    path = Path(__file__).resolve().parents[1] / "tools/wr_console.py"
+    spec = importlib.util.spec_from_file_location("wr_console_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    console = module.Console.__new__(module.Console)
+    responses = iter(
+        ["asynchronous log\nwrc# ", "asynchronous log\nwrc# ptp\nrunning; e2e master\nwrc# "]
+    )
+    monkeypatch.setattr(console, "text", lambda start: next(responses))
+    monkeypatch.setattr(console, "record", lambda *args: None)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    response = console.prompt(0, command="ptp")
+    assert "running; e2e master" in response
+
+
+def test_diagnostic_between_echo_characters_does_not_hide_completion(monkeypatch):
+    path = Path(__file__).resolve().parents[1] / "tools/wr_console.py"
+    spec = importlib.util.spec_from_file_location("wr_console_interleaving_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    console = module.Console.__new__(module.Console)
+    # Captured during a real Acorn PCS interruption. An old prompt still
+    # cannot acknowledge the command before the remaining echo arrives.
+    responses = iter([
+        "vdiag-fsm-1-wr0: 000000127.819: LEAVE slave (next:   3)\n\nwrc# ",
+        "vdiag-fsm-1-wr0: 000000127.819: LEAVE slave (next:   3)\n\n"
+        "er\nWR Core build: v8.0-126-gbaf77496-dirty\nwrc# ",
+    ])
+    monkeypatch.setattr(console, "text", lambda start: next(responses))
+    monkeypatch.setattr(console, "record", lambda *args: None)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    response = console.prompt(0, command="ver")
+    assert "WR Core build:" in response
+    assert "diag-fsm-1-wr0:" in response

--- a/test/test_wr_jtag.py
+++ b/test/test_wr_jtag.py
@@ -1,0 +1,67 @@
+"""Persistent ownership must survive an orphan without signaling reused PIDs."""
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+spec = importlib.util.spec_from_file_location('wr_jtag', Path(__file__).resolve().parents[1] / 'tools/wr_jtag.py')
+jtag = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(jtag)
+
+
+def record(tmp_path, boot=None):
+    path = tmp_path / 'owner.json'
+    jtag.write_record(path, dict(
+        boot_id=boot or Path('/proc/sys/kernel/random/boot_id').read_text().strip(),
+        group=9001, members=[dict(pid=9001, started='100'), dict(pid=9002, started='101')]))
+    return path
+
+
+def test_old_boot_does_not_signal_processes(tmp_path, monkeypatch):
+    kill = Mock()
+    monkeypatch.setattr(jtag.os, 'killpg', kill)
+    path = record(tmp_path, 'old-boot')
+    jtag.stop(path)
+    kill.assert_not_called()
+    assert not path.exists()
+
+
+def test_pid_reuse_refuses_cleanup(tmp_path, monkeypatch):
+    kill = Mock()
+    monkeypatch.setattr(jtag.os, 'killpg', kill)
+    monkeypatch.setattr(jtag, 'members', lambda group: [dict(pid=9001, started='200')])
+    path = record(tmp_path)
+    with pytest.raises(RuntimeError, match='unverified'):
+        jtag.stop(path)
+    kill.assert_not_called()
+    assert path.exists()
+
+
+def test_persisted_child_allows_cleanup_after_leader_dies(tmp_path, monkeypatch):
+    live = [dict(pid=9002, started='101')]
+    signals = []
+    def kill(group, signal):
+        signals.append((group, signal))
+        live.clear()
+    monkeypatch.setattr(jtag.os, 'killpg', kill)
+    monkeypatch.setattr(jtag, 'members', lambda group: live[:])
+    path = record(tmp_path)
+    jtag.stop(path)
+    assert signals == [(9001, jtag.signal.SIGTERM)]
+    assert not path.exists()
+
+
+def test_config_paths_and_unique_ports(tmp_path):
+    config = dict(state_dir='state', boards=dict(acorn=dict(csr='csr.csv',
+        uart='/dev/serial/by-path/board', jtag_config='jtag.cfg', jtag_port=1235, stream_port=20001)))
+    path = tmp_path / 'bench.json'
+    path.write_text(json.dumps(config))
+    loaded = jtag.load_config(path)
+    assert loaded['boards']['acorn']['csr'] == str(tmp_path / 'csr.csv')
+    assert loaded['boards']['acorn']['uart'] == '/dev/serial/by-path/board'
+    config['boards']['acorn']['stream_port'] = 1235
+    path.write_text(json.dumps(config))
+    with pytest.raises(ValueError, match='distinct'):
+        jtag.load_config(path)

--- a/test/test_wr_snapshot.py
+++ b/test/test_wr_snapshot.py
@@ -1,0 +1,51 @@
+"""Acquisition snapshots must be retained without qualifying invalid time."""
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+path = Path(__file__).resolve().parents[1] / 'tools/wr_status.py'
+spec = importlib.util.spec_from_file_location('wr_status_test', path)
+status = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(status)
+
+
+class SnapshotBus:
+    mems = SimpleNamespace(wr_wb_slave=SimpleNamespace(base=0))
+
+    def __init__(self, nanoseconds):
+        self.words = [0] * 25
+        self.words[0:5] = [2, 0x101, 0x401, 3, 9]
+        self.words[9:11] = [123, nanoseconds]
+        self.writes = []
+
+    def read(self, address, length=None):
+        if length:
+            return list(self.words[:length])
+        return self.words[(address - 0x900) // 4]
+
+    def write(self, address, value):
+        self.writes.append((address, value))
+
+
+@pytest.mark.parametrize('nanoseconds', [999999999, 1000000000, ((1 << 28) - 100) * 16])
+def test_snapshot_marks_wrapped_counter_time_invalid(nanoseconds):
+    bus = SnapshotBus(nanoseconds)
+    result = status.diagnostic_snapshot(bus)
+    assert result['raw'][10] == nanoseconds
+    assert result['time_valid'] == (nanoseconds < 1000000000)
+    assert result['tai_ns'] == (123000000000 + nanoseconds if nanoseconds < 1000000000 else None)
+    assert bus.writes[-1] == (0x904, 0)
+
+
+def test_invalid_time_cannot_start_or_pass_a_tracking_check():
+    common = dict(received=100, extension='IDLE', detection='EXT_ON', pll_locked=True,
+                  frequency_locked=True, servo='TRACK_PHASE')
+    master = dict(common, role='MASTER', mac='a', peer='b')
+    slave = dict(common, role='SLAVE', mac='b', peer='a')
+    md = dict(ptp_state=6, link=True, locked=True, tai_ns=123000000000)
+    sd = dict(md, ptp_state=9, servo_valid=True, servo_state=4, tai_ns=None)
+    assert 'slave: timestamp is not normalized' in status.qualification_errors(master, slave, md, sd, 101)
+    sd['tai_ns'] = 123500000000
+    assert status.qualification_errors(master, slave, md, sd, 101) == []

--- a/test/test_wr_trim.py
+++ b/test/test_wr_trim.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location('wr_trim', Path(__file__).resolve().parents[1] / 'tools/wr_trim.py')
+trim = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(trim)
+
+
+def sweep():
+    # Synthetic oscillators: Acorn midpoint is 26 ppm low; SPEC clips at
+    # code 40000. Each row's RX count includes a deliberate gate-scale error.
+    rows = []
+    for board in ('acorn', 'spec'):
+        for code in (0, 8192, 16384, 32768, 38500, 40960, 65535):
+            ratio = ((1 + (code - 32768) * 0.0045e-6) / (1 + 26e-6)
+                if board == 'acorn' else 1 + (2 + min(code, 40000) * 0.00075) * 1e-6)
+            rx = 62500000 * 1.00003
+            rows.append(dict(board=board, code=code, ref_hz=rx * ratio, rx_hz=rx))
+    return rows
+
+
+def test_centers_usable_range_and_cancels_gate_scale():
+    result = trim.fit_trims(sweep())
+    assert result['target_ppm'] == pytest.approx(17)
+    assert result['boards']['spec']['master_trim'] == 20000
+    assert result['boards']['acorn']['master_trim'] == 36546
+    assert result['boards']['acorn']['ppm_per_code'] == pytest.approx(0.0045)
+
+
+def test_rejects_missing_anchor():
+    with pytest.raises(ValueError, match='32768'):
+        trim.fit_trims([r for r in sweep() if r['code'] != 32768])
+
+
+def test_rejects_reversed_control():
+    rows = sweep()
+    for row in rows:
+        if row['board'] == 'spec':
+            row['ref_hz'] = 2 * row['rx_hz'] - row['ref_hz']
+    with pytest.raises(ValueError, match='positive'):
+        trim.fit_trims(rows)

--- a/tools/build_wr_bench.py
+++ b/tools/build_wr_bench.py
@@ -17,6 +17,23 @@ def git(path, *args):
     return subprocess.check_output(['git', '-C', str(path), *args], text=True).strip()
 
 
+def finish_build(board, output):
+    # Both targets generate the map in test/, including when --output-dir is
+    # supplied. SPEC's target converts the image only for --load/--flash.
+    shutil.copy2(ROOT / 'test/csr.csv', output / 'csr.csv')
+    image = output / 'gateware' / ('sqrl_acorn.bit' if board == 'acorn' else 'spec_a7_wr_nic.bin')
+    if board == 'spec':
+        subprocess.run([sys.executable, str(ROOT / 'litex_wr_nic/gateware/xilinx-bitstream.py'),
+            str(image.with_suffix('.bit')), str(image)], cwd=ROOT, check=True)
+    if not image.is_file() or not image.stat().st_size:
+        raise RuntimeError('Missing or empty programming image: ' + str(image))
+    timing = next((output / 'gateware').glob('*_timing.rpt')).read_text()
+    if 'All user specified timing constraints are met.' not in timing:
+        raise RuntimeError('Vivado timing failed; inspect the report before loading')
+    return {str(p.relative_to(output)): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in output.rglob('*') if p.is_file() and p.suffix in ('.bit', '.bin', '.bram', '.boot', '.csv')}
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--board', required=True, choices=['acorn', 'spec'])
@@ -45,13 +62,7 @@ def main():
             '--build', '--skip-firmware-build', '--skip-software-headers', '--wr-cpu-type', 'urv',
             '--wr-cpu-memory', 'private', '--output-dir', str(output)]
         run(command)
-        if args.board == 'acorn':
-            shutil.copy2(ROOT / 'test/csr.csv', output / 'csr.csv')
-        manifest['sha256'] = {str(p.relative_to(output)): hashlib.sha256(p.read_bytes()).hexdigest()
-            for p in output.rglob('*') if p.is_file() and p.suffix in ('.bit', '.bin', '.bram', '.boot', '.csv')}
-        timing = next((output / 'gateware').glob('*_timing.rpt')).read_text()
-        if 'All user specified timing constraints are met.' not in timing:
-            raise RuntimeError('Vivado timing failed; inspect the report before loading')
+        manifest['sha256'] = finish_build(args.board, output)
         manifest['passed'] = True
     finally:
         (output / 'manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')

--- a/tools/build_wr_bench.py
+++ b/tools/build_wr_bench.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Build the pinned uRV/private-RAM USB bench profile with read-only storage."""
+
+import argparse
+import hashlib
+import importlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def git(path, *args):
+    return subprocess.check_output(['git', '-C', str(path), *args], text=True).strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--board', required=True, choices=['acorn', 'spec'])
+    parser.add_argument('--output', required=True, type=Path)
+    args = parser.parse_args()
+    pins = json.loads((ROOT / 'doc/wr_bench_sources.json').read_text())
+    for name, pin in pins['python'].items():
+        module = importlib.import_module(name)
+        path = Path(module.__file__).resolve().parent
+        if git(path, 'rev-parse', 'HEAD') != pin['revision'] or git(path, 'status', '--porcelain', '--untracked-files=no'):
+            raise RuntimeError(f'{name}: expected clean source {pin["revision"]}, loaded {path}')
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    manifest = dict(board=args.board, source=git(ROOT, 'rev-parse', 'HEAD'),
+        source_dirty=bool(git(ROOT, 'status', '--porcelain', '--untracked-files=no')),
+        dependencies=pins, profile='uRV/private 128 KiB; read-only SPI storage', passed=False)
+    def run(command):
+        subprocess.run([sys.executable, *command], cwd=ROOT, check=True)
+    try:
+        run(['litex_wr_nic/firmware/build.py', '--target',
+            'acorn' if args.board == 'acorn' else 'spec_a7', '--wr-cpu-type', 'urv', '--read-only-storage'])
+        firmware = ROOT / 'litex_wr_nic/firmware'
+        for ext in ('bram', 'bin', 'boot'):
+            shutil.copy2(firmware / ('spec_a7_wrc.' + ext), output / ('spec_a7_wrc.' + ext))
+        command = ['acorn_wr_nic.py' if args.board == 'acorn' else 'spec_a7_wr_nic.py',
+            '--build', '--skip-firmware-build', '--skip-software-headers', '--wr-cpu-type', 'urv',
+            '--wr-cpu-memory', 'private', '--output-dir', str(output)]
+        run(command)
+        if args.board == 'acorn':
+            shutil.copy2(ROOT / 'test/csr.csv', output / 'csr.csv')
+        manifest['sha256'] = {str(p.relative_to(output)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in output.rglob('*') if p.is_file() and p.suffix in ('.bit', '.bin', '.bram', '.boot', '.csv')}
+        timing = next((output / 'gateware').glob('*_timing.rpt')).read_text()
+        if 'All user specified timing constraints are met.' not in timing:
+            raise RuntimeError('Vivado timing failed; inspect the report before loading')
+        manifest['passed'] = True
+    finally:
+        (output / 'manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/wr_console.py
+++ b/tools/wr_console.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+"""Paced UART commands and complete WR console capture."""
+
+import json
+from pathlib import Path
+import re
+import threading
+import time
+
+import serial
+
+
+ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+# PPSI diagnostics can be printed between any two shell echo characters.
+# Strip only their timestamped records when matching an echo; retain the full
+# response and raw UART capture for diagnosis.
+PPSI_DIAGNOSTIC = re.compile(r"diag-[\w-]+: \d+\.\d+: [^\n]*\n\n?")
+
+
+class Console:
+    def __init__(self, port, output, baudrate=115200):
+        output = Path(output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        self.port = serial.Serial(port, baudrate, timeout=0.1, write_timeout=2, exclusive=True)
+        self.raw = output.with_suffix(".uart.raw").open("wb", buffering=0)
+        self.events = output.with_suffix(".events.jsonl").open("w", buffering=1)
+        self.buffer = bytearray()
+        self.last_received = None
+        self.error = None
+        self.running = True
+        self.reader = threading.Thread(target=self.read, daemon=True)
+        self.reader.start()
+
+    def read(self):
+        try:
+            while self.running:
+                data = self.port.read(4096)
+                if data:
+                    self.raw.write(data)
+                    self.buffer.extend(data)
+                    self.last_received = time.monotonic()
+        except Exception as error:
+            if self.running:
+                self.error = error
+
+    def text(self, start=0):
+        if self.error is not None:
+            raise RuntimeError("UART disconnected") from self.error
+        return ANSI.sub("", bytes(self.buffer[start:]).decode(errors="replace")).replace("\r", "")
+
+    def record(self, kind, text):
+        self.events.write(json.dumps({"time": time.time(), "kind": kind, "text": text}) + "\n")
+
+    def send(self, text):
+        self.record("tx", text)
+        # WRPC polls a small RX FIFO; pace commands so USB bursts do not lose bytes.
+        for value in text.encode():
+            self.port.write(bytes([value]))
+            time.sleep(0.02)
+
+    def prompt(self, start, timeout=10, command=None):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            response = self.text(start)
+            # Asynchronous WR logs can redraw an old prompt while a command is
+            # being typed. Require the submitted command's echo before accepting
+            # its completion prompt; otherwise a later command can race it.
+            echo_text = PPSI_DIAGNOSTIC.sub("", response)
+            after_echo = 0 if command is None else echo_text.find(command + "\n")
+            if after_echo >= 0 and "wrc#" in echo_text[after_echo:]:
+                self.record("rx", response)
+                return response
+            time.sleep(0.05)
+        raise TimeoutError("WR prompt timeout: " + repr(self.text(start)[-1000:]))
+
+    def connect(self):
+        start = len(self.buffer)
+        self.send("\r")
+        try:
+            return self.prompt(start, timeout=3)
+        except TimeoutError:
+            start = len(self.buffer)
+            self.send("\x1bq\r")
+            return self.prompt(start)
+
+    def command(self, command, timeout=10):
+        start = len(self.buffer)
+        self.send(command + "\r")
+        response = self.prompt(start, timeout, command=command)
+        if re.search(r'Unrecognized command|Unknown subcommand|Command "[^"\n]+": error', response):
+            raise RuntimeError("WR command failed: " + response)
+        return response
+
+    def monitor(self, seconds):
+        start = len(self.buffer)
+        self.send("gui\r")
+        time.sleep(seconds)
+        screen = self.text(start)
+        self.record("gui", screen)
+        start = len(self.buffer)
+        self.send("q")
+        self.prompt(start)
+        return screen
+
+    def close(self):
+        self.running = False
+        self.reader.join(timeout=2)
+        self.port.close()
+        self.raw.close()
+        self.events.close()

--- a/tools/wr_jtag.py
+++ b/tools/wr_jtag.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Manage dedicated WR JTAG servers with persistent Linux process ownership."""
+
+import argparse
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+
+def load_config(path):
+    path = Path(path).resolve()
+    config = json.loads(path.read_text())
+    def resolve(value):
+        return os.path.abspath(path.parent / value)
+    config['state_dir'] = resolve(config['state_dir'])
+    config['pythonpath'] = [resolve(p) for p in config.get('pythonpath', [])]
+    ports = set()
+    for name, board in config['boards'].items():
+        if not re.fullmatch(r'[a-zA-Z0-9_-]+', name):
+            raise ValueError('Invalid board name')
+        for key in ('csr', 'bitstream', 'jtag_config', 'uart'):
+            if key in board:
+                board[key] = resolve(board[key])
+        for key in ('jtag_port', 'stream_port'):
+            port = board[key]
+            if type(port) is not int or not 1024 <= port <= 65535 or port in ports:
+                raise ValueError('JTAG and stream ports must be distinct integers in 1024..65535')
+            ports.add(port)
+        if 'master_trim' in board and (type(board['master_trim']) is not int
+                                      or not 0 <= board['master_trim'] <= 65535):
+            raise ValueError('Master trim must be a 16-bit code')
+        if 'jtag_config' not in board:
+            if not re.fullmatch(r'\d+-\d+(?:\.\d+)*', board['usb_location']):
+                raise ValueError('Expected a physical USB location, for example 1-3')
+    return config
+
+
+def jtag_config(config, board):
+    cfg = config['boards'][board]
+    if 'jtag_config' in cfg:
+        return cfg['jtag_config']
+    path = Path(config['state_dir']) / (board + '.cfg')
+    path.write_text('adapter driver ftdi\nadapter speed 5000\n'
+        f'adapter usb location {cfg["usb_location"]}\n'
+        'transport select jtag\nftdi_vid_pid 0x0403 0x6011\nftdi_channel 0\n'
+        'ftdi_layout_init 0x00e8 0x60eb\nreset_config none\n'
+        'tcl_port disabled\ntelnet_port disabled\ngdb_port disabled\n'
+        'source [find cpld/xilinx-xc7.cfg]\n')
+    return str(path)
+
+
+def process(pid):
+    try:
+        fields = (Path('/proc') / str(pid) / 'stat').read_text().rsplit(')', 1)[1].split()
+        return dict(pid=int(pid), state=fields[0], group=int(fields[2]), started=fields[19])
+    except (FileNotFoundError, ProcessLookupError):
+        return None
+
+
+def members(group):
+    result = []
+    for path in Path('/proc').iterdir():
+        if path.name.isdigit():
+            item = process(path.name)
+            if item and item['group'] == group and item['state'] != 'Z':
+                result.append(item)
+    return result
+
+
+def write_record(path, record):
+    temporary = path.with_suffix('.tmp')
+    temporary.write_text(json.dumps(record, indent=2) + '\n')
+    temporary.replace(path)
+
+
+def listening(port):
+    with socket.socket() as probe:
+        probe.settimeout(0.2)
+        return probe.connect_ex(('127.0.0.1', port)) == 0
+
+
+def probe_board(cfg):
+    from litex import RemoteClient
+    bus = RemoteClient(host='127.0.0.1', port=cfg['jtag_port'], csr_csv=cfg['csr'],
+        timeout=2, raise_on_timeout=True)
+    bus.open()
+    try:
+        if bus.read(bus.mems.wr_wb_slave.base) != 0x57525043:
+            raise RuntimeError('Invalid WR host signature')
+        identifier = bytes(value & 255 for value in bus.read(bus.bases.identifier_mem,
+            length=128)).split(b'\0')[0].decode()
+        if cfg['identifier'] not in identifier:
+            raise RuntimeError('Unexpected FPGA identity: '+identifier)
+        return identifier
+    finally:
+        bus.close()
+
+
+def stop(path):
+    if not path.exists():
+        return
+    record = json.loads(path.read_text())
+    if record['boot_id'] != Path('/proc/sys/kernel/random/boot_id').read_text().strip():
+        path.unlink()
+        return
+    known = record['members']
+    group = record['group']
+    for sig, grace in [(signal.SIGTERM, 1), (signal.SIGKILL, 3)]:
+        live = members(group)
+        if not live:
+            break
+        if not any(old['pid'] == new['pid'] and old['started'] == new['started']
+                   for old in known for new in live):
+            raise RuntimeError(f'Refusing to signal unverified process group {group}')
+        try:
+            os.killpg(group, sig)
+        except ProcessLookupError:
+            break
+        deadline = time.monotonic() + grace
+        while members(group) and time.monotonic() < deadline:
+            time.sleep(0.05)
+    if members(group):
+        raise RuntimeError(f'Owned process group {group} did not stop')
+    path.unlink()
+
+
+def serve(config, board, path):
+    # Record our identity before exec starts LiteX/OpenOCD. A controller killed
+    # during startup can subsequently clean up this process and its children.
+    identity = process(os.getpid())
+    assert identity['group'] == os.getpid(), 'Worker must own its process group'
+    write_record(path, dict(boot_id=Path('/proc/sys/kernel/random/boot_id').read_text().strip(),
+        group=os.getpid(), members=[identity]))
+    cfg = config['boards'][board]
+    command = [sys.executable, '-m', 'litex.tools.litex_server', '--jtag',
+        '--jtag-config', jtag_config(config, board), '--jtag-port', str(cfg['stream_port']),
+        '--bind-ip', '127.0.0.1', '--bind-port', str(cfg['jtag_port'])]
+    os.execv(sys.executable, command)
+
+
+def start(config, config_path, board, state_dir):
+    cfg = config['boards'][board]
+    path = state_dir / (board + '.json')
+    stop(path)
+    for port in (cfg['jtag_port'], cfg['stream_port']):
+        if listening(port):
+            raise RuntimeError(f'Port {port} has an unmanaged listener')
+    for attempt in range(3):
+        stamp = time.strftime('%Y%m%d-%H%M%S') + f'-{attempt + 1}'
+        log_path = state_dir / (board + '-' + stamp + '.log')
+        environment = os.environ.copy()
+        if config.get('pythonpath'):
+            environment['PYTHONPATH'] = os.pathsep.join(config['pythonpath'])
+        with log_path.open('w') as log:
+            child = subprocess.Popen([sys.executable, str(Path(__file__).resolve()),
+                '--config', str(config_path), '--board', board, '_serve'],
+                env=environment, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+        try:
+            deadline = time.monotonic() + 20
+            while time.monotonic() < deadline:
+                if child.poll() is not None:
+                    raise RuntimeError(f'{board}: startup exited with {child.returncode}; see {log_path}')
+                if path.exists():
+                    record = json.loads(path.read_text())
+                    live = members(record['group'])
+                    # Keep identities already seen, including a parent which
+                    # exits while its OpenOCD child is still starting.
+                    record['members'] += [item for item in live if not any(
+                        item['pid'] == old['pid'] and item['started'] == old['started']
+                        for old in record['members'])]
+                    write_record(path, record)
+                if path.exists() and listening(cfg['jtag_port']):
+                    probe_board(cfg)
+                    print(f'{board}: JTAG server ready on localhost:{cfg["jtag_port"]}', flush=True)
+                    return
+                time.sleep(0.1)
+            raise TimeoutError(f'{board}: JTAG startup timed out; see {log_path}')
+        except BaseException as error:
+            stop(path)
+            # Covers the short interval before the worker writes its record.
+            if child.poll() is None:
+                child.terminate()
+            child.wait(timeout=3)
+            if not isinstance(error, Exception) or attempt == 2:
+                raise
+            print(str(error) + '; retrying', file=sys.stderr, flush=True)
+            time.sleep(0.2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config', type=Path, required=True)
+    parser.add_argument('--board')
+    parser.add_argument('action', choices=['start', 'stop', 'status', '_serve'])
+    args = parser.parse_args()
+    config_path = args.config.resolve()
+    config = load_config(config_path)
+    sys.path[:0] = config['pythonpath']
+    state_dir = Path(config['state_dir'])
+    state_dir.mkdir(parents=True, exist_ok=True)
+    names = [args.board] if args.board else list(config['boards'])
+    if any(name not in config['boards'] for name in names):
+        parser.error('Unknown board')
+    if args.action == '_serve':
+        serve(config, args.board, state_dir / (args.board + '.json'))
+    with (state_dir / 'bench.lock').open('a') as lock:
+        if args.action != 'status':
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        for name in names:
+            path = state_dir / (name + '.json')
+            if args.action == 'start':
+                start(config, config_path, name, state_dir)
+            elif args.action == 'stop':
+                stop(path)
+            else:
+                record = json.loads(path.read_text()) if path.exists() else None
+                cfg = config['boards'][name]
+                print(json.dumps(dict(board=name, record=record,
+                    jtag=listening(cfg['jtag_port']), stream=listening(cfg['stream_port']))))
+
+
+if __name__ == '__main__':
+    def interrupted(signum, frame):
+        raise KeyboardInterrupt(f'signal {signum}')
+    signal.signal(signal.SIGTERM, interrupted)
+    main()

--- a/tools/wr_qualify.py
+++ b/tools/wr_qualify.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+"""Qualify two configured WR boards with physical UART and JTAGBone evidence."""
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import fcntl
+import hashlib
+import json
+from pathlib import Path
+import signal
+import time
+
+from litex import RemoteClient
+from wr_console import Console
+from wr_status import WRScreen, diagnostic_snapshot, qualification_errors
+from wr_jtag import load_config
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config', type=Path, help='Use board paths, ports and trims from a bench configuration.')
+    parser.add_argument('--master-board', help='Master board name from --config; the other board becomes slave.')
+    for role in ("master", "slave"):
+        parser.add_argument("--" + role + "-uart")
+        parser.add_argument("--" + role + "-jtag", type=int)
+        parser.add_argument("--" + role + "-csr", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--duration", type=float, default=1800)
+    parser.add_argument("--acquire-timeout", type=float, default=300)
+    parser.add_argument(
+        "--configure",
+        action="store_true",
+        help="Set roles before acquisition; otherwise observe the running pair.",
+    )
+    parser.add_argument(
+        "--master-trim",
+        type=int,
+        help="Apply a volatile master main-DAC code after role configuration.",
+    )
+    args = parser.parse_args()
+    config = load_config(args.config) if args.config else None
+    boards = {}
+    if config:
+        if len(config['boards']) != 2 or args.master_board not in config['boards']:
+            parser.error('--config requires exactly two boards and a valid --master-board')
+        boards['master'] = config['boards'][args.master_board]
+        boards['slave'] = next(b for n, b in config['boards'].items() if n != args.master_board)
+        for role, board in boards.items():
+            for argument, key in [('uart', 'uart'), ('jtag', 'jtag_port'), ('csr', 'csr')]:
+                if getattr(args, role + '_' + argument) is not None:
+                    parser.error('Explicit board connection options cannot be combined with --config')
+                setattr(args, role + '_' + argument, Path(board[key]) if argument == 'csr' else board[key])
+        if args.configure and args.master_trim is None:
+            args.master_trim = boards['master'].get('master_trim')
+    elif args.master_board:
+        parser.error('--master-board requires --config')
+    if any(getattr(args, role + '_' + key) is None
+           for role in ('master', 'slave') for key in ('uart', 'jtag', 'csr')):
+        parser.error('Provide --config and --master-board, or all master/slave connection options')
+    if args.duration <= 0 or args.acquire_timeout <= 0:
+        parser.error("Durations must be positive")
+    if args.master_trim is not None and not (args.configure and 0 <= args.master_trim <= 65535):
+        parser.error("--master-trim requires --configure and a 16-bit code")
+    lock = None
+    if config:
+        state = Path(config['state_dir'])
+        state.mkdir(parents=True, exist_ok=True)
+        lock = (state / 'bench.lock').open('a')
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    args.output.mkdir(parents=True, exist_ok=False)
+    summary = dict(
+        passed=False,
+        start_unix=time.time(),
+        duration_requested=args.duration,
+        arguments={k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()},
+        boards={},
+        tool_sha256={
+            name: hashlib.sha256(Path(__file__).with_name(name).read_bytes()).hexdigest()
+            for name in ("wr_qualify.py", "wr_console.py", "wr_status.py")
+        },
+    )
+    consoles, buses, screens, offsets = {}, {}, {}, {}
+    samples = (args.output / "samples.jsonl").open("w", buffering=1)
+    frames_log = (args.output / "gui-frames.jsonl").open("w", buffering=1)
+    pool = ThreadPoolExecutor(max_workers=2)
+    try:
+        for role in ("master", "slave"):
+            csv = getattr(args, role + "_csr")
+            summary["boards"][role] = dict(
+                csr_sha256=hashlib.sha256(csv.read_bytes()).hexdigest(), commands=[]
+            )
+            c = consoles[role] = Console(getattr(args, role + "_uart"), args.output / role)
+            c.connect()
+            b = buses[role] = RemoteClient(
+                host="127.0.0.1",
+                port=getattr(args, role + "_jtag"),
+                csr_csv=str(csv),
+                timeout=5,
+                raise_on_timeout=True,
+            )
+            b.open()
+            identifier = (
+                bytes(w & 255 for w in b.read(b.bases.identifier_mem, length=128))
+                .split(b"\0")[0]
+                .decode()
+            )
+            summary["boards"][role]["identifier"] = identifier
+            if boards and boards[role]['identifier'] not in identifier:
+                raise RuntimeError(role + ': unexpected FPGA identifier: ' + identifier)
+            if b.read(b.mems.wr_wb_slave.base) != 0x57525043:
+                raise RuntimeError(role + ": WR host map identity mismatch")
+
+        def command(role, text):
+            response = consoles[role].command(text, timeout=60)
+            summary["boards"][role]["commands"].append(dict(command=text, response=response))
+            if "PRINTF OVF" in response:
+                raise RuntimeError(role + ": firmware printf buffer overflow")
+            return response
+
+        for role in consoles:
+            command(role, "verbose 0")
+            command(role, "ver")
+        if args.configure:
+            for role in consoles:
+                command(role, "ptp stop")
+            for role in consoles:
+                command(role, "mode " + role)
+            if args.master_trim is not None:
+                command("master", f"pll sdac 0 {args.master_trim}")
+            for role in consoles:
+                command(role, "ptp start")
+        for role, c in consoles.items():
+            command(role, "ptp")
+            command(role, "mac get")
+            screens[role] = WRScreen()
+            offsets[role] = len(c.buffer)
+            c.send("gui\r")
+        start = time.monotonic()
+        tracking_start = None
+        previous = None
+        progress_times = {role: start for role in consoles}
+        update_progress = start
+        last_report = start - 30
+        while True:
+            new_frames = {}
+            for role, c in consoles.items():
+                if c.error:
+                    raise RuntimeError(role + ": UART reader failed") from c.error
+                end = len(c.buffer)
+                # Retain enough overlap to catch a warning split across reads.
+                if b"PRINTF OVF" in c.buffer[max(0, offsets[role] - 9) : end]:
+                    raise RuntimeError(role + ": firmware printf buffer overflow")
+                new_frames[role] = screens[role].feed(
+                    bytes(c.buffer[offsets[role] : end]), now=c.last_received or start
+                )
+                offsets[role] = end
+                for frame in new_frames[role]:
+                    frames_log.write(json.dumps(dict(board_role=role, **frame)) + "\n")
+            pending = {role: pool.submit(diagnostic_snapshot, b) for role, b in buses.items()}
+            diags = {role: future.result() for role, future in pending.items()}
+            now = time.monotonic()
+            master, slave = screens["master"].latest, screens["slave"].latest
+            errors = qualification_errors(master, slave, diags["master"], diags["slave"], now)
+            # Every complete UART frame during the soak is checked, including
+            # transient losses between host diagnostic samples.
+            if tracking_start is not None:
+                for frame in new_frames["master"]:
+                    errors += qualification_errors(
+                        frame, slave, diags["master"], diags["slave"], now
+                    )
+                for frame in new_frames["slave"]:
+                    errors += qualification_errors(
+                        master, frame, diags["master"], diags["slave"], now
+                    )
+                for role in diags:
+                    if diags[role]["tai_ns"] is None:
+                        continue  # qualification_errors already rejects this snapshot.
+                    if diags[role]["tai_ns"] < previous[role]["tai_ns"]:
+                        errors.append(role + ": TAI moved backwards")
+                    if diags[role]["tai_ns"] != previous[role]["tai_ns"]:
+                        progress_times[role] = now
+                    if now - progress_times[role] > 5:
+                        errors.append(role + ": TAI stopped advancing")
+                    if diags[role]["rx_errors"] != previous[role]["rx_errors"]:
+                        errors.append(role + ": RX error count changed")
+                if diags["slave"]["updates"] != previous["slave"]["updates"]:
+                    update_progress = now
+                if (
+                    diags["slave"]["updates"] - previous["slave"]["updates"]
+                ) & 0xFFFFFFFF > 0x80000000:
+                    errors.append("slave: servo update counter moved backwards")
+                if now - update_progress > 10:
+                    errors.append("slave: servo update counter stopped advancing")
+            sample = dict(
+                elapsed=now - start,
+                soak_elapsed=None if tracking_start is None else now - tracking_start,
+                errors=sorted(set(errors)),
+                diagnostics=diags,
+                gui={
+                    role: {k: v for k, v in screens[role].latest.items() if k != "screen"}
+                    if screens[role].latest
+                    else None
+                    for role in screens
+                },
+            )
+            samples.write(json.dumps(sample) + "\n")
+            if tracking_start is None:
+                if not errors:
+                    tracking_start = now
+                    summary["acquired_after"] = now - start
+                    progress_times = {role: now for role in diags}
+                    update_progress = now
+                    summary["initial_diagnostics"] = diags
+                    print(
+                        f"WR tracking acquired after {now - start:.1f}s; starting uninterrupted {args.duration:.0f}s soak",
+                        flush=True,
+                    )
+                elif now - start > args.acquire_timeout:
+                    raise RuntimeError("WR acquisition timeout: " + ", ".join(sorted(set(errors))))
+            elif errors:
+                raise RuntimeError("WR soak interrupted: " + ", ".join(sorted(set(errors))))
+            elif now - tracking_start >= args.duration:
+                summary.update(
+                    passed=True, soak_seconds=now - tracking_start, final_diagnostics=diags
+                )
+                break
+            previous = diags
+            if now - last_report >= 30:
+                print(
+                    json.dumps(
+                        dict(
+                            elapsed=round(now - start, 1),
+                            soak=sample["soak_elapsed"],
+                            errors=sample["errors"],
+                            slave_offset_ps=diags["slave"]["offset_ps"],
+                            slave_updates=diags["slave"]["updates"],
+                        )
+                    ),
+                    flush=True,
+                )
+                last_report = now
+            time.sleep(0.1)
+    except BaseException as error:
+        summary["error"] = str(error)
+        raise
+    finally:
+        pool.shutdown(wait=True)
+        for c in consoles.values():
+            try:
+                start = len(c.buffer)
+                c.send("q")
+                c.prompt(start)
+            except Exception:
+                pass
+            c.close()
+        for b in buses.values():
+            b.close()
+        samples.close()
+        frames_log.close()
+        summary["end_unix"] = time.time()
+        (args.output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+        if lock:
+            lock.close()
+    print(json.dumps(summary, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    def interrupted(signum, frame):
+        raise KeyboardInterrupt(f'signal {signum}')
+    signal.signal(signal.SIGTERM, interrupted)
+    main()

--- a/tools/wr_status.py
+++ b/tools/wr_status.py
@@ -1,0 +1,196 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+"""WRPC v5 GUI frames and coherent host diagnostic snapshots."""
+
+import re
+import time
+
+CSI = re.compile(r"\x1b\[([0-?]*)([ -/]*)([@-~])")
+
+
+class WRScreen:
+    """Small terminal model for WRPC's cursor-addressed monitor, including split CSI."""
+
+    def __init__(self):
+        self.rows = [[" "] * 100 for _ in range(50)]
+        self.row = self.col = 0
+        self.pending = ""
+        self.latest = None
+
+    def feed(self, data, now=None):
+        now = time.monotonic() if now is None else now
+        text = self.pending + data.decode("ascii", errors="replace")
+        self.pending = ""
+        i = 0
+        frames = []
+        while i < len(text):
+            ch = text[i]
+            if ch == "\x1b":
+                match = CSI.match(text, i)
+                if match is None:
+                    self.pending = text[i:]
+                    break
+                values, _, command = match.groups()
+                args = (
+                    [int(x or 0) for x in values.split(";")] if not values.startswith("?") else []
+                )
+                n = args[0] if args else 0
+                if command in ("H", "f"):
+                    self.row = max(0, min(49, (n or 1) - 1))
+                    self.col = max(0, min(99, ((args[1] if len(args) > 1 else 1) or 1) - 1))
+                elif command == "J":
+                    if n == 2:
+                        self.rows = [[" "] * 100 for _ in range(50)]
+                        self.latest = None
+                    elif n == 0:
+                        self.rows[self.row][self.col :] = [" "] * (100 - self.col)
+                        for row in range(self.row + 1, 50):
+                            self.rows[row] = [" "] * 100
+                        frame = self.frame(now)
+                        if frame is not None:
+                            self.latest = frame
+                            frames.append(frame)
+                elif command == "K":
+                    if n == 0:
+                        self.rows[self.row][self.col :] = [" "] * (100 - self.col)
+                    elif n == 2:
+                        self.rows[self.row] = [" "] * 100
+                elif command == "@":
+                    count = n or 1
+                    self.rows[self.row][self.col :] = (
+                        [" "] * count + self.rows[self.row][self.col :]
+                    )[: 100 - self.col]
+                i = match.end()
+                continue
+            if ch == "\r":
+                self.col = 0
+            elif ch == "\n":
+                self.row = min(49, self.row + 1)
+            elif ch == "\b":
+                self.col = max(0, self.col - 1)
+            elif ord(ch) >= 32:
+                self.rows[self.row][self.col] = ch
+                self.col = min(99, self.col + 1)
+            i += 1
+        return frames
+
+    def frame(self, now):
+        rows = ["".join(row) for row in self.rows]
+        tai = re.search(r"\d{4}-\d{2}-\d{2}-\d{2}:\d{2}:\d{2}", rows[2])
+        port = re.search(r"\b(\w+)\s*/\s*(\w+)\s*/\s*(\w+)", rows[11])
+        mac = re.search(r"(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}", rows[6])
+        peer = re.search(r"(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}", rows[11])
+        # The static redraw also ends in ESC[J before values are populated.
+        # Once time and our MAC are present, retain even malformed/down port
+        # rows so a brief loss cannot disappear between good frames.
+        if not (tai and mac):
+            return None
+        servo = re.search(r"White-Rabbit:\s*(\S+)", rows[15])
+        count = re.search(r"(\d+) times", rows[29])
+        return dict(
+            received=now,
+            tai=tai.group(),
+            mac=mac.group().lower(),
+            peer=peer.group().lower() if peer else None,
+            role=port[1] if port else None,
+            extension=port[2] if port else None,
+            detection=port[3] if port else None,
+            pll_locked=rows[2][69:76].strip() == "Locked",
+            frequency_locked=rows[11][7:10] == "Lck",
+            servo=servo[1] if servo else None,
+            updates=int(count[1]) if count else None,
+            screen="\n".join(row.rstrip() for row in rows).rstrip(),
+        )
+
+
+def diagnostic_snapshot(bus, timeout=3):
+    base = bus.mems.wr_wb_slave.base + 0x900
+    if bus.read(base) != 2:
+        raise RuntimeError("WR diagnostic version is not 2; verify the CPU device map")
+    try:
+        # Clear VALID while requesting a new snapshot; firmware sets it only
+        # after completing a fresh update, then holds all fields for the host.
+        bus.write(base + 4, 0x100)
+        deadline = time.monotonic() + timeout
+        while bus.read(base + 4) & 0x101 != 0x101:
+            if time.monotonic() > deadline:
+                raise TimeoutError("WR diagnostics did not produce a fresh snapshot")
+            time.sleep(0.02)
+        words = bus.read(base, length=25)
+        if words[1] & 0x101 != 0x101:
+            raise RuntimeError("WR diagnostic snapshot lost validity")
+    finally:
+        bus.write(base + 4, 0)
+    signed = lambda value: value if value < 0x80000000 else value - 0x100000000
+    # Negative PPS counter adjustments during acquisition temporarily wrap the
+    # 28-bit cycle counter. Preserve the snapshot but do not treat it as time.
+    # A normalized time remains mandatory for qualification.
+    time_valid = words[10] < 1_000_000_000
+    return dict(
+        version=words[0],
+        raw=words,
+        # Firmware calls this WR_MODE but populates it with servo validity.
+        # Actual WR extension activation must be checked independently via GUI.
+        servo_valid=bool(words[2] & 1),
+        servo_state=(words[2] >> 8) & 15,
+        link=bool(words[3] & 1),
+        locked=bool(words[3] & 2),
+        ptp_state=words[4] & 255,
+        time_valid=time_valid,
+        tai_ns=((words[8] << 32) | words[9]) * 1000000000 + words[10] if time_valid else None,
+        offset_ps=signed(words[16]),
+        updates=words[18],
+        tx=words[6],
+        rx=words[7],
+        rx_errors=words[24],
+    )
+
+
+def qualification_errors(master, slave, master_diag, slave_diag, now):
+    errors = []
+    for name, frame, diag, role, state in (
+        ("master", master, master_diag, "MASTER", 6),
+        ("slave", slave, slave_diag, "SLAVE", 9),
+    ):
+        if diag["tai_ns"] is None:
+            errors.append(name + ": timestamp is not normalized")
+        if frame is None:
+            errors.append(name + ": no complete GUI frame")
+            continue
+        if now - frame["received"] > 5:
+            errors.append(name + ": stale UART monitor")
+        if frame["role"] != role or diag["ptp_state"] != state:
+            errors.append(name + ": incorrect PTP role")
+        if frame["detection"] != "EXT_ON" or frame["extension"] != "IDLE":
+            errors.append(name + ": WR extension is not active and idle")
+        if not (
+            frame["pll_locked"] and frame["frequency_locked"] and diag["link"] and diag["locked"]
+        ):
+            errors.append(name + ": link/frequency lock missing")
+    if (
+        master
+        and slave
+        and (
+            master["mac"] != slave["peer"]
+            or slave["mac"] != master["peer"]
+            or master["mac"] == slave["mac"]
+        )
+    ):
+        errors.append("peer MAC identities do not agree")
+    if slave and (
+        slave["servo"] != "TRACK_PHASE"
+        or not slave_diag["servo_valid"]
+        or slave_diag["servo_state"] != 4
+    ):
+        errors.append("slave: servo is not tracking WR phase")
+    # Separate firmware refresh periods prevent a precise timestamp comparison,
+    # but both boards must agree on the time scale.
+    if (master_diag["tai_ns"] is not None and slave_diag["tai_ns"] is not None
+        and abs(master_diag["tai_ns"] - slave_diag["tai_ns"]) > 3_000_000_000):
+        errors.append("master/slave diagnostic time scales disagree")
+    return errors

--- a/tools/wr_trim.py
+++ b/tools/wr_trim.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Fit per-board master trims from reciprocal Acorn/SPEC main-clock sweeps."""
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from statistics import linear_regression, mean
+
+
+def fit_trims(rows, spec_linear_max=38500, spec_plateau_min=40960):
+    # Each sweep holds the peer at 32768. Normalize by RX, then anchor Acorn's
+    # sweep to its own measured midpoint. This avoids combining the offsets of
+    # sequential reciprocal measurements as though they were simultaneous.
+    points = {}
+    for board in ('acorn', 'spec'):
+        points[board] = []
+        for row in rows:
+            if row['board'] != board:
+                continue
+            code = int(row['code'])
+            ref, rx = float(row['ref_hz']), float(row['rx_hz'])
+            if (not 0 <= code <= 65535 or not ref > 0 or not rx > 0
+                    or not math.isfinite(ref) or not math.isfinite(rx)):
+                raise ValueError('Invalid DAC code or clock measurement')
+            points[board].append((code, ref / rx))
+        if len({x for x, _ in points[board]}) < 3:
+            raise ValueError('Each board requires at least three distinct codes')
+    anchors = [y for x, y in points['acorn'] if x == 32768]
+    if not anchors:
+        raise ValueError('Acorn sweep must include code 32768')
+    anchor = mean(anchors)
+    points['acorn'] = [(x, (y / anchor - 1) * 1e6) for x, y in points['acorn']]
+    points['spec'] = [(x, (y - 1) * 1e6) for x, y in points['spec']]
+    low = [y for x, y in points['spec'] if x == 0]
+    high = [y for x, y in points['spec'] if x >= spec_plateau_min]
+    if not low or not high:
+        raise ValueError('SPEC sweep must include code 0 and its measured upper plateau')
+    target = (mean(low) + mean(high)) / 2
+    result = dict(reference='Acorn at 32768; relative frequency only',
+        target_ppm=target, spec_range_ppm=[mean(low), mean(high)], boards={})
+    for board, samples in points.items():
+        linear = [(x, y) for x, y in samples if board == 'acorn' or x <= spec_linear_max]
+        if len({x for x, _ in linear}) < 3:
+            raise ValueError('Need at least three codes in each fitted linear region')
+        fit = linear_regression([x for x, _ in linear], [y for _, y in linear])
+        if fit.slope <= 0:
+            raise ValueError('Expected a positive tuning slope')
+        code = round((target - fit.intercept) / fit.slope)
+        if not min(x for x, _ in linear) <= code <= max(x for x, _ in linear):
+            raise ValueError('Centered trim lies outside the measured linear region')
+        result['boards'][board] = dict(master_trim=code, ppm_per_code=fit.slope,
+            max_fit_residual_ppm=max(abs(y - fit.slope * x - fit.intercept) for x, y in linear))
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('csv', type=Path, help='Columns: board,code,ref_hz,rx_hz')
+    parser.add_argument('--spec-linear-max', type=int, default=38500)
+    parser.add_argument('--spec-plateau-min', type=int, default=40960)
+    args = parser.parse_args()
+    with args.csv.open() as stream:
+        rows = list(csv.DictReader(stream))
+    print(json.dumps(fit_trims(rows, args.spec_linear_max, args.spec_plateau_min), indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
With Acorn at main-clock code 32768, SPEC reaches its low tuning limit before matching the master. The measured SPEC floor is still about 1.4 ppm faster. Add a reproducible USB bench profile and a per-board trim fit, replacing the unexplained 35000 bench setting with measured configuration values (36301 for this Acorn, 19677 for this SPEC).

This follow-up is stacked on #86; #85 is merged and #84 remains the historical record.

- Pin the complete WR/LiteX dependency revisions and build both uRV/private-RAM profiles with read-only firmware. Preserve matching firmware/CSR maps and convert SPEC's programming image for the physical 35T.
- Add persistent JTAG process ownership, bounded startup retries and safe cleanup of recorded orphans, using enjoy-digital/litex#2591. Add paced UART capture and config-based checks in either role direction.
- Keep unnormalized acquisition timestamps as invalid samples; reject them during tracking.
- Document the relative tuning ranges, fitted trims, SFP jumper routing and the remaining independent PPS/temperature measurements. No raw captures, plots or build artifacts are committed.

Validation:
- 42 focused tests pass, including actual patched firmware C functions, DAC/clock-domain tests and regressions for SPEC image/CSR packaging.
- Both profiles rebuilt and SRAM-loaded from the pinned sources. Acorn setup/hold slack: +0.252/+0.036 ns; SPEC: +0.166/+0.056 ns.
- Six PID-only SIGTERM/reconnect cycles and one persisted SIGKILL-orphan recovery pass on the connected boards.
- Both fresh-image role directions pass 120 seconds of uninterrupted WR tracking with no RX error increases.

These are relative frequency and tracking results. Acorn EEPROM access still needs the JP1/JP4 physical check; independent PPS delay/jitter, SFP/fiber calibration, temperature coverage and dynamic loop margin remain unmeasured. The measured trims are specific to this pair and are applied only to the selected master, in RAM.
