### PR TITLE
bench: add optional SoftPLL capture and analysis tools

### DIFF
--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -130,6 +130,7 @@ class BaseSoC(LiteXWRNICSoC):
         wr_cpu_type               = "urv",
         wr_cpu_variant            = None,
         wr_cpu_memory             = "private",
+        with_wr_pll_debug         = False,
 
     ):
         # Platform ---------------------------------------------------------------------------------
@@ -196,6 +197,10 @@ class BaseSoC(LiteXWRNICSoC):
                 data_width=32, endianness="little", mem_size=WR_CPU_MEMORY_SIZE)
             self.add_ram("wr_cpu_mem", WR_CPU_MEMORY_ORIGIN, WR_CPU_MEMORY_SIZE, contents=contents)
             wr_cpu_region = SoCRegion(origin=WR_CPU_MEMORY_ORIGIN, size=WR_CPU_MEMORY_SIZE, mode="rwx")
+
+        if with_wr_pll_debug:
+            from litex.soc.cores.xadc import S7SystemMonitor
+            self.xadc = S7SystemMonitor()
 
         # UART -------------------------------------------------------------------------------------
 
@@ -266,6 +271,7 @@ class BaseSoC(LiteXWRNICSoC):
 
                 # Board name.
                 board_name       = "SAWR",
+                with_softpll_debug = with_wr_pll_debug,
 
                 # SFP.
                 sfp_pads        = platform.request("sfp",     white_rabbit_sfp_connector),
@@ -412,6 +418,8 @@ def main():
 
     # Build/Load/Flash Arguments.
     # ---------------------------
+    parser.add_argument("--with-wr-pll-debug", action="store_true",
+        help="Enable the SoftPLL host trace FIFO and FPGA temperature/supply CSRs.")
     parser.add_argument("--build", action="store_true", help="Build bitstream.")
     parser.add_argument("--load",  action="store_true", help="Load bitstream.")
     parser.add_argument("--flash", action="store_true", help="Flash bitstream.")
@@ -452,6 +460,7 @@ def main():
         wr_cpu_type    = args.wr_cpu_type,
         wr_cpu_variant = args.wr_cpu_variant,
         wr_cpu_memory  = args.wr_cpu_memory,
+        with_wr_pll_debug = args.with_wr_pll_debug,
     )
     if args.with_wishbone_fabric_interface_probe:
         soc.add_wishbone_fabric_interface_probe()

--- a/acorn_wr_nic.py
+++ b/acorn_wr_nic.py
@@ -423,6 +423,11 @@ def main():
         help="LiteX WR CPU variant (VexRiscv defaults to lite).")
     parser.add_argument("--output-dir", default=None, help="Build directory.")
 
+    parser.add_argument("--skip-firmware-build", action="store_true",
+        help="Reuse firmware built separately (for example the read-only bench profile).")
+    parser.add_argument("--skip-software-headers", action="store_true",
+        help="Do not overwrite the checked-in PCIe software headers.")
+
     # Probes.
     # -------
     parser.add_argument("--with-wishbone-fabric-interface-probe", action="store_true")
@@ -434,7 +439,7 @@ def main():
 
     # Build Firmware.
     # ---------------
-    if args.build:
+    if args.build and not args.skip_firmware_build:
         print("Building firmware...")
         r = os.system("cd litex_wr_nic/firmware && ./build.py --target acorn --wr-cpu-type {}".format(
             args.wr_cpu_type))
@@ -462,7 +467,8 @@ def main():
 
     # Generate PCIe C Headers.
     # ------------------------
-    generate_litepcie_software_headers(soc, "litex_wr_nic/software/kernel")
+    if not args.skip_software_headers:
+        generate_litepcie_software_headers(soc, "litex_wr_nic/software/kernel")
 
     # Load FPGA.
     # ----------

--- a/doc/wr_bench.example.json
+++ b/doc/wr_bench.example.json
@@ -1,0 +1,23 @@
+{
+  "state_dir": "wr-jtag",
+  "boards": {
+    "acorn": {
+      "uart": "/dev/serial/by-path/REPLACE-ACORN-FT4232-INTERFACE-2",
+      "usb_location": "1-2",
+      "jtag_port": 1236,
+      "stream_port": 20002,
+      "csr": "bench-acorn/csr.csv",
+      "bitstream": "bench-acorn/gateware/sqrl_acorn.bit",
+      "identifier": "Acorn Baseboard Mini"
+    },
+    "spec": {
+      "uart": "/dev/serial/by-path/REPLACE-SPEC-FT4232-INTERFACE-2",
+      "usb_location": "1-3",
+      "jtag_port": 1235,
+      "stream_port": 20001,
+      "csr": "bench-spec/csr.csv",
+      "bitstream": "bench-spec/gateware/spec_a7_wr_nic.bin",
+      "identifier": "SPEC-A7"
+    }
+  }
+}

--- a/doc/wr_bench_sources.json
+++ b/doc/wr_bench_sources.json
@@ -1,0 +1,23 @@
+{
+  "python": {
+    "migen": {"url": "https://github.com/m-labs/migen.git", "revision": "4c2ae8dfeea37f235b52acb8166f12acaaae4f7c"},
+    "litex": {"url": "https://github.com/enjoy-digital/litex.git", "revision": "905384c2437b27fd35f50340dfdc23e2c0def5c1"},
+    "litepcie": {"url": "https://github.com/enjoy-digital/litepcie.git", "revision": "f9a2d43e4e9c29ae837641fb1c86cc0ffdec5da4"},
+    "liteeth": {"url": "https://github.com/enjoy-digital/liteeth.git", "revision": "8c9150ff121cb3148d8ea26ce3b1c5200479848d"},
+    "litescope": {"url": "https://github.com/enjoy-digital/litescope.git", "revision": "6bf3b92f261c50b8c7c74947f84e692ae846f512"},
+    "litex_boards": {"url": "https://github.com/litex-hub/litex-boards.git", "revision": "3e606b50b3f14e31d4bf565e5ba3cac3d21f841d"}
+  },
+  "wr_cores": {
+    "url": "https://gitlab.com/ohwr/project/wr-cores.git",
+    "revision": "8cc5e53275d229fbbf50b96a6ae4cb9c87626d53",
+    "general_cores": "d99c8460ae8b939ada406fe23198c41d236bf49b",
+    "urv": "de05caf973e17d1fa46f4fdb95762230bd1ab8c4"
+  },
+  "wrpc": {
+    "url": "https://gitlab.com/ohwr/project/wrpc-sw.git",
+    "revision": "13527cd68e1833214a89e4ee8c5b208188ff0e6a",
+    "ppsi": "33d8c46c8353be56d35dc57dd3492769e276c00f",
+    "ual": "57a9484c343cbda804ceaa39e6025ba425c9a252"
+  },
+  "tools": {"vivado": "2024.1", "riscv32-elf-gcc": "11.2.0 (riscv-11.2-small)"}
+}

--- a/doc/wr_loop_response.md
+++ b/doc/wr_loop_response.md
@@ -1,0 +1,64 @@
+# SoftPLL capture tools
+
+Use the [USB bench setup](wr_usb_bench.md) and its pinned dependencies. Build
+both targets sequentially with the optional trace profile:
+
+```sh
+python3 tools/build_wr_bench.py --board acorn --pll-trace-decimation 16 --output build/trace-acorn
+python3 tools/build_wr_bench.py --board spec --pll-trace-decimation 16 --output build/trace-spec
+```
+
+This enables the upstream SoftPLL host FIFO and XADC temperature/supply CSRs.
+On SPEC, it omits PCIe NIC/PTM and the time generator to fit the XC7A35T RAM
+budget; the PCIe PHY/QPLL clock arrangement, WR, UART, JTAGBone and PPS remain.
+Update the local configuration with the trace images and their CSR maps, and
+load SRAM as described in the bench setup. SPEC uses the converted `.bin`.
+
+For native capture, the host JTAG bridge needs the TCP latency fix from
+[LiteX #2592](https://github.com/enjoy-digital/litex/pull/2592), commit
+`84368c06e34a2b703afd2f274459636fe0de79a8`. Set the configuration's `pythonpath`
+to a checkout containing that fix; FPGA builds use the dependency pins.
+Install NumPy/SciPy for analysis.
+
+## Run and analyze
+
+First derive each board's `master_trim` and main tuning sensitivity from its
+own sweep. Add the trims to the local configuration. Set
+`ACORN_MAIN_PPB_PER_CODE` and `SPEC_MAIN_PPB_PER_CODE` below to those slopes
+in **ppb/code** (`wr_trim.py` reports ppm/code; multiply by 1000).
+
+```sh
+python3 tools/wr_jtag.py --config build/wr-bench.json start
+python3 tools/wr_loop_response.py --config build/wr-bench.json --master spec --master-sensitivity-ppb "$SPEC_MAIN_PPB_PER_CODE" --output build/response-acorn
+python3 tools/wr_loop_analysis.py build/response-acorn --sensitivity-ppb "$ACORN_MAIN_PPB_PER_CODE"
+python3 tools/wr_loop_response.py --config build/wr-bench.json --master acorn --master-sensitivity-ppb "$ACORN_MAIN_PPB_PER_CODE" --output build/response-spec
+python3 tools/wr_loop_analysis.py build/response-spec --sensitivity-ppb "$SPEC_MAIN_PPB_PER_CODE"
+python3 tools/wr_qualify.py --config build/wr-bench.json --master-board acorn --duration 20 --output build/after-stimuli
+python3 tools/wr_loop_response.py --config build/wr-bench.json --master acorn --passive 300 --output build/temperature-spec
+python3 tools/wr_loop_analysis.py build/temperature-spec
+python3 tools/wr_jtag.py --config build/wr-bench.json stop
+```
+
+Dynamic runs stop PTP, configure roles and apply phase/frequency stimuli at
+half, normal and double PI gain. Cleanup restores saved PI gains, the requested
+master trim and PTP. Run the qualifier afterward to check reacquisition.
+Passive runs observe the existing roles. The capture tool holds the shared
+bench lock and records UART/FIFO data, commands, sensors, diagnostics and input
+hashes under `--output`. Keep these generated files outside version control.
+
+The firmware's optional `pll step <absolute_ps>` command applies an atomic
+phase step and emits 640 native main-loop samples before resuming decimation.
+It requires stopped PTP and main lock, refuses overlapping bursts, and limits
+each step to 500 ps. Drain the FIFO before injecting. Existing `pll sps` slews
+the setpoint. Decimation affects logging only, not the controller update rate.
+The runner excludes initial backlog after a ten-second warm-up and rejects
+sample gaps or incomplete native captures.
+
+## Interpret the output
+
+Analysis fits a discrete PI controller, integrating oscillator and first-order
+actuator lag. Reported loop margins depend on this model; bootstrap intervals
+exclude model/systematic error. Internal phase traces do not establish physical
+PPS alignment or jitter. XADC measures FPGA die temperature, not oscillator or
+ambient temperature. Those measurements require external instruments/probes
+and calibration with the intended final FPGA image.

--- a/doc/wr_usb_bench.md
+++ b/doc/wr_usb_bench.md
@@ -1,0 +1,89 @@
+# Acorn / SPEC-A7 USB bench
+
+This profile connects Acorn SFP0 to **SPEC J12 / SFP0**, with UART and JTAG
+through each board's FT4232H USB interface. It uses uRV/private 128 KiB RAM,
+Acorn MMCM tuning, and SPEC RefClk DAC ×2 / DMTD DAC ×1.
+
+## Build and connect
+
+Install the dependency revisions in [wr_bench_sources.json](wr_bench_sources.json),
+Vivado, GHDL, pyserial, OpenOCD and openFPGALoader. Build sequentially because
+the targets share the generated firmware filename:
+
+```sh
+python3 tools/build_wr_bench.py --board acorn --output build/bench-acorn
+python3 tools/build_wr_bench.py --board spec --output build/bench-spec
+```
+
+The helper verifies dependency revisions, builds firmware from the pinned WRPC
+sources, disables firmware SPI writes/erases, and keeps calibration updates in
+RAM. It saves the programming image, firmware, CSR map, hashes and timing
+report under the output directory.
+
+Copy `doc/wr_bench.example.json` to `build/wr-bench.json`. Paths are relative to
+the configuration file. Replace USB locations and UART paths; UART uses
+FT4232H interface 2 and JTAG uses channel 0. Derive each board's `master_trim`
+using the procedure below and add that integer field to its local configuration.
+
+Stop managed servers before programming. Resolve each USB location under
+`/sys/bus/usb/devices/` to its `busnum` and `devnum`, then load one board at a
+time using those numbers as `BUS:DEVICE`:
+
+```sh
+python3 tools/wr_jtag.py --config build/wr-bench.json stop
+openFPGALoader --cable ft4232 --busdev-num BUS:DEVICE --freq 5000000 --bitstream build/bench-acorn/gateware/sqrl_acorn.bit
+openFPGALoader --cable ft4232 --busdev-num BUS:DEVICE --freq 5000000 --bitstream build/bench-spec/gateware/spec_a7_wr_nic.bin
+```
+
+These commands program SRAM. For the physical XC7A35T SPEC, use the converted
+`.bin`, not the raw 50T `.bit`. Keep each image's matching `csr.csv`.
+
+## Derive the master trim
+
+Through UART, stop PTP and the PLL loops on both boards and hold both actuators
+at midscale:
+
+```text
+ptp stop
+pll init 0 0 0
+pll sdac 0 32768
+pll sdac -1 32768
+freqmon rx
+freqmon
+```
+
+For each board in turn, leave the peer at midscale and sweep main channel 0
+with `pll sdac 0 CODE`. At each point issue `freqmon rx`, allow the frequency
+to settle, then read `freqmon`. Save CSV columns `board,code,ref_hz,rx_hz`, with
+board names `acorn` and `spec`. Include Acorn code 32768, SPEC code 0, at least
+three codes in each linear region, and SPEC's upper plateau. Restore midscale
+before changing boards. Inspect the sweep to select `LINEAR_MAX` and
+`PLATEAU_MIN` for this SPEC:
+
+```sh
+python3 tools/wr_trim.py build/main-sweep.csv --spec-linear-max LINEAR_MAX --spec-plateau-min PLATEAU_MIN > build/trim-fit.json
+```
+
+The fit uses reciprocal REF/RX ratios and centers SPEC's usable range. Copy
+its per-board `master_trim` values into the local configuration. These are
+relative measurements; an independent reference is needed for absolute
+frequency calibration. The reported slopes use ppm/code.
+
+## Check both roles
+
+```sh
+python3 tools/wr_jtag.py --config build/wr-bench.json start
+python3 tools/wr_qualify.py --config build/wr-bench.json --master-board acorn --configure --duration 120 --output build/check-acorn-master
+python3 tools/wr_qualify.py --config build/wr-bench.json --master-board spec --configure --duration 120 --output build/check-spec-master
+python3 tools/wr_jtag.py --config build/wr-bench.json stop
+```
+
+`--configure` applies the selected master's trim and restarts PTP. The checker
+waits for WR acquisition before starting the requested tracking interval. It
+checks UART GUI frames, JTAG diagnostics, roles, PLL locks, phase tracking,
+time/servo progress and RX errors. Internal tracking checks do not establish
+independent PPS alignment or jitter.
+
+Keep the manager's state directory across interruptions: it records process
+ownership for cleanup and shares a lock with the checker. Captures and build
+outputs belong outside version control.

--- a/doc/wr_usb_bench.md
+++ b/doc/wr_usb_bench.md
@@ -87,3 +87,6 @@ independent PPS alignment or jitter.
 Keep the manager's state directory across interruptions: it records process
 ownership for cleanup and shares a lock with the checker. Captures and build
 outputs belong outside version control.
+
+For optional native PLL traces and XADC capture, see
+[SoftPLL capture tools](wr_loop_response.md).

--- a/litex_wr_nic/firmware/build.py
+++ b/litex_wr_nic/firmware/build.py
@@ -87,7 +87,7 @@ def checkout_commit(target="spec_a7"):
     # only those owned files so repeated uRV/VexRiscv builds cannot leak flags.
     run_command(
         f"git checkout {COMMIT_HASH} -- Makefile arch/risc-v/crt0.S arch/risc-v/irq_helper.c "
-        "include/board.h dev/sfp.c",
+        "include/board.h dev/sfp.c dev/spi_flash.c dev/storage-cal.c",
         cwd=CLONE_DIR)
 
     # Acorn's MMCM actuator needs more tracking bandwidth than the old
@@ -145,7 +145,7 @@ def configure_cpu_profile(cpu_type):
         "#endif\n\n",
     )
 
-def configure_source_fixes():
+def configure_source_fixes(read_only_storage=False):
     """Apply compatibility fixes to the pinned WRPC sources."""
     from litex_wr_nic.gateware.wr_common import _replace_once
     def patch(name, before, after):
@@ -164,11 +164,28 @@ def configure_source_fixes():
         "\tif (match <= 0) {\n\t\tsfp_info.sfp_in_db = SFP_NOT_MATCHED;\n"
         "\t\treturn match < 0 ? match : -ENXIO;")
 
+    if read_only_storage:
+        # SRAM qualification must not silently save automatic PHY/RX calibration.
+        # Keep new calibration in RAM, and reject all SPI flash writes/erases,
+        # including commands from an existing startup script.
+        patch("dev/storage-cal.c", "return storage_save_calibration();",
+            "/* SRAM qualification: the updated calibration remains in RAM. */\n\treturn 0;")
+        patch("dev/spi_flash.c", '#include "wrc-debug.h"',
+            '#include <errno.h>\n#include "wrc-debug.h"')
+        for signature, result in (
+            ("int spi_flash_write(struct spi_flash_device *dev, uint32_t addr, uint8_t *buf, int count)", "-EROFS"),
+            ("int spi_flash_erase(struct spi_flash_device *dev, uint32_t addr, int count)", "-EROFS"),
+            ("void spi_flash_erase_sector(struct spi_flash_device *dev, uint32_t addr)", ""),
+        ):
+            patch("dev/spi_flash.c", signature + "\n{",
+                signature + "\n{\n\t/* SRAM qualification: persistent flash is read-only. */\n"
+                + (f"\treturn {result};\n" if result else "\treturn;\n"))
 
-def build_firmware(cpu_type):
+
+def build_firmware(cpu_type, read_only_storage=False):
     """Build the firmware."""
     configure_cpu_profile(cpu_type)
-    configure_source_fixes()
+    configure_source_fixes(read_only_storage)
     run_command("make clean", cwd=CLONE_DIR)
     run_command("make spec_a7_defconfig", cwd=CLONE_DIR)
     cpu_flags = "-DWR_CPU_VEXRISCV" if cpu_type == "vexriscv" else ""
@@ -218,6 +235,8 @@ def main():
     parser.add_argument("--target", default="spec_a7", help="Target Board.", choices=["spec_a7", "acorn"])
     parser.add_argument("--wr-cpu-type", default="urv", choices=WR_CPU_TYPES,
         help="WR CPU firmware profile (default: urv).")
+    parser.add_argument("--read-only-storage", action="store_true",
+        help="Retain calibration in RAM and disable firmware SPI flash writes/erases.")
     args = parser.parse_args()
 
     init_riscv_toolchain()
@@ -225,7 +244,7 @@ def main():
     clone_repository()
     checkout_commit(args.target)
     copy_config_file()
-    build_firmware(args.wr_cpu_type)
+    build_firmware(args.wr_cpu_type, args.read_only_storage)
     copy_firmware(args.wr_cpu_type)
     build_sdbfs()
     print("Build process completed successfully.")

--- a/litex_wr_nic/firmware/build.py
+++ b/litex_wr_nic/firmware/build.py
@@ -87,7 +87,8 @@ def checkout_commit(target="spec_a7"):
     # only those owned files so repeated uRV/VexRiscv builds cannot leak flags.
     run_command(
         f"git checkout {COMMIT_HASH} -- Makefile arch/risc-v/crt0.S arch/risc-v/irq_helper.c "
-        "include/board.h dev/sfp.c dev/spi_flash.c dev/storage-cal.c",
+        "include/board.h dev/sfp.c dev/spi_flash.c dev/storage-cal.c "
+        "softpll/spll_helper.c softpll/softpll_ng.c shell/cmd_pll.c",
         cwd=CLONE_DIR)
 
     # Acorn's MMCM actuator needs more tracking bandwidth than the old
@@ -182,10 +183,56 @@ def configure_source_fixes(read_only_storage=False):
                 + (f"\treturn {result};\n" if result else "\treturn;\n"))
 
 
-def build_firmware(cpu_type, read_only_storage=False):
+def configure_pll_trace(decimation=0):
+    """Emit complete main/helper samples without changing the controller rate."""
+    if not decimation:
+        return
+    if decimation < 1 or decimation > 1024 or decimation & (decimation - 1):
+        raise ValueError("PLL trace decimation must be a power of two from 1 to 1024")
+    from litex_wr_nic.gateware.wr_common import _replace_once
+    main = Path(CLONE_DIR) / "softpll/spll_main.c"
+    text = main.read_text()
+    start = text.index("\tspll_debug(s->dbg_src_id, SPLL_DBG_SIGNAL_PHASE_CURRENT,")
+    end = text.index("\n\n\t/* Wait for both out and ref tags */", start)
+    block = text[start:end]
+    gated = (f"\tif (spll_trace_burst || (s->sample_n & {decimation - 1}) == 0) {{\n"
+        + f"\t\tspll_debug(s->dbg_src_id, 11, spll_trace_burst ? 1 : {decimation}, 0);\n"
+        + "\n".join("\t" + line for line in block.replace("s->sample_n++", "s->sample_n").splitlines())
+        + "\n\t}\n\tif (spll_trace_burst) spll_trace_burst--;\n\ts->sample_n++;")
+    _replace_once(str(main), block, gated)
+    _replace_once(str(main), "#undef WITH_SEQUENCING",
+        "unsigned spll_trace_burst;\n\n#undef WITH_SEQUENCING")
+    helper = Path(CLONE_DIR) / "softpll/spll_helper.c"
+    text = helper.read_text()
+    start = text.index("\t//spll_debug(SPLL_DBG_SRC_HELPER, SPLL_DBG_SIGNAL_TIME_MS,")
+    end = text.index("\n\n\tld_update", start)
+    block = text[start:end]
+    gated = (f"\tif ((s->sample_n & {decimation - 1}) == 0) {{\n"
+        + f"\t\tspll_debug(SPLL_DBG_SRC_HELPER, 11, {decimation}, 0);\n"
+        + "\n".join("\t" + line for line in block.replace("//spll_debug", "spll_debug").replace("s->sample_n++", "s->sample_n").splitlines())
+        + "\n\t}\n\ts->sample_n++;")
+    _replace_once(str(helper), block, gated)
+    shutil.copy2(Path(__file__).with_name("pll_trace_step.h"),
+        Path(CLONE_DIR) / "softpll/litex_pll_trace_step.h")
+    _replace_once(str(Path(CLONE_DIR) / "softpll/softpll_ng.c"),
+        "volatile struct softpll_state softpll;",
+        'volatile struct softpll_state softpll;\n#include "litex_pll_trace_step.h"')
+    shell = str(Path(CLONE_DIR) / "shell/cmd_pll.c")
+    _replace_once(shell, '#include "wrc.h"',
+        '#include "wrc.h"\n#include "wrpc.h"\nextern int spll_debug_step(int phase_ps);')
+    _replace_once(shell, "#define CMD_GAIN 9", "#define CMD_GAIN 9\n#define CMD_STEP 10")
+    _replace_once(shell, '\t[CMD_GAIN] = "gain",', '\t[CMD_GAIN] = "gain",\n\t[CMD_STEP] = "step",')
+    _replace_once(shell, '\t[CMD_GAIN] = 5,', '\t[CMD_GAIN] = 5,\n\t[CMD_STEP] = 1,')
+    _replace_once(shell, '\tcase CMD_GAIN:',
+        '\tcase CMD_STEP:\n\t\tif (wrc_ptp_run(-1)) return -EBUSY;\n'
+        '\t\treturn spll_debug_step(vals[1]);\n\tcase CMD_GAIN:')
+
+
+def build_firmware(cpu_type, read_only_storage=False, pll_trace_decimation=0):
     """Build the firmware."""
     configure_cpu_profile(cpu_type)
     configure_source_fixes(read_only_storage)
+    configure_pll_trace(pll_trace_decimation)
     run_command("make clean", cwd=CLONE_DIR)
     run_command("make spec_a7_defconfig", cwd=CLONE_DIR)
     cpu_flags = "-DWR_CPU_VEXRISCV" if cpu_type == "vexriscv" else ""
@@ -237,6 +284,8 @@ def main():
         help="WR CPU firmware profile (default: urv).")
     parser.add_argument("--read-only-storage", action="store_true",
         help="Retain calibration in RAM and disable firmware SPI flash writes/erases.")
+    parser.add_argument("--pll-trace-decimation", type=int, default=0,
+        help="Emit every Nth main/helper PLL sample (power of two, 1..1024; 0 keeps upstream tracing).")
     args = parser.parse_args()
 
     init_riscv_toolchain()
@@ -244,7 +293,7 @@ def main():
     clone_repository()
     checkout_commit(args.target)
     copy_config_file()
-    build_firmware(args.wr_cpu_type, args.read_only_storage)
+    build_firmware(args.wr_cpu_type, args.read_only_storage, args.pll_trace_decimation)
     copy_firmware(args.wr_cpu_type)
     build_sdbfs()
     print("Build process completed successfully.")

--- a/litex_wr_nic/firmware/pll_trace_step.h
+++ b/litex_wr_nic/firmware/pll_trace_step.h
@@ -1,0 +1,37 @@
+/* Optional bench instrumentation, included after softpll in softpll_ng.c.
+ * Copyright (c) 2026 Enjoy-Digital. SPDX-License-Identifier: BSD-2-Clause
+ */
+extern unsigned spll_trace_burst;
+extern int reverse_spll;
+int spll_debug_step(int phase_ps);
+
+int spll_debug_step(int phase_ps)
+{
+	struct spll_main_state *s = (struct spll_main_state *)&softpll.mpll;
+	int delta, old_target;
+
+	/* Bound conversion arithmetic and reject injections during acquisition. */
+	if (phase_ps < -16000 || phase_ps > 16000)
+		return -EINVAL;
+	disable_irq();
+	if (!s->locked || spll_trace_burst) {
+		enable_irq();
+		return -EBUSY;
+	}
+	old_target = s->phase_shift_target;
+	mpll_set_phase_shift(s, phase_ps);
+	delta = s->phase_shift_target - s->phase_shift_current;
+	/* At 62.5 MHz, limit each step to 500 ps, below the lock threshold. */
+	if (delta < -512 || delta > 512) {
+		s->phase_shift_target = old_target;
+		enable_irq();
+		return -EINVAL;
+	}
+	s->adder_ref += reverse_spll ? -delta : delta;
+	s->phase_shift_current = s->phase_shift_target;
+	/* At decimation 16, 640 main samples plus helper records fit the FIFO.
+	 * Drain the FIFO before each injection. Decimation resumes automatically. */
+	spll_trace_burst = 640;
+	enable_irq();
+	return 0;
+}

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic.vhd
@@ -51,6 +51,7 @@ entity xwrc_board_litex_wr_nic is
   generic(
     -- Select whether to include external ref clock input
     g_with_external_clock_input : boolean              := TRUE;
+    g_softpll_enable_debugger   : boolean              := FALSE;
     -- Board name
     g_board_name                : string               := "NA  ";
     -- FPGA family
@@ -428,7 +429,7 @@ begin  -- architecture struct
       g_interface_mode            => PIPELINED,
       g_address_granularity       => BYTE,
       g_aux_sdb                   => c_wrc_periph3_sdb,
-      g_softpll_enable_debugger   => FALSE,
+      g_softpll_enable_debugger   => g_softpll_enable_debugger,
       g_vuart_fifo_size           => 1024,
       g_pcs_16bit                 => TRUE,
       g_diag_id                   => g_diag_id,

--- a/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
+++ b/litex_wr_nic/gateware/wr-cores/board/litex_wr_nic/xwrc_board_litex_wr_nic_wrapper.vhd
@@ -26,6 +26,7 @@ entity xwrc_board_litex_wr_nic_wrapper is
   generic(
     -- Select whether to include external ref clock input
     g_with_external_clock_input : boolean := TRUE;
+    g_softpll_enable_debugger   : boolean := FALSE;
     -- Board name
     g_board_name                : string  := "NA  ";
     -- FPGA family
@@ -300,6 +301,7 @@ begin
   u_xwrc_board_litex_wr_nic : entity work.xwrc_board_litex_wr_nic
     generic map (
       g_with_external_clock_input => g_with_external_clock_input,
+      g_softpll_enable_debugger   => g_softpll_enable_debugger,
       g_board_name                => g_board_name,
       g_fpga_family               => g_fpga_family,
       g_aux_clks                  => g_aux_clks,

--- a/litex_wr_nic/gateware/wr_common.py
+++ b/litex_wr_nic/gateware/wr_common.py
@@ -525,6 +525,7 @@ wr_core_files += [
     "wr-cores/modules/wr_softpll_ng/spll_aligner.vhd",
     "wr-cores/modules/wr_softpll_ng/spll_wb_slave.vhd",
     "wr-cores/modules/wr_softpll_ng/spll_wbgen2_pkg.vhd",
+    "wr-cores/modules/wr_softpll_ng/spll_host_map.vhd",
     "wr-cores/modules/wr_softpll_ng/xwr_softpll_ng.vhd",
 
     # WR Streamers Modules.

--- a/litex_wr_nic/gateware/wr_core.py
+++ b/litex_wr_nic/gateware/wr_core.py
@@ -75,6 +75,7 @@ class WhiteRabbitCore(LiteXModule):
         # Clocking.
         qpll         = None,
         with_ext_clk = True,
+        with_softpll_debug = False,
 
         # Serial.
         serial_pads = None,
@@ -254,6 +255,7 @@ class WhiteRabbitCore(LiteXModule):
             p_txpolarity                  = sfp_tx_polarity,
             p_rxpolarity                  = sfp_rx_polarity,
             p_g_with_external_clock_input = int(with_ext_clk),
+            p_g_softpll_enable_debugger   = int(with_softpll_debug),
             p_g_fpga_family               = {True: "artix7", False: "kintex7"}[self.platform.device.startswith("xc7a")],
             p_g_board_name                = board_name,
             p_g_dac_bits                  = dac_bits,

--- a/spec_a7_wr_nic.py
+++ b/spec_a7_wr_nic.py
@@ -128,6 +128,7 @@ class BaseSoC(LiteXWRNICSoC):
         wr_cpu_type               = "urv",
         wr_cpu_variant            = None,
         wr_cpu_memory             = "private",
+        with_wr_pll_debug         = False,
 
         # Sync-In Parameters.
         # -------------------
@@ -241,6 +242,10 @@ class BaseSoC(LiteXWRNICSoC):
             wr_cpu_ready = wr_cpu_loader.ready
             self.add_config("WR_CPU_CACHE_SIZE", 8*KILOBYTE)
 
+        if with_wr_pll_debug:
+            from litex.soc.cores.xadc import S7SystemMonitor
+            self.xadc = S7SystemMonitor()
+
         # UART -------------------------------------------------------------------------------------
 
         self.uart = UARTShared(pads=platform.request("serial"), sys_clk_freq=sys_clk_freq)
@@ -308,6 +313,7 @@ class BaseSoC(LiteXWRNICSoC):
 
                 # Board name.
                 board_name       = "SPA7",
+                with_softpll_debug = with_wr_pll_debug,
 
                 # SFP.
                 sfp_pads         = platform.request("sfp",     white_rabbit_sfp_connector),
@@ -611,9 +617,13 @@ class BaseSoC(LiteXWRNICSoC):
 
         # PCIe NIC ---------------------------------------------------------------------------------
 
-        if with_pcie and with_white_rabbit:
+        # The 8192-word SPLL trace needs the RAM otherwise used by the NIC.
+        # Retain the PCIe PHY/QPLL clock arrangement in the USB debug profile.
+        if with_pcie and with_white_rabbit and not with_wr_pll_debug:
             self.add_pcie_nic(pcie_phy=self.pcie_phy, eth_phys=[self.ethphy0], with_timing_constraints=False)
             self.add_pcie_ptm()
+        elif with_pcie and with_white_rabbit:
+            self.comb += self.ethphy0.source.ready.eq(1)
 
         # Etherbone --------------------------------------------------------------------------------
 
@@ -622,7 +632,7 @@ class BaseSoC(LiteXWRNICSoC):
 
         # Time Generator ---------------------------------------------------------------------------
 
-        if with_pcie and with_white_rabbit:
+        if with_pcie and with_white_rabbit and not with_wr_pll_debug:
             # Time Generator.
             self.time_generator = TimeGenerator(
                 clk_domain = "wr",
@@ -691,6 +701,8 @@ def main():
 
     # Build/Load/Flash Arguments.
     # ---------------------------
+    parser.add_argument("--with-wr-pll-debug", action="store_true",
+        help="Enable the SoftPLL FIFO and FPGA sensors; omit PCIe NIC/PTM/time generator to fit RAM.")
     parser.add_argument("--build", action="store_true", help="Build bitstream.")
     parser.add_argument("--load",  action="store_true", help="Load bitstream.")
     parser.add_argument("--flash", action="store_true", help="Flash bitstream.")
@@ -735,6 +747,7 @@ def main():
         wr_cpu_type    = args.wr_cpu_type,
         wr_cpu_variant = args.wr_cpu_variant,
         wr_cpu_memory  = args.wr_cpu_memory,
+        with_wr_pll_debug = args.with_wr_pll_debug,
     )
     if args.with_wishbone_fabric_interface_probe:
         soc.add_wishbone_fabric_interface_probe()

--- a/test/test_firmware_fixes.py
+++ b/test/test_firmware_fixes.py
@@ -29,7 +29,7 @@ def firmware(tmp_path, monkeypatch):
     spec = importlib.util.spec_from_file_location('wr_build', ROOT / 'litex_wr_nic/firmware/build.py')
     build = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(build)
-    for name in ('include/board.h', 'dev/sfp.c'):
+    for name in ('include/board.h', 'dev/sfp.c', 'dev/spi_flash.c', 'dev/storage-cal.c'):
         path = tmp_path / name
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(subprocess.check_output(['git', '-C', str(SOURCE), 'show', build.COMMIT_HASH + ':' + name]))
@@ -97,3 +97,47 @@ def test_diagnostics_use_cpu_map_not_host_map(firmware):
     expected = int(re.search(r'#define WRC_DEVICES_MAP_WDIAG (0x[0-9a-f]+)', cpu_map).group(1), 16)
     actual = int(re.search(r'#define BASE_WDIAGS_PRIV\s+\(DEV_BASE \+ (0x[0-9a-f]+)\)', board).group(1), 16)
     assert actual == expected == 0x800
+
+
+def test_read_only_firmware_retains_calibration_without_writes(firmware):
+    build, path = firmware
+    build.configure_source_fixes(read_only_storage=True)
+    contents = {p: p.read_text() for p in path.rglob('*.c')}
+    build.configure_source_fixes(read_only_storage=True)
+    assert all(p.read_text() == text for p, text in contents.items())
+    flash = (path / 'dev/spi_flash.c').read_text()
+    cal = (path / 'dev/storage-cal.c').read_text()
+    prefix = r'''
+#include <stdint.h>
+#include <errno.h>
+#include <assert.h>
+struct spi_flash_device { void *bus; int use_4byte_addr; int sector_size; };
+static int spi_accesses, saved, set_result;
+static uint32_t parameter, value;
+void bb_spi_cs(void *bus, int level) { spi_accesses++; }
+void bb_spi_write(void *bus, int val, int count) { spi_accesses++; }
+void bb_spi_delay(void *bus) { spi_accesses++; }
+void spi_flash_write_addr(struct spi_flash_device *dev, uint32_t addr) { spi_accesses++; }
+int spi_flash_rsr(struct spi_flash_device *dev) { spi_accesses++; return 0; }
+int storage_set_calibration_parameter(uint32_t id, uint32_t val) { parameter=id; value=val; return set_result; }
+int storage_save_calibration(void) { saved++; return 0; }
+'''
+    code = '\n'.join(function(flash, name) for name in ('spi_flash_write', 'spi_flash_erase_sector', 'spi_flash_erase'))
+    code += function(cal, 'storage_set_calibration_parameter_and_save')
+    checks = r'''
+int main(void) {
+    struct spi_flash_device dev = {.sector_size = 65536}; uint8_t byte = 0;
+    assert(spi_flash_write(&dev, 0, &byte, 1) == -EROFS);
+    assert(spi_flash_erase(&dev, 0, 65536) == -EROFS);
+    spi_flash_erase_sector(&dev, 0);
+    assert(spi_accesses == 0);
+    assert(storage_set_calibration_parameter_and_save(7, 1234) == 0);
+    assert(parameter == 7 && value == 1234 && saved == 0);
+    set_result = -1;
+    assert(storage_set_calibration_parameter_and_save(7, 5678) == -1);
+    assert(saved == 0);
+    return 0;
+}
+'''
+    result = run_c(path, prefix + code + checks)
+    assert result.returncode == 0, result.stderr

--- a/test/test_pll_trace_step.py
+++ b/test/test_pll_trace_step.py
@@ -1,0 +1,41 @@
+"""Exercise the actual optional injection helper without an FPGA."""
+from pathlib import Path
+import subprocess
+
+
+def test_phase_step_bounds_atomicity_and_polarity(tmp_path):
+    header = Path(__file__).resolve().parents[1] / 'litex_wr_nic/firmware/pll_trace_step.h'
+    source = r'''
+#include <assert.h>
+#include <errno.h>
+struct spll_main_state { int locked, phase_shift_target, phase_shift_current, adder_ref; };
+struct { struct spll_main_state mpll; } softpll;
+unsigned spll_trace_burst;
+int reverse_spll = 1, irq_disabled;
+void disable_irq(void) { assert(!irq_disabled); irq_disabled=1; }
+void enable_irq(void) { assert(irq_disabled); irq_disabled=0; }
+void mpll_set_phase_shift(struct spll_main_state *s, int ps) { s->phase_shift_target=ps*16384/16000; }
+''' + '#include "' + str(header) + '"\n' + r'''
+int main(void) {
+    assert(spll_debug_step(256)==-EBUSY && !irq_disabled);
+    softpll.mpll.locked=1;
+    assert(spll_debug_step(256)==0 && !irq_disabled);
+    assert(softpll.mpll.phase_shift_current==262);
+    assert(softpll.mpll.phase_shift_target==262 && softpll.mpll.adder_ref==-262);
+    assert(spll_trace_burst==640);
+    assert(spll_debug_step(0)==-EBUSY && !irq_disabled);
+    spll_trace_burst=0;
+    assert(spll_debug_step(2000)==-EINVAL && !irq_disabled);
+    assert(softpll.mpll.phase_shift_target==262 && softpll.mpll.adder_ref==-262);
+    assert(spll_debug_step(0)==0 && softpll.mpll.adder_ref==0);
+    spll_trace_burst=0; reverse_spll=0;
+    assert(spll_debug_step(-256)==0 && softpll.mpll.adder_ref==-262);
+    assert(spll_debug_step(2147483647)==-EINVAL && !irq_disabled);
+    return 0;
+}
+'''
+    c = tmp_path / 'step.c'
+    c.write_text(source)
+    executable = tmp_path / 'step'
+    subprocess.run(['cc', '-std=c99', '-Wall', '-Werror', str(c), '-o', str(executable)], check=True)
+    subprocess.run([str(executable)], check=True)

--- a/test/test_wr_bench_build.py
+++ b/test/test_wr_bench_build.py
@@ -1,0 +1,53 @@
+"""A successful Vivado build must still produce a usable board image and map."""
+import hashlib
+import importlib.util
+from pathlib import Path
+import subprocess
+
+import pytest
+
+spec = importlib.util.spec_from_file_location('wr_bench_build', Path(__file__).resolve().parents[1] / 'tools/build_wr_bench.py')
+build = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build)
+
+
+@pytest.fixture
+def generated(tmp_path, monkeypatch):
+    monkeypatch.setattr(build, 'ROOT', tmp_path)
+    (tmp_path / 'test').mkdir()
+    (tmp_path / 'test/csr.csv').write_text('csr_register,refclk_dac_current,0xf000a80c,1,ro\n')
+    output = tmp_path / 'output'
+    (output / 'gateware').mkdir(parents=True)
+    (output / 'gateware/board_timing.rpt').write_text('All user specified timing constraints are met.')
+    return output
+
+
+@pytest.mark.parametrize('board', ['acorn', 'spec'])
+def test_build_only_outputs_become_programmable(board, generated, monkeypatch):
+    image = generated / 'gateware' / ('sqrl_acorn.bit' if board == 'acorn' else 'spec_a7_wr_nic.bit')
+    image.write_bytes(b'Vivado output')
+    def convert(command, **kwargs):
+        assert board == 'spec'
+        assert Path(command[-2]) == image
+        assert Path(command[-1]) == image.with_suffix('.bin')
+        assert kwargs['check'] is True
+        Path(command[-1]).write_bytes(b'Converted 35T image')
+    monkeypatch.setattr(build.subprocess, 'run', convert)
+    hashes = build.finish_build(board, generated)
+    expected_image = image if board == 'acorn' else image.with_suffix('.bin')
+    assert str(expected_image.relative_to(generated)) in hashes
+    assert (generated / 'csr.csv').read_bytes() == (build.ROOT / 'test/csr.csv').read_bytes()
+    assert hashes['csr.csv'] == hashlib.sha256((generated / 'csr.csv').read_bytes()).hexdigest()
+
+
+def test_converter_failure_is_not_a_successful_build(generated, monkeypatch):
+    def fail(command, **kwargs):
+        raise subprocess.CalledProcessError(1, command)
+    monkeypatch.setattr(build.subprocess, 'run', fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        build.finish_build('spec', generated)
+
+
+def test_missing_programming_image_is_rejected(generated):
+    with pytest.raises(RuntimeError, match='programming image'):
+        build.finish_build('acorn', generated)

--- a/test/test_wr_console.py
+++ b/test/test_wr_console.py
@@ -1,0 +1,41 @@
+"""An asynchronous prompt redraw must not acknowledge a command prematurely."""
+
+import importlib.util
+from pathlib import Path
+
+
+def test_command_waits_for_its_echo_and_completion_prompt(monkeypatch):
+    path = Path(__file__).resolve().parents[1] / "tools/wr_console.py"
+    spec = importlib.util.spec_from_file_location("wr_console_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    console = module.Console.__new__(module.Console)
+    responses = iter(
+        ["asynchronous log\nwrc# ", "asynchronous log\nwrc# ptp\nrunning; e2e master\nwrc# "]
+    )
+    monkeypatch.setattr(console, "text", lambda start: next(responses))
+    monkeypatch.setattr(console, "record", lambda *args: None)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    response = console.prompt(0, command="ptp")
+    assert "running; e2e master" in response
+
+
+def test_diagnostic_between_echo_characters_does_not_hide_completion(monkeypatch):
+    path = Path(__file__).resolve().parents[1] / "tools/wr_console.py"
+    spec = importlib.util.spec_from_file_location("wr_console_interleaving_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    console = module.Console.__new__(module.Console)
+    # Captured during a real Acorn PCS interruption. An old prompt still
+    # cannot acknowledge the command before the remaining echo arrives.
+    responses = iter([
+        "vdiag-fsm-1-wr0: 000000127.819: LEAVE slave (next:   3)\n\nwrc# ",
+        "vdiag-fsm-1-wr0: 000000127.819: LEAVE slave (next:   3)\n\n"
+        "er\nWR Core build: v8.0-126-gbaf77496-dirty\nwrc# ",
+    ])
+    monkeypatch.setattr(console, "text", lambda start: next(responses))
+    monkeypatch.setattr(console, "record", lambda *args: None)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    response = console.prompt(0, command="ver")
+    assert "WR Core build:" in response
+    assert "diag-fsm-1-wr0:" in response

--- a/test/test_wr_jtag.py
+++ b/test/test_wr_jtag.py
@@ -1,0 +1,67 @@
+"""Persistent ownership must survive an orphan without signaling reused PIDs."""
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+spec = importlib.util.spec_from_file_location('wr_jtag', Path(__file__).resolve().parents[1] / 'tools/wr_jtag.py')
+jtag = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(jtag)
+
+
+def record(tmp_path, boot=None):
+    path = tmp_path / 'owner.json'
+    jtag.write_record(path, dict(
+        boot_id=boot or Path('/proc/sys/kernel/random/boot_id').read_text().strip(),
+        group=9001, members=[dict(pid=9001, started='100'), dict(pid=9002, started='101')]))
+    return path
+
+
+def test_old_boot_does_not_signal_processes(tmp_path, monkeypatch):
+    kill = Mock()
+    monkeypatch.setattr(jtag.os, 'killpg', kill)
+    path = record(tmp_path, 'old-boot')
+    jtag.stop(path)
+    kill.assert_not_called()
+    assert not path.exists()
+
+
+def test_pid_reuse_refuses_cleanup(tmp_path, monkeypatch):
+    kill = Mock()
+    monkeypatch.setattr(jtag.os, 'killpg', kill)
+    monkeypatch.setattr(jtag, 'members', lambda group: [dict(pid=9001, started='200')])
+    path = record(tmp_path)
+    with pytest.raises(RuntimeError, match='unverified'):
+        jtag.stop(path)
+    kill.assert_not_called()
+    assert path.exists()
+
+
+def test_persisted_child_allows_cleanup_after_leader_dies(tmp_path, monkeypatch):
+    live = [dict(pid=9002, started='101')]
+    signals = []
+    def kill(group, signal):
+        signals.append((group, signal))
+        live.clear()
+    monkeypatch.setattr(jtag.os, 'killpg', kill)
+    monkeypatch.setattr(jtag, 'members', lambda group: live[:])
+    path = record(tmp_path)
+    jtag.stop(path)
+    assert signals == [(9001, jtag.signal.SIGTERM)]
+    assert not path.exists()
+
+
+def test_config_paths_and_unique_ports(tmp_path):
+    config = dict(state_dir='state', boards=dict(acorn=dict(csr='csr.csv',
+        uart='/dev/serial/by-path/board', jtag_config='jtag.cfg', jtag_port=1235, stream_port=20001)))
+    path = tmp_path / 'bench.json'
+    path.write_text(json.dumps(config))
+    loaded = jtag.load_config(path)
+    assert loaded['boards']['acorn']['csr'] == str(tmp_path / 'csr.csv')
+    assert loaded['boards']['acorn']['uart'] == '/dev/serial/by-path/board'
+    config['boards']['acorn']['stream_port'] = 1235
+    path.write_text(json.dumps(config))
+    with pytest.raises(ValueError, match='distinct'):
+        jtag.load_config(path)

--- a/test/test_wr_loop_analysis.py
+++ b/test/test_wr_loop_analysis.py
@@ -1,0 +1,21 @@
+"""Check the fitted model against a closed-form discrete one-pole loop."""
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'tools'))
+from wr_loop_analysis import margins, model_response
+
+
+def test_proportional_integrating_plant_matches_closed_form():
+    gain, kp, rate = 1.2, .15, 3814.697265625
+    product = gain * kp
+    expected = -(1-product)**np.arange(100)
+    np.testing.assert_allclose(model_response(100, gain, 0, kp, 0), expected)
+    result = margins(gain, 0, kp, 0, rate)
+    angle = 2*np.arcsin(product/2)
+    assert result['crossover_hz'] == pytest.approx(angle*rate/(2*np.pi), rel=2e-4)
+    assert result['phase_margin_deg'] == pytest.approx(90-angle*90/np.pi, abs=.01)
+    assert result['gain_margin_db'] == pytest.approx(20*np.log10(2/product), abs=.01)

--- a/test/test_wr_pll_trace.py
+++ b/test/test_wr_pll_trace.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[1] / 'tools'
+sys.path.insert(0, str(TOOLS))
+from wr_pll_trace import Decoder, MODULUS, Trace
+
+
+def packet(source, sample, milliseconds, error=-17, dac=32768):
+    fields = [(7, milliseconds), (5, sample), (0, dac), (1, error)]
+    if source == 1:
+        fields[:0] = [(8, -100), (9, 200), (2, 16384), (3, 16385)]
+    words = [(source << 28) | (field << 24) | (value & (MODULUS - 1)) for field, value in fields]
+    words[-1] |= 0x80000000
+    return words
+
+
+def test_chunk_boundaries_signed_error_and_independent_sources():
+    decoder = Decoder(16)
+    main = packet(1, 200, 1000)
+    helper = packet(0, 300, 1001, error=31)
+    assert not decoder.feed(main[:3])
+    result = decoder.feed(main[3:] + helper)
+    assert [(f['source'], f['error'], f['dac']) for f in result] == [(1, -17, 32768), (0, 31, 32768)]
+    assert result[0]['phase_current'] == -100
+    assert decoder.gaps == decoder.discarded == 0
+
+
+def test_sample_and_timer_wrap_are_not_gaps():
+    decoder = Decoder(16)
+    decoder.feed(packet(1, MODULUS - 8, MODULUS - 2))
+    result = decoder.feed(packet(1, 8, 2))[0]
+    assert not result['gap']
+    assert result['sample'] == 16
+    assert result['elapsed_ms'] == 4
+
+
+def test_fifo_loss_and_restart_are_visible():
+    decoder = Decoder(16)
+    decoder.feed(packet(1, 200, 1000))
+    assert decoder.feed(packet(1, 232, 1008))[0]['gap']
+    assert decoder.feed(packet(1, 0, 1009))[0]['gap']
+    assert decoder.gaps == 2
+
+
+def test_event_and_initial_partial_packet_do_not_create_samples():
+    decoder = Decoder(16)
+    assert decoder.feed(packet(1, 200, 1000)[-2:]) == []
+    assert decoder.discarded == 1
+    assert decoder.feed([0x96000004]) == [{'source': 1, 'event': 4}]
+    assert decoder.samples == {}
+
+
+def test_duplicate_fields_and_mixed_sources_are_rejected():
+    decoder = Decoder(16)
+    data = packet(1, 200, 1000)
+    data[0] = data[1]
+    assert decoder.feed(data) == []
+    data = packet(1, 200, 1000)
+    data[0] &= ~(7 << 28)
+    assert decoder.feed(data) == []
+    assert decoder.discarded == 2
+
+
+def test_unframed_data_is_bounded():
+    with pytest.raises(ValueError, match='end-of-sample'):
+        Decoder(16).feed([0] * 33)
+
+
+def test_native_burst_transitions_and_losses():
+    decoder = Decoder(16)
+    def sample(n, stride):
+        return [(1 << 28) | (11 << 24) | stride] + packet(1, n, 1000)
+    decoder.feed(sample(16, 16))
+    assert not decoder.feed(sample(23, 1))[0]['gap']
+    assert not decoder.feed(sample(24, 1))[0]['gap']
+    assert decoder.feed(sample(26, 1))[0]['gap']
+    assert not decoder.feed(sample(32, 16))[0]['gap']
+    assert decoder.feed(sample(64, 16))[0]['gap']
+    assert decoder.gaps == 2
+
+
+def test_capture_summary_is_a_snapshot():
+    trace = Trace.__new__(Trace)
+    trace.decoder = Decoder(16)
+    trace.high_water = 0
+    trace.decoder.feed([(1 << 28) | (11 << 24) | 1] + packet(1, 16, 1000))
+    initial = trace.summary()
+    trace.decoder.feed([(1 << 28) | (11 << 24) | 1] + packet(1, 17, 1001))
+    assert initial['native_samples'] == {1: 1}
+    assert trace.summary()['native_samples'] == {1: 2}

--- a/test/test_wr_snapshot.py
+++ b/test/test_wr_snapshot.py
@@ -1,0 +1,51 @@
+"""Acquisition snapshots must be retained without qualifying invalid time."""
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+path = Path(__file__).resolve().parents[1] / 'tools/wr_status.py'
+spec = importlib.util.spec_from_file_location('wr_status_test', path)
+status = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(status)
+
+
+class SnapshotBus:
+    mems = SimpleNamespace(wr_wb_slave=SimpleNamespace(base=0))
+
+    def __init__(self, nanoseconds):
+        self.words = [0] * 25
+        self.words[0:5] = [2, 0x101, 0x401, 3, 9]
+        self.words[9:11] = [123, nanoseconds]
+        self.writes = []
+
+    def read(self, address, length=None):
+        if length:
+            return list(self.words[:length])
+        return self.words[(address - 0x900) // 4]
+
+    def write(self, address, value):
+        self.writes.append((address, value))
+
+
+@pytest.mark.parametrize('nanoseconds', [999999999, 1000000000, ((1 << 28) - 100) * 16])
+def test_snapshot_marks_wrapped_counter_time_invalid(nanoseconds):
+    bus = SnapshotBus(nanoseconds)
+    result = status.diagnostic_snapshot(bus)
+    assert result['raw'][10] == nanoseconds
+    assert result['time_valid'] == (nanoseconds < 1000000000)
+    assert result['tai_ns'] == (123000000000 + nanoseconds if nanoseconds < 1000000000 else None)
+    assert bus.writes[-1] == (0x904, 0)
+
+
+def test_invalid_time_cannot_start_or_pass_a_tracking_check():
+    common = dict(received=100, extension='IDLE', detection='EXT_ON', pll_locked=True,
+                  frequency_locked=True, servo='TRACK_PHASE')
+    master = dict(common, role='MASTER', mac='a', peer='b')
+    slave = dict(common, role='SLAVE', mac='b', peer='a')
+    md = dict(ptp_state=6, link=True, locked=True, tai_ns=123000000000)
+    sd = dict(md, ptp_state=9, servo_valid=True, servo_state=4, tai_ns=None)
+    assert 'slave: timestamp is not normalized' in status.qualification_errors(master, slave, md, sd, 101)
+    sd['tai_ns'] = 123500000000
+    assert status.qualification_errors(master, slave, md, sd, 101) == []

--- a/test/test_wr_trim.py
+++ b/test/test_wr_trim.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location('wr_trim', Path(__file__).resolve().parents[1] / 'tools/wr_trim.py')
+trim = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(trim)
+
+
+def sweep():
+    # Synthetic oscillators: Acorn midpoint is 26 ppm low; SPEC clips at
+    # code 40000. Each row's RX count includes a deliberate gate-scale error.
+    rows = []
+    for board in ('acorn', 'spec'):
+        for code in (0, 8192, 16384, 32768, 38500, 40960, 65535):
+            ratio = ((1 + (code - 32768) * 0.0045e-6) / (1 + 26e-6)
+                if board == 'acorn' else 1 + (2 + min(code, 40000) * 0.00075) * 1e-6)
+            rx = 62500000 * 1.00003
+            rows.append(dict(board=board, code=code, ref_hz=rx * ratio, rx_hz=rx))
+    return rows
+
+
+def test_centers_usable_range_and_cancels_gate_scale():
+    result = trim.fit_trims(sweep(), spec_linear_max=38500, spec_plateau_min=40960)
+    assert result['target_ppm'] == pytest.approx(17)
+    assert result['boards']['spec']['master_trim'] == 20000
+    assert result['boards']['acorn']['master_trim'] == 36546
+    assert result['boards']['acorn']['ppm_per_code'] == pytest.approx(0.0045)
+
+
+def test_rejects_missing_anchor():
+    with pytest.raises(ValueError, match='32768'):
+        trim.fit_trims([r for r in sweep() if r['code'] != 32768], 38500, 40960)
+
+
+def test_rejects_reversed_control():
+    rows = sweep()
+    for row in rows:
+        if row['board'] == 'spec':
+            row['ref_hz'] = 2 * row['rx_hz'] - row['ref_hz']
+    with pytest.raises(ValueError, match='positive'):
+        trim.fit_trims(rows, 38500, 40960)

--- a/tools/build_wr_bench.py
+++ b/tools/build_wr_bench.py
@@ -38,7 +38,11 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--board', required=True, choices=['acorn', 'spec'])
     parser.add_argument('--output', required=True, type=Path)
+    parser.add_argument('--pll-trace-decimation', type=int, default=0,
+        help='Enable PLL trace FIFO, main/helper trace decimation and FPGA sensors (power of two, 1..1024).')
     args = parser.parse_args()
+    if args.pll_trace_decimation < 0 or args.pll_trace_decimation > 1024 or args.pll_trace_decimation & (args.pll_trace_decimation - 1):
+        parser.error('--pll-trace-decimation must be 0 or a power of two from 1 to 1024')
     pins = json.loads((ROOT / 'doc/wr_bench_sources.json').read_text())
     for name, pin in pins['python'].items():
         module = importlib.import_module(name)
@@ -49,18 +53,23 @@ def main():
     output.mkdir(parents=True, exist_ok=False)
     manifest = dict(board=args.board, source=git(ROOT, 'rev-parse', 'HEAD'),
         source_dirty=bool(git(ROOT, 'status', '--porcelain', '--untracked-files=no')),
-        dependencies=pins, profile='uRV/private 128 KiB; read-only SPI storage', passed=False)
+        dependencies=pins, profile='uRV/private 128 KiB; read-only SPI storage',
+        pll_trace_decimation=args.pll_trace_decimation,
+        pcie_nic=not (args.board == 'spec' and args.pll_trace_decimation), passed=False)
     def run(command):
         subprocess.run([sys.executable, *command], cwd=ROOT, check=True)
     try:
         run(['litex_wr_nic/firmware/build.py', '--target',
-            'acorn' if args.board == 'acorn' else 'spec_a7', '--wr-cpu-type', 'urv', '--read-only-storage'])
+            'acorn' if args.board == 'acorn' else 'spec_a7', '--wr-cpu-type', 'urv', '--read-only-storage',
+            '--pll-trace-decimation', str(args.pll_trace_decimation)])
         firmware = ROOT / 'litex_wr_nic/firmware'
         for ext in ('bram', 'bin', 'boot'):
             shutil.copy2(firmware / ('spec_a7_wrc.' + ext), output / ('spec_a7_wrc.' + ext))
         command = ['acorn_wr_nic.py' if args.board == 'acorn' else 'spec_a7_wr_nic.py',
             '--build', '--skip-firmware-build', '--skip-software-headers', '--wr-cpu-type', 'urv',
             '--wr-cpu-memory', 'private', '--output-dir', str(output)]
+        if args.pll_trace_decimation:
+            command.append('--with-wr-pll-debug')
         run(command)
         manifest['sha256'] = finish_build(args.board, output)
         manifest['passed'] = True

--- a/tools/build_wr_bench.py
+++ b/tools/build_wr_bench.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Build the pinned uRV/private-RAM USB bench profile with read-only storage."""
+
+import argparse
+import hashlib
+import importlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def git(path, *args):
+    return subprocess.check_output(['git', '-C', str(path), *args], text=True).strip()
+
+
+def finish_build(board, output):
+    # Both targets generate the map in test/, including when --output-dir is
+    # supplied. SPEC's target converts the image only for --load/--flash.
+    shutil.copy2(ROOT / 'test/csr.csv', output / 'csr.csv')
+    image = output / 'gateware' / ('sqrl_acorn.bit' if board == 'acorn' else 'spec_a7_wr_nic.bin')
+    if board == 'spec':
+        subprocess.run([sys.executable, str(ROOT / 'litex_wr_nic/gateware/xilinx-bitstream.py'),
+            str(image.with_suffix('.bit')), str(image)], cwd=ROOT, check=True)
+    if not image.is_file() or not image.stat().st_size:
+        raise RuntimeError('Missing or empty programming image: ' + str(image))
+    timing = next((output / 'gateware').glob('*_timing.rpt')).read_text()
+    if 'All user specified timing constraints are met.' not in timing:
+        raise RuntimeError('Vivado timing failed; inspect the report before loading')
+    return {str(p.relative_to(output)): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in output.rglob('*') if p.is_file() and p.suffix in ('.bit', '.bin', '.bram', '.boot', '.csv')}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--board', required=True, choices=['acorn', 'spec'])
+    parser.add_argument('--output', required=True, type=Path)
+    args = parser.parse_args()
+    pins = json.loads((ROOT / 'doc/wr_bench_sources.json').read_text())
+    for name, pin in pins['python'].items():
+        module = importlib.import_module(name)
+        path = Path(module.__file__).resolve().parent
+        if git(path, 'rev-parse', 'HEAD') != pin['revision'] or git(path, 'status', '--porcelain', '--untracked-files=no'):
+            raise RuntimeError(f'{name}: expected clean source {pin["revision"]}, loaded {path}')
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    manifest = dict(board=args.board, source=git(ROOT, 'rev-parse', 'HEAD'),
+        source_dirty=bool(git(ROOT, 'status', '--porcelain', '--untracked-files=no')),
+        dependencies=pins, profile='uRV/private 128 KiB; read-only SPI storage', passed=False)
+    def run(command):
+        subprocess.run([sys.executable, *command], cwd=ROOT, check=True)
+    try:
+        run(['litex_wr_nic/firmware/build.py', '--target',
+            'acorn' if args.board == 'acorn' else 'spec_a7', '--wr-cpu-type', 'urv', '--read-only-storage'])
+        firmware = ROOT / 'litex_wr_nic/firmware'
+        for ext in ('bram', 'bin', 'boot'):
+            shutil.copy2(firmware / ('spec_a7_wrc.' + ext), output / ('spec_a7_wrc.' + ext))
+        command = ['acorn_wr_nic.py' if args.board == 'acorn' else 'spec_a7_wr_nic.py',
+            '--build', '--skip-firmware-build', '--skip-software-headers', '--wr-cpu-type', 'urv',
+            '--wr-cpu-memory', 'private', '--output-dir', str(output)]
+        run(command)
+        manifest['sha256'] = finish_build(args.board, output)
+        manifest['passed'] = True
+    finally:
+        (output / 'manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/wr_console.py
+++ b/tools/wr_console.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+"""Paced UART commands and complete WR console capture."""
+
+import json
+from pathlib import Path
+import re
+import threading
+import time
+
+import serial
+
+
+ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+# PPSI diagnostics can be printed between any two shell echo characters.
+# Strip only their timestamped records when matching an echo; retain the full
+# response and raw UART capture for diagnosis.
+PPSI_DIAGNOSTIC = re.compile(r"diag-[\w-]+: \d+\.\d+: [^\n]*\n\n?")
+
+
+class Console:
+    def __init__(self, port, output, baudrate=115200):
+        output = Path(output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        self.port = serial.Serial(port, baudrate, timeout=0.1, write_timeout=2, exclusive=True)
+        self.raw = output.with_suffix(".uart.raw").open("wb", buffering=0)
+        self.events = output.with_suffix(".events.jsonl").open("w", buffering=1)
+        self.buffer = bytearray()
+        self.last_received = None
+        self.error = None
+        self.running = True
+        self.reader = threading.Thread(target=self.read, daemon=True)
+        self.reader.start()
+
+    def read(self):
+        try:
+            while self.running:
+                data = self.port.read(4096)
+                if data:
+                    self.raw.write(data)
+                    self.buffer.extend(data)
+                    self.last_received = time.monotonic()
+        except Exception as error:
+            if self.running:
+                self.error = error
+
+    def text(self, start=0):
+        if self.error is not None:
+            raise RuntimeError("UART disconnected") from self.error
+        return ANSI.sub("", bytes(self.buffer[start:]).decode(errors="replace")).replace("\r", "")
+
+    def record(self, kind, text):
+        self.events.write(json.dumps({"time": time.time(), "kind": kind, "text": text}) + "\n")
+
+    def send(self, text):
+        self.record("tx", text)
+        # WRPC polls a small RX FIFO; pace commands so USB bursts do not lose bytes.
+        for value in text.encode():
+            self.port.write(bytes([value]))
+            time.sleep(0.02)
+
+    def prompt(self, start, timeout=10, command=None):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            response = self.text(start)
+            # Asynchronous WR logs can redraw an old prompt while a command is
+            # being typed. Require the submitted command's echo before accepting
+            # its completion prompt; otherwise a later command can race it.
+            echo_text = PPSI_DIAGNOSTIC.sub("", response)
+            after_echo = 0 if command is None else echo_text.find(command + "\n")
+            if after_echo >= 0 and "wrc#" in echo_text[after_echo:]:
+                self.record("rx", response)
+                return response
+            time.sleep(0.05)
+        raise TimeoutError("WR prompt timeout: " + repr(self.text(start)[-1000:]))
+
+    def connect(self):
+        start = len(self.buffer)
+        self.send("\r")
+        try:
+            return self.prompt(start, timeout=3)
+        except TimeoutError:
+            start = len(self.buffer)
+            self.send("\x1bq\r")
+            return self.prompt(start)
+
+    def command(self, command, timeout=10):
+        start = len(self.buffer)
+        self.send(command + "\r")
+        response = self.prompt(start, timeout, command=command)
+        if re.search(r'Unrecognized command|Unknown subcommand|Command "[^"\n]+": error', response):
+            raise RuntimeError("WR command failed: " + response)
+        return response
+
+    def monitor(self, seconds):
+        start = len(self.buffer)
+        self.send("gui\r")
+        time.sleep(seconds)
+        screen = self.text(start)
+        self.record("gui", screen)
+        start = len(self.buffer)
+        self.send("q")
+        self.prompt(start)
+        return screen
+
+    def close(self):
+        self.running = False
+        self.reader.join(timeout=2)
+        self.port.close()
+        self.raw.close()
+        self.events.close()

--- a/tools/wr_jtag.py
+++ b/tools/wr_jtag.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Manage dedicated WR JTAG servers with persistent Linux process ownership."""
+
+import argparse
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+
+def load_config(path):
+    path = Path(path).resolve()
+    config = json.loads(path.read_text())
+    def resolve(value):
+        return os.path.abspath(path.parent / value)
+    config['state_dir'] = resolve(config['state_dir'])
+    config['pythonpath'] = [resolve(p) for p in config.get('pythonpath', [])]
+    ports = set()
+    for name, board in config['boards'].items():
+        if not re.fullmatch(r'[a-zA-Z0-9_-]+', name):
+            raise ValueError('Invalid board name')
+        for key in ('csr', 'bitstream', 'jtag_config', 'uart'):
+            if key in board:
+                board[key] = resolve(board[key])
+        for key in ('jtag_port', 'stream_port'):
+            port = board[key]
+            if type(port) is not int or not 1024 <= port <= 65535 or port in ports:
+                raise ValueError('JTAG and stream ports must be distinct integers in 1024..65535')
+            ports.add(port)
+        if 'master_trim' in board and (type(board['master_trim']) is not int
+                                      or not 0 <= board['master_trim'] <= 65535):
+            raise ValueError('Master trim must be a 16-bit code')
+        if 'jtag_config' not in board:
+            if not re.fullmatch(r'\d+-\d+(?:\.\d+)*', board['usb_location']):
+                raise ValueError('Expected a physical USB location, for example 1-3')
+    return config
+
+
+def jtag_config(config, board):
+    cfg = config['boards'][board]
+    if 'jtag_config' in cfg:
+        return cfg['jtag_config']
+    path = Path(config['state_dir']) / (board + '.cfg')
+    path.write_text('adapter driver ftdi\nadapter speed 5000\n'
+        f'adapter usb location {cfg["usb_location"]}\n'
+        'transport select jtag\nftdi_vid_pid 0x0403 0x6011\nftdi_channel 0\n'
+        'ftdi_layout_init 0x00e8 0x60eb\nreset_config none\n'
+        'tcl_port disabled\ntelnet_port disabled\ngdb_port disabled\n'
+        'source [find cpld/xilinx-xc7.cfg]\n')
+    return str(path)
+
+
+def process(pid):
+    try:
+        fields = (Path('/proc') / str(pid) / 'stat').read_text().rsplit(')', 1)[1].split()
+        return dict(pid=int(pid), state=fields[0], group=int(fields[2]), started=fields[19])
+    except (FileNotFoundError, ProcessLookupError):
+        return None
+
+
+def members(group):
+    result = []
+    for path in Path('/proc').iterdir():
+        if path.name.isdigit():
+            item = process(path.name)
+            if item and item['group'] == group and item['state'] != 'Z':
+                result.append(item)
+    return result
+
+
+def write_record(path, record):
+    temporary = path.with_suffix('.tmp')
+    temporary.write_text(json.dumps(record, indent=2) + '\n')
+    temporary.replace(path)
+
+
+def listening(port):
+    with socket.socket() as probe:
+        probe.settimeout(0.2)
+        return probe.connect_ex(('127.0.0.1', port)) == 0
+
+
+def probe_board(cfg):
+    from litex import RemoteClient
+    bus = RemoteClient(host='127.0.0.1', port=cfg['jtag_port'], csr_csv=cfg['csr'],
+        timeout=2, raise_on_timeout=True)
+    bus.open()
+    try:
+        if bus.read(bus.mems.wr_wb_slave.base) != 0x57525043:
+            raise RuntimeError('Invalid WR host signature')
+        identifier = bytes(value & 255 for value in bus.read(bus.bases.identifier_mem,
+            length=128)).split(b'\0')[0].decode()
+        if cfg['identifier'] not in identifier:
+            raise RuntimeError('Unexpected FPGA identity: '+identifier)
+        return identifier
+    finally:
+        bus.close()
+
+
+def stop(path):
+    if not path.exists():
+        return
+    record = json.loads(path.read_text())
+    if record['boot_id'] != Path('/proc/sys/kernel/random/boot_id').read_text().strip():
+        path.unlink()
+        return
+    known = record['members']
+    group = record['group']
+    for sig, grace in [(signal.SIGTERM, 1), (signal.SIGKILL, 3)]:
+        live = members(group)
+        if not live:
+            break
+        if not any(old['pid'] == new['pid'] and old['started'] == new['started']
+                   for old in known for new in live):
+            raise RuntimeError(f'Refusing to signal unverified process group {group}')
+        try:
+            os.killpg(group, sig)
+        except ProcessLookupError:
+            break
+        deadline = time.monotonic() + grace
+        while members(group) and time.monotonic() < deadline:
+            time.sleep(0.05)
+    if members(group):
+        raise RuntimeError(f'Owned process group {group} did not stop')
+    path.unlink()
+
+
+def serve(config, board, path):
+    # Record our identity before exec starts LiteX/OpenOCD. A controller killed
+    # during startup can subsequently clean up this process and its children.
+    identity = process(os.getpid())
+    assert identity['group'] == os.getpid(), 'Worker must own its process group'
+    write_record(path, dict(boot_id=Path('/proc/sys/kernel/random/boot_id').read_text().strip(),
+        group=os.getpid(), members=[identity]))
+    cfg = config['boards'][board]
+    command = [sys.executable, '-m', 'litex.tools.litex_server', '--jtag',
+        '--jtag-config', jtag_config(config, board), '--jtag-port', str(cfg['stream_port']),
+        '--bind-ip', '127.0.0.1', '--bind-port', str(cfg['jtag_port'])]
+    os.execv(sys.executable, command)
+
+
+def start(config, config_path, board, state_dir):
+    cfg = config['boards'][board]
+    path = state_dir / (board + '.json')
+    stop(path)
+    for port in (cfg['jtag_port'], cfg['stream_port']):
+        if listening(port):
+            raise RuntimeError(f'Port {port} has an unmanaged listener')
+    for attempt in range(3):
+        stamp = time.strftime('%Y%m%d-%H%M%S') + f'-{attempt + 1}'
+        log_path = state_dir / (board + '-' + stamp + '.log')
+        environment = os.environ.copy()
+        if config.get('pythonpath'):
+            environment['PYTHONPATH'] = os.pathsep.join(config['pythonpath'])
+        with log_path.open('w') as log:
+            child = subprocess.Popen([sys.executable, str(Path(__file__).resolve()),
+                '--config', str(config_path), '--board', board, '_serve'],
+                env=environment, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+        try:
+            deadline = time.monotonic() + 20
+            while time.monotonic() < deadline:
+                if child.poll() is not None:
+                    raise RuntimeError(f'{board}: startup exited with {child.returncode}; see {log_path}')
+                if path.exists():
+                    record = json.loads(path.read_text())
+                    live = members(record['group'])
+                    # Keep identities already seen, including a parent which
+                    # exits while its OpenOCD child is still starting.
+                    record['members'] += [item for item in live if not any(
+                        item['pid'] == old['pid'] and item['started'] == old['started']
+                        for old in record['members'])]
+                    write_record(path, record)
+                if path.exists() and listening(cfg['jtag_port']):
+                    probe_board(cfg)
+                    print(f'{board}: JTAG server ready on localhost:{cfg["jtag_port"]}', flush=True)
+                    return
+                time.sleep(0.1)
+            raise TimeoutError(f'{board}: JTAG startup timed out; see {log_path}')
+        except BaseException as error:
+            stop(path)
+            # Covers the short interval before the worker writes its record.
+            if child.poll() is None:
+                child.terminate()
+            child.wait(timeout=3)
+            if not isinstance(error, Exception) or attempt == 2:
+                raise
+            print(str(error) + '; retrying', file=sys.stderr, flush=True)
+            time.sleep(0.2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config', type=Path, required=True)
+    parser.add_argument('--board')
+    parser.add_argument('action', choices=['start', 'stop', 'status', '_serve'])
+    args = parser.parse_args()
+    config_path = args.config.resolve()
+    config = load_config(config_path)
+    sys.path[:0] = config['pythonpath']
+    state_dir = Path(config['state_dir'])
+    state_dir.mkdir(parents=True, exist_ok=True)
+    names = [args.board] if args.board else list(config['boards'])
+    if any(name not in config['boards'] for name in names):
+        parser.error('Unknown board')
+    if args.action == '_serve':
+        serve(config, args.board, state_dir / (args.board + '.json'))
+    with (state_dir / 'bench.lock').open('a') as lock:
+        if args.action != 'status':
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        for name in names:
+            path = state_dir / (name + '.json')
+            if args.action == 'start':
+                start(config, config_path, name, state_dir)
+            elif args.action == 'stop':
+                stop(path)
+            else:
+                record = json.loads(path.read_text()) if path.exists() else None
+                cfg = config['boards'][name]
+                print(json.dumps(dict(board=name, record=record,
+                    jtag=listening(cfg['jtag_port']), stream=listening(cfg['stream_port']))))
+
+
+if __name__ == '__main__':
+    def interrupted(signum, frame):
+        raise KeyboardInterrupt(f'signal {signum}')
+    signal.signal(signal.SIGTERM, interrupted)
+    main()

--- a/tools/wr_loop_analysis.py
+++ b/tools/wr_loop_analysis.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Fit native PLL phase steps; all reported margins are model-derived."""
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import least_squares
+
+RATE = 62500000 / 16384
+QUANTUM_PS = 16000 / 16384
+
+
+def model_response(count, gain, lag_samples, p, i):
+    # Positive plant; upstream negative PI regulates e = y - reference.
+    # First-order actuator with exact integration over a sampling interval.
+    error, integrator, rate = -1., 0., 0.
+    a = np.exp(-1 / lag_samples) if lag_samples > 1e-6 else 0.
+    integral_factor = lag_samples * (1 - a)
+    result = np.empty(count)
+    for k in range(count):
+        result[k] = error
+        integrator -= i * error
+        command = integrator - p * error
+        error += gain * (command + (rate - command) * integral_factor)
+        rate = a * rate + (1 - a) * command
+    return result
+
+
+def margins(gain, lag_samples, p, i, rate=RATE):
+    w = np.geomspace(1e-5, np.pi, 100000)
+    z = np.exp(1j*w)
+    a = np.exp(-1/lag_samples) if lag_samples > 1e-6 else 0.
+    h = lag_samples*(1-a)
+    # x[k+1] = x[k] + g*((1-h)*u[k] + h*v[k]); v[k+1]=a*v[k]+(1-a)*u[k].
+    plant = gain/(z-1) * ((1-h) + h*(1-a)/(z-a))
+    loop = plant*(p+i*z/(z-1))
+    magnitude = np.abs(loop)
+    phase = np.unwrap(np.angle(loop))*180/np.pi
+    crossing = np.argmin(abs(magnitude-1))
+    phase_cross = np.where(phase <= -180 + 1e-7)[0]
+    closed = loop/(1+loop)
+    return dict(crossover_hz=float(w[crossing]*rate/(2*np.pi)),
+        phase_margin_deg=float(180+phase[crossing]),
+        gain_margin_db=None if not len(phase_cross) else float(-20*np.log10(magnitude[phase_cross[0]])),
+        closed_loop_peak_db=float(20*np.log10(np.max(abs(closed)))))
+
+
+def load(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def analyse_passive(directory, summary):
+    start = next(e['time_unix'] for e in load(directory/'events.jsonl') if e['kind']=='capture_ready')
+    result = dict(kind='passive', boards={},
+        caveat='Uncalibrated FPGA die sensors and internal DAC commands; no independent PPS or oscillator-temperature measurement.')
+    for board in ('acorn','spec'):
+        sensors = [s for s in load(directory/(board+'-sensors.jsonl')) if s['time_unix']>=start]
+        diagnostics = [s for s in load(directory/(board+'-diagnostics.jsonl')) if s['time_unix']>=start]
+        samples = [s for s in load(directory/(board+'-trace.samples.jsonl')) if s['received_unix']>=start and 'dac' in s]
+        if not sensors or not diagnostics or not samples:
+            raise ValueError('Missing passive observation data for '+board)
+        temperature = np.array([s['die_temperature_c'] for s in sensors])
+        entry = dict(die_min_c=float(temperature.min()), die_max_c=float(temperature.max()),
+            die_start_c=float(np.median(temperature[:30])), die_end_c=float(np.median(temperature[-30:])),
+            sensor_samples=len(sensors), duration_seconds=sensors[-1]['time_unix']-sensors[0]['time_unix'],
+            diagnostics=len(diagnostics),
+            link_lock_time_valid=all(all(d[k] for k in ('link','locked','time_valid')) for d in diagnostics),
+            servo_states=sorted(set(d['servo_state'] for d in diagnostics)),
+            ptp_states=sorted(set(d['ptp_state'] for d in diagnostics)),
+            rx_error_change=(diagnostics[-1]['rx_errors']-diagnostics[0]['rx_errors'])%(1<<32),
+            servo_update_change=(diagnostics[-1]['updates']-diagnostics[0]['updates'])%(1<<32),
+            dac={})
+        end=sensors[-1]['time_unix']
+        for source,name in ((0,'helper'),(1,'main')):
+            rows=[s for s in samples if s['source']==source]
+            if not rows:
+                continue
+            early=[s['dac'] for s in rows if s['received_unix']<start+30]
+            late=[s['dac'] for s in rows if s['received_unix']>end-30]
+            if not early or not late:
+                raise ValueError('Incomplete DAC record for '+board)
+            entry['dac'][name]=dict(start_mean=float(np.mean(early)),end_mean=float(np.mean(late)),
+                min=min(s['dac'] for s in rows),max=max(s['dac'] for s in rows))
+        result['boards'][board]=entry
+    (directory/'analysis.json').write_text(json.dumps(result,indent=2)+'\n')
+    print(json.dumps(result,indent=2))
+    return result
+
+
+def analyse(directory, sensitivity_ppb, bootstrap=200):
+    summary = json.loads((directory/'summary.json').read_text())
+    if not summary['passed']:
+        raise ValueError('Capture did not pass integrity checks')
+    if summary['arguments'].get('passive'):
+        return analyse_passive(directory,summary)
+    if sensitivity_ppb is None or sensitivity_ppb<=0:
+        raise ValueError('A positive slave main-actuator sensitivity is required for a loop fit')
+    board = summary['slave']
+    events = load(directory/'events.jsonl')
+    capture_start = next(e['time_unix'] for e in events if e['kind']=='capture_ready')
+    data = load(directory/(board+'-trace.samples.jsonl'))
+    main = [f for f in data if f['source']==1 and 'sample_id' in f and f['received_unix']>=capture_start]
+    bursts, current = [], []
+    for index, f in enumerate(main):
+        if f.get('stride') == 1:
+            if not current:
+                previous = main[max(0,index-40):index]
+            current.append(f)
+        elif current:
+            bursts.append((previous,current)); current=[]
+    if current:
+        bursts.append((previous,current))
+    commands = [e for e in events if e['kind']=='command_done' and e.get('command','').startswith('pll step ')]
+    stages = [e for e in events if e['kind']=='gain_stage' and e['loop']=='main']
+    if not bursts or len(bursts) != len(commands):
+        raise ValueError('Native bursts and phase commands must match one to one')
+    result = dict(board=board, bursts_seen=len(bursts), commands_seen=len(commands), bursts=[],
+        sensitivity_ppb_per_code=sensitivity_ppb, bootstrap_repeats=bootstrap,
+        caveat='Margins assume a discrete PI and integrating oscillator with first-order actuator lag. Bootstrap intervals resample whole bursts and exclude systematic/model error.')
+    controllers = {}
+    curves = {}
+    for n,(previous,burst) in enumerate(bursts):
+        errors = []
+        if len(burst)!=640: errors.append('native sample count differs from 640')
+        if any(f['gap'] for f in burst): errors.append('sample gap')
+        if any(abs(f['ref']-16384)>1024 or abs(f['tag']-16384)>1024 for f in burst):
+            errors.append('missing/abnormal DMTD tag period')
+        if not previous or any(f['gap'] for f in previous[-20:]):
+            errors.append('missing/gapped preceding baseline')
+        expected_phase = int(int(commands[n]['command'].split()[-1]) / QUANTUM_PS)
+        if any(f['phase_current'] != expected_phase for f in burst):
+            errors.append('trace phase does not match command')
+        if errors:
+            result['bursts'].append(dict(index=n, valid=False, errors=errors)); continue
+        step = burst[0]['phase_current']-previous[-1]['phase_current']
+        if step==0:
+            result['bursts'].append(dict(index=n, valid=False, errors=['zero phase step']));continue
+        command_time = commands[n]['time_unix']
+        stage = [e for e in stages if e['time_unix']<command_time][-1]
+        factor = stage['factor']
+        gain_command = [e for e in events if e['kind']=='command_done'
+            and e.get('board')==board and e.get('command','').startswith('pll gain 0 0 ')
+            and stage['time_unix']<e['time_unix']<command_time][-1]
+        kp, ki, shift = map(int, gain_command['command'].split()[-3:])
+        controller = (-kp / 2**shift, -ki / 2**shift)
+        if min(controller)<=0 or controllers.setdefault(factor,controller)!=controller:
+            raise ValueError('Unsupported or inconsistent PI gains within a stage')
+        baseline = np.mean([f['error'] for f in previous[-20:]])
+        normalized = (np.array([f['error'] for f in burst])-baseline)/step
+        curves.setdefault(factor,[]).append(normalized)
+        dac = np.array([f['dac'] for f in burst])
+        interval = (burst[-1]['time_ms']-burst[0]['time_ms'])%(1<<24)
+        result['bursts'].append(dict(index=n, valid=True, gain_factor=factor,
+            step_ps=step*QUANTUM_PS, elapsed_ms=interval, first_error_ps=burst[0]['error']*QUANTUM_PS,
+            peak_error_ps=float(max(abs(f['error']) for f in burst)*QUANTUM_PS),
+            dac_min=int(dac.min()), dac_max=int(dac.max())))
+    if any(not b['valid'] for b in result['bursts']):
+        raise ValueError('Incomplete or invalid native burst: ' + repr([b for b in result['bursts'] if not b['valid']]))
+    result['gain_stages']={}
+    rng = np.random.default_rng(20260911)
+    for factor, rows in curves.items():
+        matrix=np.array(rows); mean=matrix.mean(axis=0)
+        p,i=controllers[factor]
+        initial_gain=sensitivity_ppb*1e-9*16384**2
+        def residual(x):
+            gain,lag,scale,offset=x
+            return scale*model_response(len(mean),gain,lag,p,i)+offset-mean
+        fit=least_squares(residual,[initial_gain,.3,1,0],
+            bounds=([initial_gain*.25,0,.75,-.1],[initial_gain*3,8,1.25,.1]))
+        gain,lag,scale,offset=fit.x
+        predicted=scale*model_response(len(mean),gain,lag,p,i)+offset
+        output=1+mean
+        amplitude_ps=float(np.median([abs(b['step_ps']) for b in result['bursts'] if b.get('valid') and b['gain_factor']==factor]))
+        smoothed=np.convolve(mean, np.ones(8)/8, mode='valid')
+        unsettled=np.where(abs(smoothed)*amplitude_ps>50)[0]
+        metrics=dict(bursts=len(rows), fitted_gain_counts_per_code_per_update=float(gain),
+            static_gain_counts_per_code_per_update=initial_gain, actuator_lag_samples=float(lag),
+            fitted_amplitude=float(scale), fitted_offset=float(offset),
+            residual_rms_ps=float(np.sqrt(np.mean((mean-predicted)**2))*amplitude_ps),
+            measured_overshoot_percent=float(100*(output.max()-1)),
+            mean_50ps_settling_ms=None if len(unsettled) and unsettled[-1]==len(smoothed)-1 else float((unsettled[-1]+8 if len(unsettled) else 0)*1000/RATE),
+            model_margins=margins(gain,lag,p,i))
+        if bootstrap:
+            fitted = []
+            original_mean = mean
+            for repeat in range(bootstrap):
+                mean = matrix[rng.integers(0,len(matrix),len(matrix))].mean(axis=0)
+                sampled = least_squares(residual, fit.x,
+                    bounds=([initial_gain*.25,0,.75,-.1],[initial_gain*3,8,1.25,.1]))
+                fitted.append(margins(sampled.x[0],sampled.x[1],p,i))
+            mean = original_mean
+            metrics['bootstrap_95_percent_interval'] = {key: np.percentile(
+                [m[key] for m in fitted], [2.5,97.5]).tolist()
+                for key in ('crossover_hz','phase_margin_deg')}
+        result['gain_stages'][factor]=metrics
+        np.savez(directory/(f'{board}-gain-{factor}-curves.npz'),mean=mean, individual=matrix,predicted=predicted,time_s=np.arange(len(mean))/RATE)
+    result['temperature']={}
+    for name in ('acorn','spec'):
+        if not (directory/(name+'-sensors.jsonl')).exists():
+            result['temperature'][name]={'available':False}
+            continue
+        sensors=load(directory/(name+'-sensors.jsonl'))
+        temp=np.array([s['die_temperature_c'] for s in sensors])
+        result['temperature'][name]=dict(samples=len(temp),die_min_c=float(temp.min()),die_max_c=float(temp.max()),
+            die_start_c=float(np.median(temp[:10])),die_end_c=float(np.median(temp[-10:])))
+    (directory/'analysis.json').write_text(json.dumps(result,indent=2)+'\n')
+    print(json.dumps({k:v for k,v in result.items() if k!='bursts'},indent=2))
+    return result
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('directory',type=Path)
+    p.add_argument('--sensitivity-ppb', type=float, help='Previously measured slave main-actuator sensitivity, in ppb/code; required for a loop fit.')
+    p.add_argument('--bootstrap', type=int, default=200)
+    args=p.parse_args()
+    if (args.sensitivity_ppb is not None and args.sensitivity_ppb<=0) or args.bootstrap<0:
+        p.error('Sensitivity must be positive; bootstrap count must be nonnegative')
+    analyse(args.directory,args.sensitivity_ppb,args.bootstrap)

--- a/tools/wr_loop_response.py
+++ b/tools/wr_loop_response.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Measure the Acorn/SPEC USB bench with optional PLL stimuli and automatic recovery."""
+import argparse
+import fcntl
+import hashlib
+import json
+from pathlib import Path
+import re
+import signal
+import threading
+import time
+
+from litex import RemoteClient
+from wr_console import Console
+from wr_jtag import load_config
+from wr_pll_trace import Trace, read_sensors
+from wr_status import diagnostic_snapshot
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config', required=True, type=Path)
+    parser.add_argument('--master', required=True, choices=['acorn', 'spec'])
+    parser.add_argument('--output', required=True, type=Path)
+    parser.add_argument('--passive', type=float, default=0)
+    parser.add_argument('--repeats', type=int, default=4)
+    parser.add_argument('--step-ps', type=int, default=500)
+    parser.add_argument('--frequency-step-ppb', type=float, default=100)
+    parser.add_argument('--master-sensitivity-ppb', type=float,
+        help='Measured master main-actuator slope, in ppb per code; required for stimuli.')
+    args = parser.parse_args()
+    cfg = load_config(args.config)
+    if set(cfg['boards']) != {'acorn', 'spec'}:
+        parser.error('This experiment requires the acorn/spec bench profile')
+    if args.passive < 0 or args.repeats < 1 or not 1 <= args.step_ps <= 500:
+        parser.error('Use a nonnegative passive duration, positive repeats and a 1..500 ps step')
+    if not args.passive:
+        if args.master_sensitivity_ppb is None or args.master_sensitivity_ppb <= 0 or args.frequency_step_ppb <= 0:
+            parser.error('Stimuli require positive --master-sensitivity-ppb and --frequency-step-ppb')
+        trim = cfg['boards'][args.master].get('master_trim')
+        if trim is None:
+            parser.error('Set the selected board\'s calibrated master_trim in --config before applying stimuli')
+        step = round(args.frequency_step_ppb / args.master_sensitivity_ppb)
+        if not 0 < step <= min(trim, 65535-trim):
+            parser.error('Frequency step must be nonzero and remain inside the DAC rails')
+    out = args.output
+    out.mkdir(parents=True, exist_ok=False)
+    master = args.master
+    slave = 'spec' if master == 'acorn' else 'acorn'
+    consoles, buses, traces, workers = {}, {}, {}, []
+    gains = {}
+    delock_counts = {}
+    modified = False
+    halt = threading.Event()
+    errors = []
+    events = (out/'events.jsonl').open('w', buffering=1)
+    state = dict(master=master, slave=slave, start_unix=time.time(), passed=False,
+                 restored=False, decimation=16, config=cfg,
+                 arguments={k: str(v) if isinstance(v, Path) else v for k,v in vars(args).items()})
+    state['tool_sha256'] = {name: hashlib.sha256(Path(__file__).with_name(name).read_bytes()).hexdigest()
+        for name in ('wr_loop_response.py', 'wr_pll_trace.py', 'wr_console.py', 'wr_status.py')}
+    state['input_sha256'] = {name: {key: hashlib.sha256(Path(board[key]).read_bytes()).hexdigest()
+        for key in ('csr', 'bitstream') if board.get(key)} for name,board in cfg['boards'].items()}
+
+    def interrupt(signum, frame):
+        raise KeyboardInterrupt(f'signal {signum}')
+    signal.signal(signal.SIGTERM, interrupt)
+    signal.signal(signal.SIGINT, interrupt)
+
+    def event(kind, **data):
+        events.write(json.dumps(dict(time_unix=time.time(), kind=kind, **data))+'\n')
+
+    def command(name, text):
+        event('command_start', board=name, command=text)
+        answer = consoles[name].command(text, timeout=15)
+        event('command_done', board=name, command=text, response=answer)
+        return answer
+
+    def pause(seconds):
+        if halt.wait(seconds):
+            raise RuntimeError('Capture stopped: '+repr(errors))
+
+    def check_locks(name):
+        stats = command(name, 'pll stat')
+        delocks = re.search(r'DelCnt:(\d+)', stats)
+        if delocks is None or 'HL1' not in stats or (name == slave and 'MFL1 MPL1' not in stats):
+            raise RuntimeError(name + ': PLL lock check failed')
+        count = int(delocks.group(1))
+        if delock_counts.setdefault(name, count) != count:
+            raise RuntimeError(name + ': PLL lost lock during the experiment')
+
+    def capture(name):
+        try:
+            sensor_due = 0
+            diagnostic_due = 0
+            with (out/(name+'-sensors.jsonl')).open('w', buffering=1) as sensors, (out/(name+'-diagnostics.jsonl')).open('w', buffering=1) as diagnostics:
+                while not halt.is_set():
+                    frames = traces[name].poll()
+                    now = time.monotonic()
+                    if now >= sensor_due:
+                        sensors.write(json.dumps(dict(time_unix=time.time(), **read_sensors(buses[name])))+'\n')
+                        sensor_due = now + 1
+                    if now >= diagnostic_due:
+                        diagnostics.write(json.dumps(dict(time_unix=time.time(), **diagnostic_snapshot(buses[name])))+'\n')
+                        diagnostic_due = now + 5
+                    if not frames:
+                        halt.wait(0.002)
+        except BaseException as error:
+            errors.append(name+': '+repr(error))
+            halt.set()
+
+    with (Path(cfg['state_dir'])/'bench.lock').open('a') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            for name, board in cfg['boards'].items():
+                c = consoles[name] = Console(board['uart'], out/name)
+                c.connect()
+                command(name, 'verbose 0')
+                command(name, 'ver')
+                stats = command(name, 'pll stat')
+                gains[name] = {}
+                for loop in ('m', 'h'):
+                    values = re.search(rf'{loop}_kp:(-?\d+) {loop}_ki:(-?\d+) {loop}_sh:(\d+)', stats)
+                    if values is None:
+                        raise RuntimeError(name + ': cannot save PI gains before experiment')
+                    gains[name][loop] = tuple(map(int, values.groups()))
+                b = buses[name] = RemoteClient(host='127.0.0.1', port=board['jtag_port'],
+                    csr_csv=board['csr'], timeout=5, raise_on_timeout=True)
+                b.open()
+                identifier = bytes(v & 255 for v in b.read(b.bases.identifier_mem, length=128)).split(b'\0')[0].decode()
+                if board['identifier'] not in identifier:
+                    raise RuntimeError(name + ': unexpected FPGA identifier: ' + identifier)
+                event('initial_diagnostics', board=name, values=diagnostic_snapshot(b))
+            state['saved_gains'] = gains
+            if not args.passive:
+                modified = True
+                for name in consoles:
+                    command(name, 'ptp stop')
+                command(master, 'pll init 2 0 0')
+                command(master, f"pll sdac 0 {cfg['boards'][master]['master_trim']}")
+                command(slave, 'pll init 3 0 0')
+                deadline = time.monotonic()+60
+                while time.monotonic() < deadline:
+                    answer = command(slave, 'pll cl 0')
+                    if re.search(r'\n1\n', answer):
+                        break
+                    time.sleep(1)
+                else:
+                    raise RuntimeError('Isolated slave PLL did not lock')
+                for name in consoles:
+                    check_locks(name)
+                command(slave, 'pll sps 0 0')
+            for name, b in buses.items():
+                traces[name] = Trace(b, out/(name+'-trace'), 16)
+                t = threading.Thread(target=capture, args=(name,), daemon=True)
+                workers.append(t)
+                t.start()
+            pause(10)
+            initial_trace = {name: trace.summary() for name, trace in traces.items()}
+            event('capture_ready', traces=initial_trace)
+            if args.passive:
+                pause(args.passive)
+            else:
+                kp, ki, shift = gains[slave]['m']
+                event('frequency_step', codes=step, ppb=step*args.master_sensitivity_ppb)
+                for factor in (1, 0.5, 2, 1):
+                    event('gain_stage', factor=factor, loop='main')
+                    command(slave, f'pll gain 0 0 {int(kp*factor)} {int(ki*factor)} {shift}')
+                    pause(2)
+                    for repeat in range(args.repeats):
+                        event('native_step_trial', factor=factor, repeat=repeat)
+                        for phase in (args.step_ps, 0, -args.step_ps, 0):
+                            command(slave, f'pll step {phase}')
+                            pause(1)
+                            deadline = time.monotonic()+15
+                            while traces[slave].last_count > 128:
+                                if time.monotonic() >= deadline:
+                                    raise RuntimeError('Trace FIFO did not drain between native bursts')
+                                pause(.1)
+                        event('phase_trial', factor=factor, repeat=repeat)
+                        for phase in (1024, 0, -1024, 0):
+                            command(slave, f'pll sps 0 {phase}')
+                            pause(0.7)
+                        event('frequency_trial', factor=factor, repeat=repeat, master_delta_code=step)
+                        for delta in (step, 0, -step, 0):
+                            command(master, f'pll sdac 0 {trim+delta}')
+                            pause(0.7)
+                    answer = command(slave, 'pll cl 0')
+                    if not re.search(r'\n1\n', answer):
+                        raise RuntimeError('Slave PLL lost lock during a gain stage')
+                    for name in consoles:
+                        check_locks(name)
+                for factor in (0.5, 2, 1):
+                    event('gain_stage', factor=factor, loop='helper')
+                    for name in consoles:
+                        hkp, hki, hshift = gains[name]['h']
+                        command(name, f'pll gain -1 0 {int(hkp*factor)} {int(hki*factor)} {hshift}')
+                    pause(2)
+                    for repeat in range(args.repeats):
+                        event('helper_frequency_trial', factor=factor, repeat=repeat, master_delta_code=step)
+                        for delta in (step, 0, -step, 0):
+                            command(master, f'pll sdac 0 {trim+delta}')
+                            pause(1)
+                    for name in consoles:
+                        check_locks(name)
+                event('experiment_done')
+                pause(3)
+            final_trace = {name: trace.summary() for name, trace in traces.items()}
+            state['active_capture_gaps'] = {name: final_trace[name]['gaps']-initial_trace[name]['gaps'] for name in traces}
+            state['active_discarded_frames'] = {name: final_trace[name]['discarded']-initial_trace[name]['discarded'] for name in traces}
+            state['passed'] = not errors and not any(state['active_capture_gaps'].values()) and not any(state['active_discarded_frames'].values())
+            for name in traces:
+                required_sources = (0,1) if name == slave else (0,)
+                state['passed'] &= all(final_trace[name]['samples'].get(source,0)
+                    > initial_trace[name]['samples'].get(source,0) for source in required_sources)
+            if not args.passive:
+                native = final_trace[slave]['native_samples'].get(1, 0) - initial_trace[slave]['native_samples'].get(1, 0)
+                state['native_samples'] = native
+                state['passed'] &= native == 16 * args.repeats * 640
+        except BaseException as error:
+            state['error'] = repr(error)
+            raise
+        finally:
+            halt.set()
+            for worker in workers:
+                worker.join(timeout=12)
+                if worker.is_alive():
+                    errors.append('Capture worker did not stop within 12 seconds')
+            state['passed'] &= not errors
+            state['capture_errors'] = errors
+            state['traces'] = {name: trace.summary() for name, trace in traces.items()}
+            for trace in traces.values():
+                trace.close()
+            restore_errors = []
+            if modified:
+                for name in consoles:
+                    try:
+                        command(name, 'ptp stop')
+                        for loop, index in (('m', 0), ('h', -1)):
+                            kp, ki, shift = gains[name][loop]
+                            command(name, f'pll gain {index} 0 {kp} {ki} {shift}')
+                        command(name, 'pll sps 0 0')
+                        command(name, 'mode '+('master' if name == master else 'slave'))
+                        if name == master:
+                            command(name, f"pll sdac 0 {cfg['boards'][name]['master_trim']}")
+                        command(name, 'ptp start')
+                    except BaseException as error:
+                        restore_errors.append(name+': '+repr(error))
+            state['restore_errors'] = restore_errors
+            state['passed'] &= not restore_errors
+            state['restored'] = not restore_errors and len(consoles) == 2
+            for console in consoles.values():
+                console.close()
+            for bus in buses.values():
+                bus.close()
+            state['end_unix'] = time.time()
+            (out/'summary.json').write_text(json.dumps(state, indent=2)+'\n')
+            events.close()
+            print(json.dumps({k:v for k,v in state.items() if k != 'config'}, indent=2), flush=True)
+    if not state['passed']:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/wr_pll_trace.py
+++ b/tools/wr_pll_trace.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Read the upstream SoftPLL host FIFO without stopping the WR CPU.
+
+Requires --with-wr-pll-debug gateware. Values are internal detector samples,
+not an independent PPS measurement. Raw FIFO words remain in the capture.
+"""
+
+import argparse
+import fcntl
+import json
+from pathlib import Path
+import struct
+import time
+
+from litex import RemoteClient
+from wr_jtag import load_config
+
+
+FIELDS = {
+    0: 'dac', 1: 'error', 2: 'tag', 3: 'ref', 4: 'period',
+    5: 'sample_id', 6: 'event', 7: 'time_ms',
+    8: 'phase_current', 9: 'phase_target', 10: 'src', 11: 'stride',
+}
+SIGNED = {'error', 'phase_current', 'phase_target'}
+MODULUS = 1 << 24
+
+
+class Decoder:
+    def __init__(self, decimation):
+        self.decimation = decimation
+        self.pending = []
+        self.previous = {}
+        self.samples = {}
+        self.native_samples = {}
+        self.discarded = 0
+        self.gaps = 0
+
+    def feed(self, words):
+        result = []
+        for word in words:
+            self.pending.append(word)
+            if not word & 0x80000000:
+                if len(self.pending) > 32:
+                    raise ValueError('No SoftPLL end-of-sample marker in 32 records')
+                continue
+            records, self.pending = self.pending, []
+            source = (records[0] >> 28) & 7
+            frame = {'source': source}
+            valid = True
+            for value in records:
+                field = FIELDS.get((value >> 24) & 15)
+                if (value >> 28) & 7 != source or field is None or field in frame:
+                    valid = False
+                    break
+                data = value & (MODULUS - 1)
+                if field in SIGNED and data & (1 << 23):
+                    data -= MODULUS
+                frame[field] = data
+            if valid and len(frame) == 2 and 'event' in frame:
+                result.append(frame)
+                continue
+            required = {'time_ms', 'sample_id', 'dac', 'error'}
+            if source == 1:
+                required |= {'phase_current', 'phase_target', 'tag', 'ref'}
+            if not valid or source not in (0, 1) or not required <= frame.keys():
+                self.discarded += 1
+                continue
+            previous = self.previous.get(source)
+            stride = frame.get('stride', self.decimation)
+            if stride not in (1, self.decimation):
+                raise ValueError('Unexpected trace stride: ' + str(stride))
+            frame['stride'] = stride
+            frame['gap'] = False
+            frame['stride_transition'] = False
+            if previous is None:
+                frame['sample'] = 0
+                frame['elapsed_ms'] = 0
+            else:
+                delta = (frame['sample_id'] - previous['sample_id']) % MODULUS
+                frame['stride_transition'] = stride != previous['stride']
+                frame['gap'] = (not 0 < delta <= max(stride, previous['stride'])
+                    if frame['stride_transition'] else delta != stride)
+                self.gaps += int(frame['gap'])
+                frame['sample'] = previous['sample'] + delta
+                frame['elapsed_ms'] = previous['elapsed_ms'] + (frame['time_ms'] - previous['time_ms']) % MODULUS
+            self.previous[source] = frame
+            self.samples[source] = self.samples.get(source, 0) + 1
+            if stride == 1:
+                self.native_samples[source] = self.native_samples.get(source, 0) + 1
+            result.append(frame)
+        return result
+
+
+def read_sensors(bus):
+    names = ('temperature', 'vccint', 'vccaux', 'vccbram')
+    addresses = [getattr(bus.regs, 'xadc_' + name).addr for name in names]
+    if addresses != list(range(addresses[0], addresses[0]+16, 4)):
+        raise ValueError('Expected contiguous 32-bit XADC status registers')
+    values = dict(zip(names, bus.read(addresses[0], length=4)))
+    if any(not 0 < value < 4096 for value in values.values()):
+        raise ValueError('Invalid XADC readings: ' + repr(values))
+    return dict(raw=values, die_temperature_c=values['temperature'] * 503.975 / 4096 - 273.15,
+        **{name + '_v': values[name] * 3 / 4096 for name in ('vccint', 'vccaux', 'vccbram')})
+
+
+class Trace:
+    def __init__(self, bus, output, decimation):
+        self.bus = bus
+        self.base = bus.mems.wr_wb_slave.base
+        if bus.read(self.base) != 0x57525043:
+            raise ValueError('WR host map signature mismatch')
+        self.decoder = Decoder(decimation)
+        self.raw = output.with_suffix('.words.bin').open('wb')
+        self.frames = output.with_suffix('.samples.jsonl').open('w', buffering=1)
+        self.high_water = 0
+        self.last_count = 0
+
+    def poll(self):
+        status = self.bus.read(self.base + 0x278)
+        if status & ~0x21fff:
+            raise ValueError('Invalid SoftPLL FIFO status: ' + hex(status))
+        self.last_count = status & 0x1fff
+        if status & 0x20000:
+            return []
+        count = status & 0x1fff
+        if not count:
+            return []
+        self.high_water = max(self.high_water, count)
+        # Fixed-address bursts pop FIFO words. Incrementing reads access other
+        # registers and silently corrupt the measurement.
+        words = self.bus.read(self.base + 0x270, length=min(count, 2040), burst='fixed')
+        self.raw.write(struct.pack('<' + 'I' * len(words), *words))
+        received = time.time()
+        frames = self.decoder.feed(words)
+        for frame in frames:
+            frame['received_unix'] = received
+            self.frames.write(json.dumps(frame) + '\n')
+        return frames
+
+    def close(self):
+        self.raw.close()
+        self.frames.close()
+
+    def summary(self):
+        return dict(samples=dict(self.decoder.samples), gaps=self.decoder.gaps,
+            native_samples=dict(self.decoder.native_samples),
+            discarded=self.decoder.discarded, fifo_high_water_words=self.high_water,
+            incomplete_tail_words=len(self.decoder.pending))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config', required=True, type=Path)
+    parser.add_argument('--board', required=True)
+    parser.add_argument('--decimation', type=int, required=True, help='Must match the loaded firmware.')
+    parser.add_argument('--duration', type=float, default=60)
+    parser.add_argument('--output', required=True, type=Path)
+    args = parser.parse_args()
+    if args.decimation < 1 or args.duration <= 0:
+        parser.error('Decimation and duration must be positive')
+    config = load_config(args.config)
+    cfg = config['boards'][args.board]
+    args.output.mkdir(parents=True, exist_ok=False)
+    result = dict(board=args.board, decimation=args.decimation, start_unix=time.time(), passed=False)
+    with (Path(config['state_dir']) / 'bench.lock').open('a') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        bus = RemoteClient(host='127.0.0.1', port=cfg['jtag_port'], csr_csv=cfg['csr'], timeout=5, raise_on_timeout=True)
+        bus.open()
+        trace = None
+        try:
+            trace = Trace(bus, args.output / args.board, args.decimation)
+            with (args.output / 'sensors.jsonl').open('w', buffering=1) as sensors:
+                deadline, next_sensor = time.monotonic() + args.duration, 0
+                while time.monotonic() < deadline:
+                    frames = trace.poll()
+                    now = time.monotonic()
+                    if now >= next_sensor:
+                        sensors.write(json.dumps(dict(time_unix=time.time(), **read_sensors(bus))) + '\n')
+                        next_sensor = now + 1
+                    if not frames:
+                        time.sleep(0.002)
+            result.update(trace.summary())
+            result['passed'] = bool(result['samples']) and not result['gaps'] and not result['discarded']
+        finally:
+            if trace:
+                result.update(trace.summary())
+                trace.close()
+            bus.close()
+            result['end_unix'] = time.time()
+            (args.output / 'summary.json').write_text(json.dumps(result, indent=2) + '\n')
+    print(json.dumps(result, indent=2))
+    if not result['passed']:
+        raise SystemExit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/wr_qualify.py
+++ b/tools/wr_qualify.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+"""Qualify two configured WR boards with physical UART and JTAGBone evidence."""
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import fcntl
+import hashlib
+import json
+from pathlib import Path
+import signal
+import time
+
+from litex import RemoteClient
+from wr_console import Console
+from wr_status import WRScreen, diagnostic_snapshot, qualification_errors
+from wr_jtag import load_config
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config', type=Path, help='Use board paths, ports and trims from a bench configuration.')
+    parser.add_argument('--master-board', help='Master board name from --config; the other board becomes slave.')
+    for role in ("master", "slave"):
+        parser.add_argument("--" + role + "-uart")
+        parser.add_argument("--" + role + "-jtag", type=int)
+        parser.add_argument("--" + role + "-csr", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--duration", type=float, default=1800)
+    parser.add_argument("--acquire-timeout", type=float, default=300)
+    parser.add_argument(
+        "--configure",
+        action="store_true",
+        help="Set roles before acquisition; otherwise observe the running pair.",
+    )
+    parser.add_argument(
+        "--master-trim",
+        type=int,
+        help="Apply a volatile master main-DAC code after role configuration.",
+    )
+    args = parser.parse_args()
+    config = load_config(args.config) if args.config else None
+    boards = {}
+    if config:
+        if len(config['boards']) != 2 or args.master_board not in config['boards']:
+            parser.error('--config requires exactly two boards and a valid --master-board')
+        boards['master'] = config['boards'][args.master_board]
+        boards['slave'] = next(b for n, b in config['boards'].items() if n != args.master_board)
+        for role, board in boards.items():
+            for argument, key in [('uart', 'uart'), ('jtag', 'jtag_port'), ('csr', 'csr')]:
+                if getattr(args, role + '_' + argument) is not None:
+                    parser.error('Explicit board connection options cannot be combined with --config')
+                setattr(args, role + '_' + argument, Path(board[key]) if argument == 'csr' else board[key])
+        if args.configure and args.master_trim is None:
+            args.master_trim = boards['master'].get('master_trim')
+    elif args.master_board:
+        parser.error('--master-board requires --config')
+    if any(getattr(args, role + '_' + key) is None
+           for role in ('master', 'slave') for key in ('uart', 'jtag', 'csr')):
+        parser.error('Provide --config and --master-board, or all master/slave connection options')
+    if args.duration <= 0 or args.acquire_timeout <= 0:
+        parser.error("Durations must be positive")
+    if args.master_trim is not None and not (args.configure and 0 <= args.master_trim <= 65535):
+        parser.error("--master-trim requires --configure and a 16-bit code")
+    lock = None
+    if config:
+        state = Path(config['state_dir'])
+        state.mkdir(parents=True, exist_ok=True)
+        lock = (state / 'bench.lock').open('a')
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    args.output.mkdir(parents=True, exist_ok=False)
+    summary = dict(
+        passed=False,
+        start_unix=time.time(),
+        duration_requested=args.duration,
+        arguments={k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()},
+        boards={},
+        tool_sha256={
+            name: hashlib.sha256(Path(__file__).with_name(name).read_bytes()).hexdigest()
+            for name in ("wr_qualify.py", "wr_console.py", "wr_status.py")
+        },
+    )
+    consoles, buses, screens, offsets = {}, {}, {}, {}
+    samples = (args.output / "samples.jsonl").open("w", buffering=1)
+    frames_log = (args.output / "gui-frames.jsonl").open("w", buffering=1)
+    pool = ThreadPoolExecutor(max_workers=2)
+    try:
+        for role in ("master", "slave"):
+            csv = getattr(args, role + "_csr")
+            summary["boards"][role] = dict(
+                csr_sha256=hashlib.sha256(csv.read_bytes()).hexdigest(), commands=[]
+            )
+            c = consoles[role] = Console(getattr(args, role + "_uart"), args.output / role)
+            c.connect()
+            b = buses[role] = RemoteClient(
+                host="127.0.0.1",
+                port=getattr(args, role + "_jtag"),
+                csr_csv=str(csv),
+                timeout=5,
+                raise_on_timeout=True,
+            )
+            b.open()
+            identifier = (
+                bytes(w & 255 for w in b.read(b.bases.identifier_mem, length=128))
+                .split(b"\0")[0]
+                .decode()
+            )
+            summary["boards"][role]["identifier"] = identifier
+            if boards and boards[role]['identifier'] not in identifier:
+                raise RuntimeError(role + ': unexpected FPGA identifier: ' + identifier)
+            if b.read(b.mems.wr_wb_slave.base) != 0x57525043:
+                raise RuntimeError(role + ": WR host map identity mismatch")
+
+        def command(role, text):
+            response = consoles[role].command(text, timeout=60)
+            summary["boards"][role]["commands"].append(dict(command=text, response=response))
+            if "PRINTF OVF" in response:
+                raise RuntimeError(role + ": firmware printf buffer overflow")
+            return response
+
+        for role in consoles:
+            command(role, "verbose 0")
+            command(role, "ver")
+        if args.configure:
+            for role in consoles:
+                command(role, "ptp stop")
+            for role in consoles:
+                command(role, "mode " + role)
+            if args.master_trim is not None:
+                command("master", f"pll sdac 0 {args.master_trim}")
+            for role in consoles:
+                command(role, "ptp start")
+        for role, c in consoles.items():
+            command(role, "ptp")
+            command(role, "mac get")
+            screens[role] = WRScreen()
+            offsets[role] = len(c.buffer)
+            c.send("gui\r")
+        start = time.monotonic()
+        tracking_start = None
+        previous = None
+        progress_times = {role: start for role in consoles}
+        update_progress = start
+        last_report = start - 30
+        while True:
+            new_frames = {}
+            for role, c in consoles.items():
+                if c.error:
+                    raise RuntimeError(role + ": UART reader failed") from c.error
+                end = len(c.buffer)
+                # Retain enough overlap to catch a warning split across reads.
+                if b"PRINTF OVF" in c.buffer[max(0, offsets[role] - 9) : end]:
+                    raise RuntimeError(role + ": firmware printf buffer overflow")
+                new_frames[role] = screens[role].feed(
+                    bytes(c.buffer[offsets[role] : end]), now=c.last_received or start
+                )
+                offsets[role] = end
+                for frame in new_frames[role]:
+                    frames_log.write(json.dumps(dict(board_role=role, **frame)) + "\n")
+            pending = {role: pool.submit(diagnostic_snapshot, b) for role, b in buses.items()}
+            diags = {role: future.result() for role, future in pending.items()}
+            now = time.monotonic()
+            master, slave = screens["master"].latest, screens["slave"].latest
+            errors = qualification_errors(master, slave, diags["master"], diags["slave"], now)
+            # Every complete UART frame during the soak is checked, including
+            # transient losses between host diagnostic samples.
+            if tracking_start is not None:
+                for frame in new_frames["master"]:
+                    errors += qualification_errors(
+                        frame, slave, diags["master"], diags["slave"], now
+                    )
+                for frame in new_frames["slave"]:
+                    errors += qualification_errors(
+                        master, frame, diags["master"], diags["slave"], now
+                    )
+                for role in diags:
+                    if diags[role]["tai_ns"] is None:
+                        continue  # qualification_errors already rejects this snapshot.
+                    if diags[role]["tai_ns"] < previous[role]["tai_ns"]:
+                        errors.append(role + ": TAI moved backwards")
+                    if diags[role]["tai_ns"] != previous[role]["tai_ns"]:
+                        progress_times[role] = now
+                    if now - progress_times[role] > 5:
+                        errors.append(role + ": TAI stopped advancing")
+                    if diags[role]["rx_errors"] != previous[role]["rx_errors"]:
+                        errors.append(role + ": RX error count changed")
+                if diags["slave"]["updates"] != previous["slave"]["updates"]:
+                    update_progress = now
+                if (
+                    diags["slave"]["updates"] - previous["slave"]["updates"]
+                ) & 0xFFFFFFFF > 0x80000000:
+                    errors.append("slave: servo update counter moved backwards")
+                if now - update_progress > 10:
+                    errors.append("slave: servo update counter stopped advancing")
+            sample = dict(
+                elapsed=now - start,
+                soak_elapsed=None if tracking_start is None else now - tracking_start,
+                errors=sorted(set(errors)),
+                diagnostics=diags,
+                gui={
+                    role: {k: v for k, v in screens[role].latest.items() if k != "screen"}
+                    if screens[role].latest
+                    else None
+                    for role in screens
+                },
+            )
+            samples.write(json.dumps(sample) + "\n")
+            if tracking_start is None:
+                if not errors:
+                    tracking_start = now
+                    summary["acquired_after"] = now - start
+                    progress_times = {role: now for role in diags}
+                    update_progress = now
+                    summary["initial_diagnostics"] = diags
+                    print(
+                        f"WR tracking acquired after {now - start:.1f}s; starting uninterrupted {args.duration:.0f}s soak",
+                        flush=True,
+                    )
+                elif now - start > args.acquire_timeout:
+                    raise RuntimeError("WR acquisition timeout: " + ", ".join(sorted(set(errors))))
+            elif errors:
+                raise RuntimeError("WR soak interrupted: " + ", ".join(sorted(set(errors))))
+            elif now - tracking_start >= args.duration:
+                summary.update(
+                    passed=True, soak_seconds=now - tracking_start, final_diagnostics=diags
+                )
+                break
+            previous = diags
+            if now - last_report >= 30:
+                print(
+                    json.dumps(
+                        dict(
+                            elapsed=round(now - start, 1),
+                            soak=sample["soak_elapsed"],
+                            errors=sample["errors"],
+                            slave_offset_ps=diags["slave"]["offset_ps"],
+                            slave_updates=diags["slave"]["updates"],
+                        )
+                    ),
+                    flush=True,
+                )
+                last_report = now
+            time.sleep(0.1)
+    except BaseException as error:
+        summary["error"] = str(error)
+        raise
+    finally:
+        pool.shutdown(wait=True)
+        for c in consoles.values():
+            try:
+                start = len(c.buffer)
+                c.send("q")
+                c.prompt(start)
+            except Exception:
+                pass
+            c.close()
+        for b in buses.values():
+            b.close()
+        samples.close()
+        frames_log.close()
+        summary["end_unix"] = time.time()
+        (args.output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+        if lock:
+            lock.close()
+    print(json.dumps(summary, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    def interrupted(signum, frame):
+        raise KeyboardInterrupt(f'signal {signum}')
+    signal.signal(signal.SIGTERM, interrupted)
+    main()

--- a/tools/wr_status.py
+++ b/tools/wr_status.py
@@ -1,0 +1,196 @@
+#
+# This file is part of LiteX-WR-NIC.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+"""WRPC v5 GUI frames and coherent host diagnostic snapshots."""
+
+import re
+import time
+
+CSI = re.compile(r"\x1b\[([0-?]*)([ -/]*)([@-~])")
+
+
+class WRScreen:
+    """Small terminal model for WRPC's cursor-addressed monitor, including split CSI."""
+
+    def __init__(self):
+        self.rows = [[" "] * 100 for _ in range(50)]
+        self.row = self.col = 0
+        self.pending = ""
+        self.latest = None
+
+    def feed(self, data, now=None):
+        now = time.monotonic() if now is None else now
+        text = self.pending + data.decode("ascii", errors="replace")
+        self.pending = ""
+        i = 0
+        frames = []
+        while i < len(text):
+            ch = text[i]
+            if ch == "\x1b":
+                match = CSI.match(text, i)
+                if match is None:
+                    self.pending = text[i:]
+                    break
+                values, _, command = match.groups()
+                args = (
+                    [int(x or 0) for x in values.split(";")] if not values.startswith("?") else []
+                )
+                n = args[0] if args else 0
+                if command in ("H", "f"):
+                    self.row = max(0, min(49, (n or 1) - 1))
+                    self.col = max(0, min(99, ((args[1] if len(args) > 1 else 1) or 1) - 1))
+                elif command == "J":
+                    if n == 2:
+                        self.rows = [[" "] * 100 for _ in range(50)]
+                        self.latest = None
+                    elif n == 0:
+                        self.rows[self.row][self.col :] = [" "] * (100 - self.col)
+                        for row in range(self.row + 1, 50):
+                            self.rows[row] = [" "] * 100
+                        frame = self.frame(now)
+                        if frame is not None:
+                            self.latest = frame
+                            frames.append(frame)
+                elif command == "K":
+                    if n == 0:
+                        self.rows[self.row][self.col :] = [" "] * (100 - self.col)
+                    elif n == 2:
+                        self.rows[self.row] = [" "] * 100
+                elif command == "@":
+                    count = n or 1
+                    self.rows[self.row][self.col :] = (
+                        [" "] * count + self.rows[self.row][self.col :]
+                    )[: 100 - self.col]
+                i = match.end()
+                continue
+            if ch == "\r":
+                self.col = 0
+            elif ch == "\n":
+                self.row = min(49, self.row + 1)
+            elif ch == "\b":
+                self.col = max(0, self.col - 1)
+            elif ord(ch) >= 32:
+                self.rows[self.row][self.col] = ch
+                self.col = min(99, self.col + 1)
+            i += 1
+        return frames
+
+    def frame(self, now):
+        rows = ["".join(row) for row in self.rows]
+        tai = re.search(r"\d{4}-\d{2}-\d{2}-\d{2}:\d{2}:\d{2}", rows[2])
+        port = re.search(r"\b(\w+)\s*/\s*(\w+)\s*/\s*(\w+)", rows[11])
+        mac = re.search(r"(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}", rows[6])
+        peer = re.search(r"(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}", rows[11])
+        # The static redraw also ends in ESC[J before values are populated.
+        # Once time and our MAC are present, retain even malformed/down port
+        # rows so a brief loss cannot disappear between good frames.
+        if not (tai and mac):
+            return None
+        servo = re.search(r"White-Rabbit:\s*(\S+)", rows[15])
+        count = re.search(r"(\d+) times", rows[29])
+        return dict(
+            received=now,
+            tai=tai.group(),
+            mac=mac.group().lower(),
+            peer=peer.group().lower() if peer else None,
+            role=port[1] if port else None,
+            extension=port[2] if port else None,
+            detection=port[3] if port else None,
+            pll_locked=rows[2][69:76].strip() == "Locked",
+            frequency_locked=rows[11][7:10] == "Lck",
+            servo=servo[1] if servo else None,
+            updates=int(count[1]) if count else None,
+            screen="\n".join(row.rstrip() for row in rows).rstrip(),
+        )
+
+
+def diagnostic_snapshot(bus, timeout=3):
+    base = bus.mems.wr_wb_slave.base + 0x900
+    if bus.read(base) != 2:
+        raise RuntimeError("WR diagnostic version is not 2; verify the CPU device map")
+    try:
+        # Clear VALID while requesting a new snapshot; firmware sets it only
+        # after completing a fresh update, then holds all fields for the host.
+        bus.write(base + 4, 0x100)
+        deadline = time.monotonic() + timeout
+        while bus.read(base + 4) & 0x101 != 0x101:
+            if time.monotonic() > deadline:
+                raise TimeoutError("WR diagnostics did not produce a fresh snapshot")
+            time.sleep(0.02)
+        words = bus.read(base, length=25)
+        if words[1] & 0x101 != 0x101:
+            raise RuntimeError("WR diagnostic snapshot lost validity")
+    finally:
+        bus.write(base + 4, 0)
+    signed = lambda value: value if value < 0x80000000 else value - 0x100000000
+    # Negative PPS counter adjustments during acquisition temporarily wrap the
+    # 28-bit cycle counter. Preserve the snapshot but do not treat it as time.
+    # A normalized time remains mandatory for qualification.
+    time_valid = words[10] < 1_000_000_000
+    return dict(
+        version=words[0],
+        raw=words,
+        # Firmware calls this WR_MODE but populates it with servo validity.
+        # Actual WR extension activation must be checked independently via GUI.
+        servo_valid=bool(words[2] & 1),
+        servo_state=(words[2] >> 8) & 15,
+        link=bool(words[3] & 1),
+        locked=bool(words[3] & 2),
+        ptp_state=words[4] & 255,
+        time_valid=time_valid,
+        tai_ns=((words[8] << 32) | words[9]) * 1000000000 + words[10] if time_valid else None,
+        offset_ps=signed(words[16]),
+        updates=words[18],
+        tx=words[6],
+        rx=words[7],
+        rx_errors=words[24],
+    )
+
+
+def qualification_errors(master, slave, master_diag, slave_diag, now):
+    errors = []
+    for name, frame, diag, role, state in (
+        ("master", master, master_diag, "MASTER", 6),
+        ("slave", slave, slave_diag, "SLAVE", 9),
+    ):
+        if diag["tai_ns"] is None:
+            errors.append(name + ": timestamp is not normalized")
+        if frame is None:
+            errors.append(name + ": no complete GUI frame")
+            continue
+        if now - frame["received"] > 5:
+            errors.append(name + ": stale UART monitor")
+        if frame["role"] != role or diag["ptp_state"] != state:
+            errors.append(name + ": incorrect PTP role")
+        if frame["detection"] != "EXT_ON" or frame["extension"] != "IDLE":
+            errors.append(name + ": WR extension is not active and idle")
+        if not (
+            frame["pll_locked"] and frame["frequency_locked"] and diag["link"] and diag["locked"]
+        ):
+            errors.append(name + ": link/frequency lock missing")
+    if (
+        master
+        and slave
+        and (
+            master["mac"] != slave["peer"]
+            or slave["mac"] != master["peer"]
+            or master["mac"] == slave["mac"]
+        )
+    ):
+        errors.append("peer MAC identities do not agree")
+    if slave and (
+        slave["servo"] != "TRACK_PHASE"
+        or not slave_diag["servo_valid"]
+        or slave_diag["servo_state"] != 4
+    ):
+        errors.append("slave: servo is not tracking WR phase")
+    # Separate firmware refresh periods prevent a precise timestamp comparison,
+    # but both boards must agree on the time scale.
+    if (master_diag["tai_ns"] is not None and slave_diag["tai_ns"] is not None
+        and abs(master_diag["tai_ns"] - slave_diag["tai_ns"]) > 3_000_000_000):
+        errors.append("master/slave diagnostic time scales disagree")
+    return errors

--- a/tools/wr_trim.py
+++ b/tools/wr_trim.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Fit per-board master trims from reciprocal Acorn/SPEC main-clock sweeps."""
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from statistics import linear_regression, mean
+
+
+def fit_trims(rows, spec_linear_max, spec_plateau_min):
+    # Each sweep holds the peer at 32768. Normalize by RX, then anchor Acorn's
+    # sweep to its own measured midpoint. This avoids combining the offsets of
+    # sequential reciprocal measurements as though they were simultaneous.
+    points = {}
+    for board in ('acorn', 'spec'):
+        points[board] = []
+        for row in rows:
+            if row['board'] != board:
+                continue
+            code = int(row['code'])
+            ref, rx = float(row['ref_hz']), float(row['rx_hz'])
+            if (not 0 <= code <= 65535 or not ref > 0 or not rx > 0
+                    or not math.isfinite(ref) or not math.isfinite(rx)):
+                raise ValueError('Invalid DAC code or clock measurement')
+            points[board].append((code, ref / rx))
+        if len({x for x, _ in points[board]}) < 3:
+            raise ValueError('Each board requires at least three distinct codes')
+    anchors = [y for x, y in points['acorn'] if x == 32768]
+    if not anchors:
+        raise ValueError('Acorn sweep must include code 32768')
+    anchor = mean(anchors)
+    points['acorn'] = [(x, (y / anchor - 1) * 1e6) for x, y in points['acorn']]
+    points['spec'] = [(x, (y - 1) * 1e6) for x, y in points['spec']]
+    low = [y for x, y in points['spec'] if x == 0]
+    high = [y for x, y in points['spec'] if x >= spec_plateau_min]
+    if not low or not high:
+        raise ValueError('SPEC sweep must include code 0 and its measured upper plateau')
+    target = (mean(low) + mean(high)) / 2
+    result = dict(reference='Acorn at 32768; relative frequency only',
+        target_ppm=target, spec_range_ppm=[mean(low), mean(high)], boards={})
+    for board, samples in points.items():
+        linear = [(x, y) for x, y in samples if board == 'acorn' or x <= spec_linear_max]
+        if len({x for x, _ in linear}) < 3:
+            raise ValueError('Need at least three codes in each fitted linear region')
+        fit = linear_regression([x for x, _ in linear], [y for _, y in linear])
+        if fit.slope <= 0:
+            raise ValueError('Expected a positive tuning slope')
+        code = round((target - fit.intercept) / fit.slope)
+        if not min(x for x, _ in linear) <= code <= max(x for x, _ in linear):
+            raise ValueError('Centered trim lies outside the measured linear region')
+        result['boards'][board] = dict(master_trim=code, ppm_per_code=fit.slope,
+            max_fit_residual_ppm=max(abs(y - fit.slope * x - fit.intercept) for x, y in linear))
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('csv', type=Path, help='Columns: board,code,ref_hz,rx_hz')
+    parser.add_argument('--spec-linear-max', type=int, required=True,
+        help='Highest code in the measured SPEC linear region.')
+    parser.add_argument('--spec-plateau-min', type=int, required=True,
+        help='Lowest code in the measured SPEC upper plateau.')
+    args = parser.parse_args()
+    with args.csv.open() as stream:
+        rows = list(csv.DictReader(stream))
+    print(json.dumps(fit_trims(rows, args.spec_linear_max, args.spec_plateau_min), indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add an optional upstream SoftPLL FIFO/XADC profile, bounded phase-step instrumentation, and capture/analysis tools. SPEC’s optional trace profile reserves RAM by omitting the PCIe NIC/PTM/time generator. The runner restores saved PI gains and PTP after dynamic tests.

This targets **main** with two clean commits on top of #88. The incremental diff is https://github.com/enjoy-digital/litex_wr_nic/compare/integrate/wr-bench-main...measure/wr-loop-response. Commits contain implementation, tests and short usage instructions; measured results and board-specific calibration values stay out of the repository. Native JTAG capture uses enjoy-digital/litex#2592.

Validation: focused tests pass and missing calibration inputs are rejected before hardware access. The FPGA/firmware logic is unchanged from the SRAM images already tested.

<details>
<summary>Previous bench validation (PR history only)</summary>

Each slave direction completed 64 × 640 native phase samples without capture loss. Main phase/frequency tests and helper frequency tests at half, normal and double PI gain completed without PLL delocks. Normal-gain model fits gave approximately 111 Hz crossover / 77° phase margin for Acorn and 40 Hz / 62° for SPEC, with greater uncertainty for SPEC. These are model estimates, not independently measured open-loop margins.

Five-minute tracking observations passed in both directions, at roughly 34–35°C Acorn die temperature and 67–69°C SPEC die temperature. Independent physical PPS alignment/jitter and controlled oscillator-temperature characterization still need external instruments and cabling. Captures and plots remain outside version control.

</details>
